### PR TITLE
work around crash on Android 8

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
@@ -31,6 +31,7 @@ import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Parcel;
@@ -494,6 +495,11 @@ public final class ComposeActivity
             startingText = builder.toString();
             textEditor.setText(startingText);
             textEditor.setSelection(textEditor.length());
+        }
+
+        // work around Android platform bug -> https://issuetracker.google.com/issues/67102093
+        if(Build.VERSION.SDK_INT == Build.VERSION_CODES.O || Build.VERSION.SDK_INT == Build.VERSION_CODES.O_MR1 ) {
+            textEditor.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
         }
 
         // Initialise the content warning editor.


### PR DESCRIPTION
Seeing this crash in Play Store logs & getting it reported by multiple people. 

to reproduce, paste the following text into the compose TextEditor while custom emoji style is active, then add somemthing between the second emoji and the c -> 💥

> now Im sure that it's true 🎶
🎵cause think you're so good
and I'm nothing like you ✨

Its a platform bug, tracked by Google here: https://issuetracker.google.com/issues/67102093
Only crashes in production apk.

It does not crash anymore with this fix, I hope it doesnt have any side effects >_<