### PR TITLE
Add regular expression feed filtering

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/PreferencesFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/PreferencesFragment.java
@@ -15,6 +15,7 @@
 
 package com.keylesspalace.tusky.fragment;
 
+import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Build;
@@ -24,6 +25,8 @@ import android.preference.EditTextPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.support.annotation.XmlRes;
+import android.text.Editable;
+import android.text.TextWatcher;
 
 import com.keylesspalace.tusky.BuildConfig;
 import com.keylesspalace.tusky.PreferencesActivity;
@@ -31,6 +34,8 @@ import com.keylesspalace.tusky.R;
 import com.keylesspalace.tusky.TuskyApplication;
 import com.keylesspalace.tusky.db.AccountEntity;
 import com.keylesspalace.tusky.db.AccountManager;
+
+import java.util.regex.Pattern;
 
 public class PreferencesFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
     SharedPreferences sharedPreferences;
@@ -62,6 +67,31 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
 
         addPreferencesFromResource(preference);
 
+        Preference regexPref = findPreference("tabFilterRegex");
+        if (regexPref != null) regexPref.setOnPreferenceClickListener(preference1 -> {
+            // Reset the error dialog when shown; if the dialog was closed with the cancel button
+            // while an invalid regex was present, this would otherwise cause buggy behaviour.
+            ((EditTextPreference) regexPref).getEditText().setError(null);
+
+            // Test the regex on as the user inputs text, ensuring immediate feedback and preventing
+            // setting of an invalid regex, which would cause a crash loop.
+            ((EditTextPreference) regexPref).getEditText().addTextChangedListener(new TextWatcher() {
+                @Override
+                public void afterTextChanged(Editable s) {
+                    try {
+                        Pattern.compile(s.toString());
+                        ((EditTextPreference) regexPref).getEditText().setError(null);
+                        ((AlertDialog) ((EditTextPreference) preference1).getDialog()).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+                    } catch (IllegalArgumentException e) {
+                        ((AlertDialog) ((EditTextPreference) preference1).getDialog()).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+                        ((EditTextPreference) regexPref).getEditText().setError("Invalid regular expression!");
+                    } catch (NullPointerException e) {}
+                }
+                @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+                @Override public void onTextChanged(CharSequence s, int start, int before, int count) {}
+            });
+            return false;
+        });
 
         Preference notificationPreferences = findPreference("notificationPreferences");
 

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/PreferencesFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/PreferencesFragment.java
@@ -85,7 +85,7 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                         if (dialog != null) dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
                     } catch (IllegalArgumentException e) {
                         ((AlertDialog) ((EditTextPreference) pref).getDialog()).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
-                        ((EditTextPreference) regexPref).getEditText().setError("Invalid regular expression!");
+                        ((EditTextPreference) regexPref).getEditText().setError(getString(R.string.error_invalid_regex));
                     }
                 }
                 @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/PreferencesFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/PreferencesFragment.java
@@ -68,12 +68,12 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
         addPreferencesFromResource(preference);
 
         Preference regexPref = findPreference("tabFilterRegex");
