### PR TITLE
Separate display name from notification summary text for favorite/boost/follow

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -249,30 +249,28 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
     }
 
     private static class FollowViewHolder extends RecyclerView.ViewHolder {
-        private TextView message;
+        private TextView messageDisplayName;
         private TextView usernameView;
         private TextView displayNameView;
         private ImageView avatar;
 
         FollowViewHolder(View itemView) {
             super(itemView);
-            message = itemView.findViewById(R.id.notification_text);
+            messageDisplayName = itemView.findViewById(R.id.follow_notification_id);
             usernameView = itemView.findViewById(R.id.notification_username);
             displayNameView = itemView.findViewById(R.id.notification_display_name);
-            avatar = itemView.findViewById(R.id.notification_avatar);
+            avatar = itemView.findViewById(R.id.follow_notification_avatar);
             //workaround because Android < API 21 does not support setting drawableLeft from xml when it is a vector image
-            Drawable followIcon = ContextCompat.getDrawable(message.getContext(), R.drawable.ic_person_add_24dp);
-            message.setCompoundDrawablesWithIntrinsicBounds(followIcon, null, null, null);
+            Drawable followIcon = ContextCompat.getDrawable(messageDisplayName.getContext(), R.drawable.ic_person_add_24dp);
+            messageDisplayName.setCompoundDrawablesWithIntrinsicBounds(followIcon, null, null, null);
         }
 
         void setMessage(String displayName, String username, String avatarUrl) {
-            Context context = message.getContext();
+            Context context = messageDisplayName.getContext();
 
-            String format = context.getString(R.string.notification_follow_format);
-            String wholeMessage = String.format(format, displayName);
-            message.setText(wholeMessage);
+            messageDisplayName.setText(displayName);
 
-            format = context.getString(R.string.status_username_format);
+            String format = context.getString(R.string.status_username_format);
             String wholeUsername = String.format(format, username);
             usernameView.setText(wholeUsername);
 
@@ -298,6 +296,8 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
     private static class StatusNotificationViewHolder extends RecyclerView.ViewHolder
             implements View.OnClickListener, ToggleButton.OnCheckedChangeListener {
         private final TextView message;
+        private final ViewGroup messageContainer;
+        private final TextView messageDisplayName;
         private final View statusNameBar;
         private final TextView displayName;
         private final TextView username;
@@ -317,6 +317,8 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
         StatusNotificationViewHolder(View itemView) {
             super(itemView);
             message = itemView.findViewById(R.id.notification_top_text);
+            messageContainer = itemView.findViewById(R.id.notification_top_bar);
+            messageDisplayName = itemView.findViewById(R.id.notification_top_id);
             statusNameBar = itemView.findViewById(R.id.status_name_bar);
             displayName = itemView.findViewById(R.id.status_display_name);
             username = itemView.findViewById(R.id.status_username);
@@ -334,6 +336,8 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
 
             container.setOnClickListener(this);
             message.setOnClickListener(this);
+            messageContainer.setOnClickListener(this);
+            messageDisplayName.setOnClickListener(this);
             statusContent.setOnClickListener(this);
             contentWarningButton.setOnCheckedChangeListener(this);
         }
@@ -388,7 +392,7 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
             Notification.Type type = notificationViewData.getType();
 
             Context context = message.getContext();
-            String format;
+            String messageText;
             Drawable icon;
             switch (type) {
                 default:
@@ -399,7 +403,7 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
                                 R.color.status_favourite_button_marked_dark), PorterDuff.Mode.SRC_ATOP);
                     }
 
-                    format = context.getString(R.string.notification_favourite_format);
+                    messageText = context.getString(R.string.notification_favourite_format);
                     break;
                 }
                 case REBLOG: {
@@ -409,16 +413,16 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
                                 R.color.color_accent_dark), PorterDuff.Mode.SRC_ATOP);
                     }
 
-                    format = context.getString(R.string.notification_reblog_format);
+                    messageText = context.getString(R.string.notification_reblog_format);
                     break;
                 }
             }
