### PR TITLE
Work on AccountActivity enhancements #745

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
@@ -379,6 +379,10 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasSupportF
                     startActivityForResult(intent, EDIT_ACCOUNT)
                     return@setOnClickListener
                 }
+                if (blocking) {
+                    viewModel.changeBlockState(accountId)
+                    return@setOnClickListener
+                }
                 when (followState) {
                     AccountActivity.FollowState.NOT_FOLLOWING -> {
                         viewModel.changeFollowState(accountId)
@@ -434,6 +438,10 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasSupportF
             accountFollowButton.setText(R.string.action_edit_own_profile)
             return
         }
+        if (blocking) {
+            accountFollowButton.setText(R.string.action_unblock)
+            return
+        }
         when (followState) {
             AccountActivity.FollowState.NOT_FOLLOWING -> {
                 accountFollowButton.setText(R.string.action_follow)
@@ -450,12 +458,12 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasSupportF
     private fun updateButtons() {
         invalidateOptionsMenu()
 
-        if (!blocking && loadedAccount?.moved == null) {
+        if (loadedAccount?.moved == null) {
 
             accountFollowButton.show()
             updateFollowButton()
 
-            if(isSelf) {
+            if(blocking || isSelf) {
                 accountFloatingActionButton.hide()
             } else {
                 accountFloatingActionButton.show()

--- a/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
@@ -234,6 +234,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasSupportF
         // Initialise the default UI states.
         accountFloatingActionButton.hide()
         accountFollowButton.hide()
+        accountMuteButton.hide()
         accountFollowsYouTextView.hide()
 
         // Obtain information to fill out the profile.
@@ -389,6 +390,11 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasSupportF
                 }
                 updateFollowButton()
             }
+
+            accountMuteButton.setOnClickListener { _ ->
+                viewModel.changeMuteState(accountId)
+                updateMuteButton()
+            }
         }
     }
 
@@ -427,7 +433,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasSupportF
     }
 
     private fun updateFollowButton() {
-        if(isSelf) {
+        if (isSelf) {
             accountFollowButton.setText(R.string.action_edit_own_profile)
             return
         }
@@ -448,6 +454,14 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasSupportF
         }
     }
 
+    private fun updateMuteButton() {
+        if (muting) {
+            accountMuteButton.setImageResource(R.drawable.ic_unmute_24dp)
+        } else {
+            accountMuteButton.setImageResource(R.drawable.ic_mute_24dp)
+        }
+    }
+
     private fun updateButtons() {
         invalidateOptionsMenu()
 
@@ -456,15 +470,19 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasSupportF
             accountFollowButton.show()
             updateFollowButton()
 
-            if(blocking || isSelf) {
+            if (blocking || isSelf) {
                 accountFloatingActionButton.hide()
+                accountMuteButton.hide()
             } else {
                 accountFloatingActionButton.show()
+                accountMuteButton.show()
+                updateMuteButton()
             }
 
         } else {
             accountFloatingActionButton.hide()
             accountFollowButton.hide()
+            accountMuteButton.hide()
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
@@ -357,13 +357,6 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasSupportF
                 movedIcon?.setColorFilter(textColor, PorterDuff.Mode.SRC_IN)
 
                 TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(accountMovedText, movedIcon, null, null, null)
-
-                accountFollowers.hide()
-                accountFollowing.hide()
-                accountStatuses.hide()
-                accountTabLayout.hide()
-                accountFragmentViewPager.hide()
-                accountTabBottomShadow.hide()
             }
 
             val numberFormat = NumberFormat.getNumberInstance()

--- a/app/src/main/res/layout/activity_account.xml
+++ b/app/src/main/res/layout/activity_account.xml
@@ -52,6 +52,18 @@
                     app:layout_constraintTop_toTopOf="parent"
                     tools:text="Follow" />
 
+                <android.support.v7.widget.AppCompatImageButton
+                    android:id="@+id/accountMuteButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    android:layout_marginEnd="6dp"
+                    android:scaleType="fitXY"
+                    app:layout_constrainedHeight="true"
+                    app:layout_constraintBottom_toBottomOf="@+id/accountFollowButton"
+                    app:layout_constraintEnd_toStartOf="@id/accountFollowButton"
+                    app:layout_constraintTop_toTopOf="@+id/accountFollowButton"
+                    app:srcCompat="@drawable/ic_unmute_24dp" />
+
                 <android.support.text.emoji.widget.EmojiTextView
                     android:id="@+id/accountDisplayNameTextView"
                     android:layout_width="wrap_content"


### PR DESCRIPTION
Current state:
- [ ] add pull to refresh to the header, remove it from tabs
- [x] use the "follow" button as an "unblock" button on the profiles of blocked users
- [x] add an icon to the profiles of muted users that can be clicked to unmute the user
 - Actually mute/unmute button (always visible). What do you think?
- [ ] mark suspended profiles and profiles that have blocked the current user
- [ ] improve the layout of the AccountFields
- [x] dont remove the tabs from "moved" profiles
 - General question: removing "moved" status from profile doesn't reset "moved" status when others (from other instances?) look at profile. Is that a Mastodon bug?