### PR TITLE
Show absolute time on timelines

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.java
@@ -34,8 +34,10 @@ public class PreferencesActivity extends BaseActivity
         implements SharedPreferences.OnSharedPreferenceChangeListener {
 
     private boolean restartActivitiesOnExit;
-    private @XmlRes int currentPreferences;
-    private @StringRes int currentTitle;
+    private @XmlRes
+    int currentPreferences;
+    private @StringRes
+    int currentTitle;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -61,7 +63,7 @@ public class PreferencesActivity extends BaseActivity
 
         preferences.registerOnSharedPreferenceChangeListener(this);
 
-        if(savedInstanceState == null) {
+        if (savedInstanceState == null) {
             currentPreferences = R.xml.preferences;
             currentTitle = R.string.action_view_preferences;
         } else {
@@ -124,6 +126,10 @@ public class PreferencesActivity extends BaseActivity
                 restartActivitiesOnExit = true;
                 break;
             }
+            case "absoluteTimeView": {
+                restartActivitiesOnExit = true;
+                break;
+            }
             case "notificationsEnabled": {
                 boolean enabled = sharedPreferences.getBoolean("notificationsEnabled", true);
                 if (enabled) {
@@ -145,14 +151,14 @@ public class PreferencesActivity extends BaseActivity
     @Override
     public void onBackPressed() {
         //if we are not on the top level, show the top level. Else exit the activity
-        if(currentPreferences != R.xml.preferences) {
+        if (currentPreferences != R.xml.preferences) {
             showFragment(R.xml.preferences, R.string.action_view_preferences);
 
         } else {
-        /* Switching themes won't actually change the theme of activities on the back stack.
-         * Either the back stack activities need to all be recreated, or do the easier thing, which
-         * is hijack the back button press and use it to launch a new MainActivity and clear the
-         * back stack. */
+            /* Switching themes won't actually change the theme of activities on the back stack.
+             * Either the back stack activities need to all be recreated, or do the easier thing, which
+             * is hijack the back button press and use it to launch a new MainActivity and clear the
+             * back stack. */
             if (restartActivitiesOnExit) {
                 Intent intent = new Intent(this, MainActivity.class);
                 intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);

--- a/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.java
@@ -34,10 +34,8 @@ public class PreferencesActivity extends BaseActivity
         implements SharedPreferences.OnSharedPreferenceChangeListener {
 
     private boolean restartActivitiesOnExit;
-    private @XmlRes
-    int currentPreferences;
-    private @StringRes
-    int currentTitle;
+    private @XmlRes int currentPreferences;
+    private @StringRes int currentTitle;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -328,8 +328,8 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
         private StatusViewData.Concrete statusViewData;
 
         private boolean useAbsoluteTime;
-        private SimpleDateFormat sdf;
-        private boolean passed1day;
+        private SimpleDateFormat shortSdf;
+        private SimpleDateFormat longSdf;
 
         StatusNotificationViewHolder(View itemView, boolean useAbsoluteTime) {
             super(itemView);
@@ -355,8 +355,8 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
             contentWarningButton.setOnCheckedChangeListener(this);
 
             this.useAbsoluteTime = useAbsoluteTime;
-            sdf = new SimpleDateFormat("HH:mm:ss", Locale.getDefault());
-            passed1day = false;
+            shortSdf = new SimpleDateFormat("HH:mm:ss", Locale.getDefault());
+            longSdf = new SimpleDateFormat("MM/dd HH:mm:ss", Locale.getDefault());
         }
 
         private void showNotificationContent(boolean show) {
@@ -385,13 +385,11 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
             if (useAbsoluteTime) {
                 String time;
                 if (createdAt != null) {
-                    if (!passed1day) {
-                        if (new Date().getTime() - createdAt.getTime() > 86400000L) {
-                            passed1day = true;
-                            sdf = new SimpleDateFormat("MM/dd HH:mm:ss", Locale.getDefault());
-                        }
+                    if (System.currentTimeMillis() - createdAt.getTime() > 86400000L) {
+                        time = longSdf.format(createdAt);
+                    } else {
+                        time = shortSdf.format(createdAt);
                     }
-                    time = sdf.format(createdAt);
                 } else {
                     time = "??:??:??";
                 }

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -379,7 +379,7 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
 
         protected void setCreatedAt(@Nullable Date createdAt) {
             if (useAbsoluteTime) {
-                String time = "ERROR!";
+                String time;
                 if (createdAt != null) {
                     SimpleDateFormat sdf;
                     if (new Date().getTime() - createdAt.getTime() > 86400000L) {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -388,8 +388,10 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
                         sdf = new SimpleDateFormat("HH:mm:ss", Locale.getDefault());
                     }
                     time = sdf.format(createdAt);
-                    timestampInfo.setText(time);
+                } else {
+                    time = "??:??:??";
                 }
+                timestampInfo.setText(time);
             } else {
                 // This is the visible timestampInfo.
                 String readout;

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -328,6 +328,8 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
         private StatusViewData.Concrete statusViewData;
 
         private boolean useAbsoluteTime;
+        private SimpleDateFormat sdf;
+        private boolean passed1day;
 
         StatusNotificationViewHolder(View itemView, boolean useAbsoluteTime) {
             super(itemView);
@@ -353,6 +355,8 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
             contentWarningButton.setOnCheckedChangeListener(this);
 
             this.useAbsoluteTime = useAbsoluteTime;
+            sdf = new SimpleDateFormat("HH:mm:ss", Locale.getDefault());
+            passed1day = false;
         }
 
         private void showNotificationContent(boolean show) {
@@ -381,11 +385,11 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
             if (useAbsoluteTime) {
                 String time;
                 if (createdAt != null) {
-                    SimpleDateFormat sdf;
-                    if (new Date().getTime() - createdAt.getTime() > 86400000L) {
-                        sdf = new SimpleDateFormat("MM/dd HH:mm:ss", Locale.getDefault());
-                    } else {
-                        sdf = new SimpleDateFormat("HH:mm:ss", Locale.getDefault());
+                    if (!passed1day) {
+                        if (new Date().getTime() - createdAt.getTime() > 86400000L) {
+                            passed1day = true;
+                            sdf = new SimpleDateFormat("MM/dd HH:mm:ss", Locale.getDefault());
+                        }
                     }
                     time = sdf.format(createdAt);
                 } else {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/SearchResultsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/SearchResultsAdapter.java
@@ -48,12 +48,14 @@ public class SearchResultsAdapter extends RecyclerView.Adapter {
 
     private boolean mediaPreviewsEnabled;
     private boolean alwaysShowSensitiveMedia;
+    private boolean useAbsoluteTime;
 
     private LinkListener linkListener;
     private StatusActionListener statusListener;
 
     public SearchResultsAdapter(boolean mediaPreviewsEnabled, boolean alwaysShowSensitiveMedia,
-                                LinkListener linkListener, StatusActionListener statusListener) {
+                                LinkListener linkListener, StatusActionListener statusListener,
+                                boolean useAbsoluteTime) {
 
         this.accountList = Collections.emptyList();
         this.statusList = Collections.emptyList();
@@ -62,6 +64,7 @@ public class SearchResultsAdapter extends RecyclerView.Adapter {
 
         this.mediaPreviewsEnabled = mediaPreviewsEnabled;
         this.alwaysShowSensitiveMedia = alwaysShowSensitiveMedia;
+        this.useAbsoluteTime = useAbsoluteTime;
 
         this.linkListener = linkListener;
         this.statusListener = statusListener;
@@ -86,7 +89,7 @@ public class SearchResultsAdapter extends RecyclerView.Adapter {
             case VIEW_TYPE_STATUS: {
                 View view = LayoutInflater.from(parent.getContext())
                         .inflate(R.layout.item_status, parent, false);
-                return new StatusViewHolder(view);
+                return new StatusViewHolder(view, useAbsoluteTime);
             }
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -133,7 +133,7 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
     protected void setCreatedAt(@Nullable Date createdAt) {
         if (useAbsoluteTime) {
-            String time = "ERROR!";
+            String time;
             if (createdAt != null) {
                 SimpleDateFormat sdf;
                 if (new Date().getTime() - createdAt.getTime() > 86400000L) {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -67,8 +67,8 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
     TextView contentWarningDescription;
 
     private boolean useAbsoluteTime;
-    private SimpleDateFormat sdf;
-    private boolean passed1day;
+    private SimpleDateFormat shortSdf;
+    private SimpleDateFormat longSdf;
 
     StatusBaseViewHolder(View itemView, boolean useAbsoluteTime) {
         super(itemView);
@@ -99,8 +99,8 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         contentWarningButton = itemView.findViewById(R.id.status_content_warning_button);
 
         this.useAbsoluteTime = useAbsoluteTime;
-        sdf = new SimpleDateFormat("HH:mm:ss", Locale.getDefault());
-        passed1day = false;
+        shortSdf = new SimpleDateFormat("HH:mm:ss", Locale.getDefault());
+        longSdf = new SimpleDateFormat("MM/dd HH:mm:ss", Locale.getDefault());
     }
 
     protected abstract int getMediaPreviewHeight(Context context);
@@ -139,13 +139,11 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         if (useAbsoluteTime) {
             String time;
             if (createdAt != null) {
-                if (!passed1day) {
-                    if (new Date().getTime() - createdAt.getTime() > 86400000L) {
-                        passed1day = true;
-                        sdf = new SimpleDateFormat("MM/dd HH:mm:ss", Locale.getDefault());
-                    }
+                if (System.currentTimeMillis() - createdAt.getTime() > 86400000L) {
+                    time = longSdf.format(createdAt);
+                } else {
+                    time = shortSdf.format(createdAt);
                 }
-                time = sdf.format(createdAt);
             } else {
                 time = "??:??:??";
             }

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -67,6 +67,8 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
     TextView contentWarningDescription;
 
     private boolean useAbsoluteTime;
+    private SimpleDateFormat sdf;
+    private boolean passed1day;
 
     StatusBaseViewHolder(View itemView, boolean useAbsoluteTime) {
         super(itemView);
@@ -97,6 +99,8 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         contentWarningButton = itemView.findViewById(R.id.status_content_warning_button);
 
         this.useAbsoluteTime = useAbsoluteTime;
+        sdf = new SimpleDateFormat("HH:mm:ss", Locale.getDefault());
+        passed1day = false;
     }
 
     protected abstract int getMediaPreviewHeight(Context context);
@@ -135,11 +139,11 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         if (useAbsoluteTime) {
             String time;
             if (createdAt != null) {
-                SimpleDateFormat sdf;
-                if (new Date().getTime() - createdAt.getTime() > 86400000L) {
-                    sdf = new SimpleDateFormat("MM/dd HH:mm:ss", Locale.getDefault());
-                } else {
-                    sdf = new SimpleDateFormat("HH:mm:ss", Locale.getDefault());
+                if (!passed1day) {
+                    if (new Date().getTime() - createdAt.getTime() > 86400000L) {
+                        passed1day = true;
+                        sdf = new SimpleDateFormat("MM/dd HH:mm:ss", Locale.getDefault());
+                    }
                 }
                 time = sdf.format(createdAt);
             } else {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -1,9 +1,7 @@
 package com.keylesspalace.tusky.adapter;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.drawable.Drawable;
-import android.preference.PreferenceManager;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -68,7 +66,9 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
     TextView content;
     TextView contentWarningDescription;
 
-    StatusBaseViewHolder(View itemView) {
+    private boolean useAbsoluteTime;
+
+    StatusBaseViewHolder(View itemView, boolean useAbsoluteTime) {
         super(itemView);
         container = itemView.findViewById(R.id.status_container);
         displayName = itemView.findViewById(R.id.status_display_name);
@@ -95,6 +95,8 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         mediaLabel = itemView.findViewById(R.id.status_media_label);
         contentWarningDescription = itemView.findViewById(R.id.status_content_warning_description);
         contentWarningButton = itemView.findViewById(R.id.status_content_warning_button);
+
+        this.useAbsoluteTime = useAbsoluteTime;
     }
 
     protected abstract int getMediaPreviewHeight(Context context);
@@ -130,8 +132,7 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
     }
 
     protected void setCreatedAt(@Nullable Date createdAt) {
-        SharedPreferences defPrefs = PreferenceManager.getDefaultSharedPreferences(timestampInfo.getContext());
-        if (defPrefs.getBoolean("absoluteTimeView", true)) {
+        if (useAbsoluteTime) {
             String time = "ERROR!";
             if (createdAt != null) {
                 SimpleDateFormat sdf;

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -142,8 +142,10 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                     sdf = new SimpleDateFormat("HH:mm:ss", Locale.getDefault());
                 }
                 time = sdf.format(createdAt);
-                timestampInfo.setText(time);
+            } else {
+                time = "??:??:??";
             }
+            timestampInfo.setText(time);
         } else {
             // This is the visible timestampInfo.
             String readout;

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
@@ -41,7 +41,7 @@ class StatusDetailedViewHolder extends StatusBaseViewHolder {
     private TextView cardUrl;
 
     StatusDetailedViewHolder(View view) {
-        super(view);
+        super(view, false);
         reblogs = view.findViewById(R.id.status_reblogs);
         favourites = view.findViewById(R.id.status_favourites);
         cardView = view.findViewById(R.id.card_view);

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusViewHolder.java
@@ -34,8 +34,8 @@ public class StatusViewHolder extends StatusBaseViewHolder {
     private ImageView avatarReblog;
     private TextView rebloggedBar;
 
-    StatusViewHolder(View itemView) {
-        super(itemView);
+    StatusViewHolder(View itemView, boolean useAbsoluteTime) {
+        super(itemView, useAbsoluteTime);
         avatarReblog = itemView.findViewById(R.id.status_avatar_reblog);
         rebloggedBar = itemView.findViewById(R.id.status_reblogged);
         //workaround because Android < API 21 does not support setting drawableLeft from xml when it is a vector image

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/ThreadAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/ThreadAdapter.java
@@ -36,12 +36,14 @@ public class ThreadAdapter extends RecyclerView.Adapter {
     private List<StatusViewData.Concrete> statuses;
     private StatusActionListener statusActionListener;
     private boolean mediaPreviewEnabled;
+    private boolean useAbsoluteTime;
     private int detailedStatusPosition;
 
     public ThreadAdapter(StatusActionListener listener) {
         this.statusActionListener = listener;
         this.statuses = new ArrayList<>();
         mediaPreviewEnabled = true;
+        useAbsoluteTime = false;
         detailedStatusPosition = RecyclerView.NO_POSITION;
     }
 
@@ -53,7 +55,7 @@ public class ThreadAdapter extends RecyclerView.Adapter {
             case VIEW_TYPE_STATUS: {
                 View view = LayoutInflater.from(parent.getContext())
                         .inflate(R.layout.item_status, parent, false);
-                return new StatusViewHolder(view);
+                return new StatusViewHolder(view, useAbsoluteTime);
             }
             case VIEW_TYPE_STATUS_DETAILED: {
                 View view = LayoutInflater.from(parent.getContext())
@@ -147,6 +149,10 @@ public class ThreadAdapter extends RecyclerView.Adapter {
 
     public void setMediaPreviewEnabled(boolean enabled) {
         mediaPreviewEnabled = enabled;
+    }
+
+    public void setUseAbsoluteTime(boolean useAbsoluteTime) {
+        this.useAbsoluteTime = useAbsoluteTime;
     }
 
     public void setDetailedStatusPosition(int position) {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/TimelineAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/TimelineAdapter.java
@@ -39,6 +39,7 @@ public final class TimelineAdapter extends RecyclerView.Adapter {
     private final AdapterDataSource<StatusViewData> dataSource;
     private final StatusActionListener statusListener;
     private boolean mediaPreviewEnabled;
+    private boolean useAbsoluteTime;
 
     public TimelineAdapter(AdapterDataSource<StatusViewData> dataSource,
                            StatusActionListener statusListener) {
@@ -46,6 +47,7 @@ public final class TimelineAdapter extends RecyclerView.Adapter {
         this.dataSource = dataSource;
         this.statusListener = statusListener;
         mediaPreviewEnabled = true;
+        useAbsoluteTime = false;
     }
 
     @NonNull
@@ -56,7 +58,7 @@ public final class TimelineAdapter extends RecyclerView.Adapter {
             case VIEW_TYPE_STATUS: {
                 View view = LayoutInflater.from(viewGroup.getContext())
                         .inflate(R.layout.item_status, viewGroup, false);
-                return new StatusViewHolder(view);
+                return new StatusViewHolder(view, useAbsoluteTime);
             }
             case VIEW_TYPE_PLACEHOLDER: {
                 View view = LayoutInflater.from(viewGroup.getContext())
@@ -96,6 +98,10 @@ public final class TimelineAdapter extends RecyclerView.Adapter {
 
     public void setMediaPreviewEnabled(boolean enabled) {
         mediaPreviewEnabled = enabled;
+    }
+
+    public void setUseAbsoluteTime(boolean useAbsoluteTime){
+        this.useAbsoluteTime=useAbsoluteTime;
     }
 
     public boolean getMediaPreviewEnabled() {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -198,6 +198,8 @@ public class NotificationsFragment extends SFragment implements
         alwaysShowSensitiveMedia = preferences.getBoolean("alwaysShowSensitiveMedia", false);
         boolean mediaPreviewEnabled = preferences.getBoolean("mediaPreviewEnabled", true);
         adapter.setMediaPreviewEnabled(mediaPreviewEnabled);
+        boolean useAbsoluteTime = preferences.getBoolean("absoluteTimeView", false);
+        adapter.setUseAbsoluteTime(useAbsoluteTime);
         recyclerView.setAdapter(adapter);
 
         notifications.clear();

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/SearchFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/SearchFragment.kt
@@ -50,6 +50,7 @@ class SearchFragment : SFragment(), StatusActionListener, Injectable {
 
     private var alwaysShowSensitiveMedia = false
     private var mediaPreviewEnabled = true
+    private var useAbsoluteTime = false
 
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -60,10 +61,11 @@ class SearchFragment : SFragment(), StatusActionListener, Injectable {
         val preferences = PreferenceManager.getDefaultSharedPreferences(view.context)
         alwaysShowSensitiveMedia = preferences.getBoolean("alwaysShowSensitiveMedia", false)
         mediaPreviewEnabled = preferences.getBoolean("mediaPreviewEnabled", true)
+        useAbsoluteTime = preferences.getBoolean("absoluteTimeView", false)
 
         searchRecyclerView.addItemDecoration(DividerItemDecoration(view.context, DividerItemDecoration.VERTICAL))
         searchRecyclerView.layoutManager = LinearLayoutManager(view.context)
-        searchAdapter = SearchResultsAdapter(mediaPreviewEnabled, alwaysShowSensitiveMedia, this, this)
+        searchAdapter = SearchResultsAdapter(mediaPreviewEnabled, alwaysShowSensitiveMedia, this, this, useAbsoluteTime)
         searchRecyclerView.adapter = searchAdapter
 
     }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -248,6 +248,8 @@ public class TimelineFragment extends SFragment implements
         alwaysShowSensitiveMedia = preferences.getBoolean("alwaysShowSensitiveMedia", false);
         boolean mediaPreviewEnabled = preferences.getBoolean("mediaPreviewEnabled", true);
         adapter.setMediaPreviewEnabled(mediaPreviewEnabled);
+        boolean useAbsoluteTime = preferences.getBoolean("absoluteTimeView", false);
+        adapter.setUseAbsoluteTime(useAbsoluteTime);
 
         boolean filter = preferences.getBoolean("tabFilterHomeReplies", true);
         filterRemoveReplies = kind == Kind.HOME && !filter;
@@ -605,7 +607,7 @@ public class TimelineFragment extends SFragment implements
             case "mediaPreviewEnabled": {
                 boolean enabled = sharedPreferences.getBoolean("mediaPreviewEnabled", true);
                 boolean oldMediaPreviewEnabled = adapter.getMediaPreviewEnabled();
-                if(enabled != oldMediaPreviewEnabled) {
+                if (enabled != oldMediaPreviewEnabled) {
                     adapter.setMediaPreviewEnabled(enabled);
                     fullyRefresh();
                 }
@@ -827,7 +829,7 @@ public class TimelineFragment extends SFragment implements
     }
 
     private void onFetchTimelineFailure(Exception exception, FetchEnd fetchEnd, int position) {
-        if(isAdded()) {
+        if (isAdded()) {
             swipeRefreshLayout.setRefreshing(false);
 
             if (fetchEnd == FetchEnd.MIDDLE && !statuses.get(position).isRight()) {
@@ -1049,7 +1051,7 @@ public class TimelineFragment extends SFragment implements
     private final ListUpdateCallback listUpdateCallback = new ListUpdateCallback() {
         @Override
         public void onInserted(int position, int count) {
-            if(isAdded()) {
+            if (isAdded()) {
                 adapter.notifyItemRangeInserted(position, count);
                 Context context = getContext();
                 if (position == 0 && context != null) {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -156,6 +156,8 @@ public final class ViewThreadFragment extends SFragment implements
         alwaysShowSensitiveMedia = preferences.getBoolean("alwaysShowSensitiveMedia", false);
         boolean mediaPreviewEnabled = preferences.getBoolean("mediaPreviewEnabled", true);
         adapter.setMediaPreviewEnabled(mediaPreviewEnabled);
+        boolean useAbsoluteTime = preferences.getBoolean("absoluteTimeView", false);
+        adapter.setUseAbsoluteTime(useAbsoluteTime);
         recyclerView.setAdapter(adapter);
 
         statuses.clear();

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -277,4 +277,6 @@
     <string name="action_set_caption">説明を設定</string>
     <string name="action_remove_media">消去</string>
 
+    <string name="pref_title_absolute_time">絶対時間で表示</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -347,4 +347,6 @@
     <string name="profile_metadata_label_label">Label</string>
     <string name="profile_metadata_content_label">Content</string>
 
+    <string name="pref_title_absolute_time">Use absolute time</string>
+
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -42,6 +42,11 @@
             android:key="alwaysShowSensitiveMedia"
             android:title="@string/pref_title_alway_show_sensitive_media" />
 
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="absoluteTimeView"
+            android:title="@string/pref_title_absolute_time" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_publishing">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -43,7 +43,7 @@
             android:title="@string/pref_title_alway_show_sensitive_media" />
 
         <CheckBoxPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="absoluteTimeView"
             android:title="@string/pref_title_absolute_time" />
 


### PR DESCRIPTION
Add an option in the settings to show the absolute time of every user’s post on timeline instead of relative time, as there frequently happens time delay if we use current system depending on refresh time of the timeline. This PR is made for those users who want to know the time by the default time stamp.
![c23388134cd7af55](https://user-images.githubusercontent.com/27999567/44218308-683fd880-a1b4-11e8-9755-fba721807871.png)
![7f622e30147c61fd](https://user-images.githubusercontent.com/27999567/44218348-7beb3f00-a1b4-11e8-9626-fc770d9b29de.png)

Same as for now, we can use relative time displaying by disable this settings. See the attached image:
![e3f677a4fd7ac0aa](https://user-images.githubusercontent.com/27999567/44218361-83124d00-a1b4-11e8-891d-8bab33cc5472.png)