### PR TITLE
Fix crash on receiving event in timeline

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -196,14 +196,21 @@ public class TimelineFragment extends SFragment implements
     }
 
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
-                             Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
         Bundle arguments = Objects.requireNonNull(getArguments());
         kind = Kind.valueOf(arguments.getString(KIND_ARG));
-        if (kind == Kind.TAG || kind == Kind.USER || kind == Kind.USER_WITH_REPLIES|| kind == Kind.LIST) {
+        if (kind == Kind.TAG
+                || kind == Kind.USER
+                || kind == Kind.USER_WITH_REPLIES
+                || kind == Kind.LIST) {
             hashtagOrId = arguments.getString(HASHTAG_OR_ID_ARG);
         }
+    }
 
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
         final View rootView = inflater.inflate(R.layout.fragment_timeline, container, false);
 
         recyclerView = rootView.findViewById(R.id.recycler_view);


### PR DESCRIPTION
As per this stack trace
https://gist.github.com/connyduck/fec040ac63c3615f9ee8e6c0758686bc
it seems like we're trying to handle event after `onCreate` but before `onCreateView` and we don't have a kind at that moment of time yet. So it's hard to reproduce (and I didn't really but I had this crash I think) but I see no other reason.