### PR TITLE
add more aggressive proguard config

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
         release {
             minifyEnabled true
             shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            proguardFiles 'proguard-rules.pro'
         }
         debug { }
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -77,6 +77,7 @@
 
 # preserve line numbers for crash reporting
 -keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile
 
 # remove all logging from production apk
 -assumenosideeffects class android.util.Log {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,20 +1,47 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /home/andrew/Android/Sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# GENERAL OPTIONS
 
-# Add any project specific keep options here:
+# turn on all optimizations except those that are known to cause problems on Android
+-optimizations !code/simplification/cast,!field/*,!class/merging/*
+-optimizationpasses 6
+-allowaccessmodification
+-dontpreverify
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-dontusemixedcaseclassnames
+-dontskipnonpubliclibraryclasses
+-keepattributes *Annotation*
+
+# For native methods, see http://proguard.sourceforge.net/manual/examples.html#native
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+# keep setters in Views so that animations can still work.
+# see http://proguard.sourceforge.net/manual/examples.html#beans
+-keepclassmembers public class * extends android.view.View {
+   void set*(***);
+   *** get*();
+}
+# We want to keep methods in Activity that could be used in the XML attribute onClick
+-keepclassmembers class * extends android.app.Activity {
+   public void *(android.view.View);
+}
+# For enumeration classes, see http://proguard.sourceforge.net/manual/examples.html#enumerations
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+-keepclassmembers class * implements android.os.Parcelable {
+  public static final android.os.Parcelable$Creator CREATOR;
+}
+-keepclassmembers class **.R$* {
+    public static <fields>;
+}
+# The support library contains references to newer platform versions.
+# Don't warn about those in case this app is linking against an older
+# platform version.  We know about them, and they are safe.
+-dontwarn android.support.**
+
+
+# TUSKY SPECIFIC OPTIONS
 
 ## for okhttp
 -dontwarn okio.**


### PR DESCRIPTION
This is a more aggressive proguard config than the default optimizing Android config. 
Specifically, it turns on the `code/simplification/arithmetic` optimization and makes one more pass.
Shrinks the apk about 15kb. I could not find any problems with this config, and I bet it feels a tad faster than before.
I will be deploying this to nightly and merge it if no problems occur.