### PR TITLE
fix bug where home timeline was never showing "load more" button

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -723,7 +723,7 @@ public class TimelineFragment extends SFragment implements
         switch (kind) {
             default:
             case HOME:
-                return api.homeTimeline(fromId, uptoId, null);
+                return api.homeTimeline(fromId, uptoId, LOAD_AT_ONCE);
             case PUBLIC_FEDERATED:
                 return api.publicTimeline(null, fromId, uptoId, LOAD_AT_ONCE);
             case PUBLIC_LOCAL:


### PR DESCRIPTION
if we dont send the number of toots we want to get to the api, the check if we actually got that number does not work.

(Im pretty sure the timeline logic has some other problems as well, but this fixes this annoying problem at least most of the time)