-        if (regexPref != null) regexPref.setOnPreferenceClickListener(preference1 -> {
+        if (regexPref != null) regexPref.setOnPreferenceClickListener(pref -> {
             // Reset the error dialog when shown; if the dialog was closed with the cancel button
             // while an invalid regex was present, this would otherwise cause buggy behaviour.
             ((EditTextPreference) regexPref).getEditText().setError(null);
 
-            // Test the regex on as the user inputs text, ensuring immediate feedback and preventing
+            // Test the regex as the user inputs text, ensuring immediate feedback and preventing
             // setting of an invalid regex, which would cause a crash loop.
             ((EditTextPreference) regexPref).getEditText().addTextChangedListener(new TextWatcher() {
                 @Override
@@ -81,11 +81,12 @@ public class PreferencesFragment extends PreferenceFragment implements SharedPre
                     try {
                         Pattern.compile(s.toString());
                         ((EditTextPreference) regexPref).getEditText().setError(null);
-                        ((AlertDialog) ((EditTextPreference) preference1).getDialog()).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+                        AlertDialog dialog = (AlertDialog) ((EditTextPreference) pref).getDialog();
+                        if (dialog != null) dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
                     } catch (IllegalArgumentException e) {
-                        ((AlertDialog) ((EditTextPreference) preference1).getDialog()).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+                        ((AlertDialog) ((EditTextPreference) pref).getDialog()).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
                         ((EditTextPreference) regexPref).getEditText().setError("Invalid regular expression!");
-                    } catch (NullPointerException e) {}
+                    }
                 }
                 @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
                 @Override public void onTextChanged(CharSequence s, int start, int before, int count) {}

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -726,7 +726,8 @@ public class TimelineFragment extends SFragment implements
             Status status = it.next();
             if ((status.getInReplyToId() != null && filterRemoveReplies)
                     || (status.getReblog() != null && filterRemoveReblogs)
-                    || (filterRemoveRegex && filterRemoveRegexMatcher.reset(status.getContent()).find())) {
+                    || (filterRemoveRegex && (filterRemoveRegexMatcher.reset(status.getContent()).find()
+                    || (!status.getSpoilerText().isEmpty() && filterRemoveRegexMatcher.reset(status.getContent()).find())))) {
                 it.remove();
             }
         }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -506,20 +506,19 @@ public class TimelineFragment extends SFragment implements
                 break;
             }
             case "tabFilterRegex": {
-                String newFilterRegex = sharedPreferences.getString("tabFilterRegex", "");
-                boolean oldFilterRegex = filterRemoveRegex;
-                Matcher oldFilterRegexMatcher = filterRemoveRegexMatcher;
-                filterRemoveRegex = (kind == Kind.HOME || kind == Kind.PUBLIC_LOCAL || kind == Kind.PUBLIC_FEDERATED) && !newFilterRegex.isEmpty();
+                boolean oldFilterRemoveRegex = filterRemoveRegex;
+                String newFilterRemoveRegexPattern = sharedPreferences.getString("tabFilterRegex", "");
+                boolean patternChanged = !newFilterRemoveRegexPattern.equalsIgnoreCase(filterRemoveRegexMatcher.pattern().pattern());
+                filterRemoveRegex = (kind == Kind.HOME || kind == Kind.PUBLIC_LOCAL || kind == Kind.PUBLIC_FEDERATED) && !newFilterRemoveRegexPattern.isEmpty();
                 if (filterRemoveRegex) {
-                    String oldFilterRegexPattern = filterRemoveRegexMatcher.pattern().pattern();
-                    if (!newFilterRegex.equalsIgnoreCase(oldFilterRegexPattern)) {
-                        filterRemoveRegexMatcher = Pattern.compile(newFilterRegex, Pattern.CASE_INSENSITIVE).matcher("");
+                    if (patternChanged) {
+                        filterRemoveRegexMatcher = Pattern.compile(newFilterRemoveRegexPattern, Pattern.CASE_INSENSITIVE).matcher("");
                     }
                 }
-                if (adapter.getItemCount() > 1 && (oldFilterRegex != filterRemoveRegex || oldFilterRegexMatcher != filterRemoveRegexMatcher)) {
+                if (oldFilterRemoveRegex != filterRemoveRegex || patternChanged) {
                     fullyRefresh();
                 }
-
+                break;
             }
             case "alwaysShowSensitiveMedia": {
                 //it is ok if only newly loaded statuses are affected, no need to fully refresh

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -508,14 +508,15 @@ public class TimelineFragment extends SFragment implements
             case "tabFilterRegex": {
                 boolean oldFilterRemoveRegex = filterRemoveRegex;
                 String newFilterRemoveRegexPattern = sharedPreferences.getString("tabFilterRegex", "");
-                boolean patternChanged = !newFilterRemoveRegexPattern.equalsIgnoreCase(filterRemoveRegexMatcher.pattern().pattern());
-                filterRemoveRegex = (kind == Kind.HOME || kind == Kind.PUBLIC_LOCAL || kind == Kind.PUBLIC_FEDERATED) && !newFilterRemoveRegexPattern.isEmpty();
-                if (filterRemoveRegex) {
-                    if (patternChanged) {
-                        filterRemoveRegexMatcher = Pattern.compile(newFilterRemoveRegexPattern, Pattern.CASE_INSENSITIVE).matcher("");
-                    }
+                boolean patternChanged;
+                if (filterRemoveRegexMatcher != null) {
+                    patternChanged = !newFilterRemoveRegexPattern.equalsIgnoreCase(filterRemoveRegexMatcher.pattern().pattern());
+                } else {
+                    patternChanged = !newFilterRemoveRegexPattern.isEmpty();
                 }
+                filterRemoveRegex = (kind == Kind.HOME || kind == Kind.PUBLIC_LOCAL || kind == Kind.PUBLIC_FEDERATED) && !newFilterRemoveRegexPattern.isEmpty();
                 if (oldFilterRemoveRegex != filterRemoveRegex || patternChanged) {
+                    filterRemoveRegexMatcher = Pattern.compile(newFilterRemoveRegexPattern, Pattern.CASE_INSENSITIVE).matcher("");
                     fullyRefresh();
                 }
                 break;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="error_report_too_few_statuses">At least one status must be reported.</string>
 
     <string name="title_home">Home</string>
+    <string name="title_advanced">Advanced</string>
     <string name="title_notifications">Notifications</string>
     <string name="title_public_local">Local</string>
     <string name="title_public_federated">Federated</string>
@@ -177,6 +178,7 @@
     <string name="pref_title_status_tabs">Tabs</string>
     <string name="pref_title_show_boosts">Show boosts</string>
     <string name="pref_title_show_replies">Show replies</string>
+    <string name="pref_title_filter_regex">Filter out by regular expressions</string>
     <string name="pref_title_show_media_preview">Show media previews</string>
     <string name="pref_title_proxy_settings">Proxy</string>
     <string name="pref_title_http_proxy_settings">HTTP proxy</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="error_media_upload_image_or_video">Images and videos cannot both be attached to the same status.</string>
     <string name="error_media_upload_sending">The upload failed.</string>
     <string name="error_report_too_few_statuses">At least one status must be reported.</string>
+    <string name="error_invalid_regex">Invalid regular expression</string>
 
     <string name="title_home">Home</string>
     <string name="title_advanced">Advanced</string>

--- a/app/src/main/res/xml/timeline_filter_preferences.xml
+++ b/app/src/main/res/xml/timeline_filter_preferences.xml
@@ -16,6 +16,7 @@
     <PreferenceCategory android:title="@string/title_advanced">
         <EditTextPreference
             android:key="tabFilterRegex"
+            android:inputType="textNoSuggestions"
             android:title="@string/pref_title_filter_regex" />
     </PreferenceCategory>
 

--- a/app/src/main/res/xml/timeline_filter_preferences.xml
+++ b/app/src/main/res/xml/timeline_filter_preferences.xml
@@ -13,4 +13,10 @@
             android:title="@string/pref_title_show_replies" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/title_advanced">
+        <EditTextPreference
+            android:key="tabFilterRegex"
+            android:title="@string/pref_title_filter_regex" />
+    </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
Mimics Mastodon web's functionality, but in a simpler form; a single regular expression is shared across the home, local and federated feeds. Even uses the exact same labels.

Strings are currently only provided in English and will need to be translated. Not sure what the current state of testing within the app is either, as the unit tests seem to fail for me, so I've included none here for now.

Fixes #555.