### PR TITLE
fix OOM crash when trying to caption large image

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
@@ -64,6 +64,7 @@ import android.text.InputType;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.text.style.URLSpan;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
@@ -1110,8 +1111,14 @@ public final class ComposeActivity
 
         dialogLayout.setOrientation(LinearLayout.VERTICAL);
         ImageView imageView = new ImageView(this);
+
+        DisplayMetrics displayMetrics = new DisplayMetrics();
+        getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+
         Picasso.with(this)
                 .load(item.uri)
+                .resize(displayMetrics.widthPixels, displayMetrics.heightPixels)
+                .onlyScaleDown()
                 .into(imageView);
 
         int margin = Utils.dpToPx(this, 4);


### PR DESCRIPTION
(I think the dialog needs some rework so the layout does not jump after the image is loaded.)

This fixes the crash and reduces the memory usage so its at least a first step. I think using the display size is the best option because it automatically takes all resolutions into account.