-            message.setCompoundDrawablesWithIntrinsicBounds(icon, null, null, null);
-            String wholeMessage = String.format(format, displayName);
-            final SpannableStringBuilder str = new SpannableStringBuilder(wholeMessage);
+            messageDisplayName.setCompoundDrawablesWithIntrinsicBounds(icon, null, null, null);
+            final SpannableStringBuilder str = new SpannableStringBuilder(displayName);
             str.setSpan(new StyleSpan(Typeface.BOLD), 0, displayName.length(),
                     Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
-            message.setText(str);
+            messageDisplayName.setText(str);
+            message.setText(messageText);
 
             if (statusViewData != null) {
                 boolean hasSpoiler = !TextUtils.isEmpty(statusViewData.getSpoilerText());
@@ -468,6 +472,8 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
                 case R.id.notification_content:
                     if (notificationActionListener != null) notificationActionListener.onViewStatusForNotificationId(notificationId);
                     break;
+                case R.id.notification_top_id:
+                case R.id.notification_top_bar:
                 case R.id.notification_top_text:
                     if (notificationActionListener != null) notificationActionListener.onViewAccount(accountId);
                     break;

--- a/app/src/main/res/layout/item_follow.xml
+++ b/app/src/main/res/layout/item_follow.xml
@@ -11,27 +11,43 @@
     android:paddingLeft="14dp"
     android:paddingRight="14dp">
 
-    <TextView
-        android:id="@+id/notification_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="4dp"
+    <RelativeLayout
+        android:id="@+id/follow_notification_bar"
+        android:layout_alignParentTop="true"
+        android:layout_marginBottom="6dp"
         android:layout_marginTop="8dp"
-        android:drawablePadding="10dp"
-        android:ellipsize="end"
-        android:gravity="center_vertical"
-        android:maxLines="1"
-        android:paddingStart="28dp"
-        android:textColor="?android:textColorTertiary"
-        android:textSize="?attr/status_text_medium"
-        tools:text="Someone followed you" />
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <TextView
+            android:id="@+id/follow_notification_id"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="28dp"
+            android:drawablePadding="10dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="?android:textColorSecondary"
+            android:textSize="?attr/status_text_medium"
+            tools:text="Someone" />
+        <TextView
+            android:id="@+id/follow_notification_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_toRightOf="@id/follow_notification_id"
+            android:layout_marginLeft="4dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="?android:textColorTertiary"
+            android:textSize="?attr/status_text_medium"
+            android:text="@string/notification_follow_format" />
+    </RelativeLayout>
 
     <ImageView
-        android:id="@+id/notification_avatar"
+        android:id="@+id/follow_notification_avatar"
         android:layout_width="40dp"
         android:layout_height="40dp"
         android:layout_alignParentStart="true"
-        android:layout_below="@+id/notification_text"
+        android:layout_below="@+id/follow_notification_bar"
         android:layout_marginEnd="14dp"
         android:layout_marginStart="8dp"
         android:contentDescription="@string/action_view_profile"
@@ -42,8 +58,8 @@
         android:id="@+id/notification_display_name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/notification_text"
-        android:layout_toEndOf="@id/notification_avatar"
+        android:layout_below="@+id/follow_notification_bar"
+        android:layout_toEndOf="@id/follow_notification_avatar"
         android:ellipsize="end"
         android:maxLines="1"
         android:textColor="?android:textColorPrimary"
@@ -56,7 +72,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@+id/notification_display_name"
-        android:layout_toEndOf="@id/notification_avatar"
+        android:layout_toEndOf="@id/follow_notification_avatar"
         android:ellipsize="end"
         android:maxLines="1"
         android:textColor="?android:textColorSecondary"

--- a/app/src/main/res/layout/item_status_notification.xml
+++ b/app/src/main/res/layout/item_status_notification.xml
@@ -8,27 +8,42 @@
     android:paddingLeft="14dp"
     android:paddingRight="14dp">
 
-    <TextView
-        android:id="@+id/notification_top_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+    <RelativeLayout
+        android:id="@+id/notification_top_bar"
         android:layout_alignParentTop="true"
         android:layout_marginBottom="6dp"
         android:layout_marginTop="8dp"
-        android:drawablePadding="10dp"
-        android:ellipsize="end"
-        android:gravity="center_vertical"
-        android:maxLines="1"
-        android:paddingStart="28dp"
-        android:textColor="?android:textColorSecondary"
-        android:textSize="?attr/status_text_medium"
-        tools:text="Someone favourited your status" />
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <TextView
+            android:id="@+id/notification_top_id"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="28dp"
+            android:drawablePadding="10dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="?android:textColorSecondary"
+            android:textSize="?attr/status_text_medium"
+            tools:text="Someone" />
+        <TextView
+            android:id="@+id/notification_top_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_toRightOf="@id/notification_top_id"
+            android:layout_marginLeft="4dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="?android:textColorSecondary"
+            android:textSize="?attr/status_text_medium"
+            tools:text="favourited your status" />
+    </RelativeLayout>
 
     <RelativeLayout
         android:id="@+id/status_name_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/notification_top_text"
+        android:layout_below="@+id/notification_top_bar"
         android:layout_toEndOf="@+id/notification_status_avatar"
         android:paddingBottom="4dp">
 
@@ -119,7 +134,7 @@
         android:id="@+id/notification_status_avatar"
         android:layout_width="48dp"
         android:layout_height="48dp"
-        android:layout_below="@id/notification_top_text"
+        android:layout_below="@id/notification_top_bar"
         android:layout_marginBottom="14dp"
         android:layout_marginEnd="14dp"
         android:layout_marginRight="14dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,9 +50,9 @@
 
     <string name="footer_empty">Nothing here. Pull down to refresh!</string>
 
-    <string name="notification_reblog_format">%s boosted your toot</string>
-    <string name="notification_favourite_format">%s favourited your toot</string>
-    <string name="notification_follow_format">%s followed you</string>
+    <string name="notification_reblog_format">boosted your toot</string>
+    <string name="notification_favourite_format">favourited your toot</string>
+    <string name="notification_follow_format">followed you</string>
 
     <string name="report_username_format">Report @%s</string>
     <string name="report_comment_hint">Additional comments?</string>


### PR DESCRIPTION
Fixes notification display when display name contains RTL text

Before
![image](https://user-images.githubusercontent.com/142250/39805197-711c0bfe-5376-11e8-874f-2129381b00e4.png)

After
![image](https://user-images.githubusercontent.com/142250/39805212-7b8a344e-5376-11e8-8fa9-8216d618375f.png)
