### PR TITLE
notification tab - fix progressbars of footer and fragment overlapping

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -64,7 +64,6 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
     private List<NotificationViewData> notifications;
     private StatusActionListener statusListener;
     private NotificationActionListener notificationActionListener;
-    private FooterViewHolder.State footerState;
     private boolean mediaPreviewEnabled;
     private BidiFormatter bidiFormatter;
 
@@ -74,7 +73,6 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
         notifications = new ArrayList<>();
         this.statusListener = statusListener;
         this.notificationActionListener = notificationActionListener;
-        footerState = FooterViewHolder.State.END;
         mediaPreviewEnabled = true;
         bidiFormatter = BidiFormatter.getInstance();
     }
@@ -164,15 +162,12 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
                     break;
                 }
             }
-        } else {
-            FooterViewHolder holder = (FooterViewHolder) viewHolder;
-            holder.setState(footerState);
         }
     }
 
     @Override
     public int getItemCount() {
-        return notifications.size() + 1;
+        return notifications.size();
     }
 
     @Override
@@ -227,14 +222,6 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
     public void clear() {
         notifications.clear();
         notifyDataSetChanged();
-    }
-
-    public void setFooterState(FooterViewHolder.State newFooterState) {
-        FooterViewHolder.State oldValue = footerState;
-        footerState = newFooterState;
-        if (footerState != oldValue) {
-            notifyItemChanged(notifications.size());
-        }
     }
 
     public void setMediaPreviewEnabled(boolean enabled) {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -117,7 +117,7 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
             if (notification instanceof NotificationViewData.Placeholder) {
                 NotificationViewData.Placeholder placeholder = ((NotificationViewData.Placeholder) notification);
                 PlaceholderViewHolder holder = (PlaceholderViewHolder) viewHolder;
-                holder.setup(!placeholder.isLoading(), statusListener);
+                holder.setup(statusListener, placeholder.isLoading());
                 return;
             }
             NotificationViewData.Concrete concreteNotificaton =
@@ -217,6 +217,11 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
     public void addItems(List<NotificationViewData> newNotifications) {
         notifications.addAll(newNotifications);
         notifyItemRangeInserted(notifications.size(), newNotifications.size());
+    }
+
+    public void removeItemAndNotify(int position) {
+        notifications.remove(position);
+        notifyItemRemoved(position);
     }
 
     public void clear() {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/PlaceholderViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/PlaceholderViewHolder.java
@@ -34,21 +34,16 @@ public final class PlaceholderViewHolder extends RecyclerView.ViewHolder {
         progressBar = itemView.findViewById(R.id.progress_bar);
     }
 
-    public void setup(boolean enabled, final StatusActionListener listener) {
-        this.setup(enabled, listener, false);
-    }
-
-    public void setup(boolean enabled, final StatusActionListener listener, boolean progress) {
+    public void setup(final StatusActionListener listener, boolean progress) {
         loadMoreButton.setVisibility(progress ? View.GONE : View.VISIBLE);
         progressBar.setVisibility(progress ? View.VISIBLE : View.GONE);
 
-        loadMoreButton.setEnabled(enabled);
-        if (enabled) {
-            loadMoreButton.setOnClickListener(v -> {
-                loadMoreButton.setEnabled(false);
-                listener.onLoadMore(getAdapterPosition());
-            });
-        }
+        loadMoreButton.setEnabled(true);
+        loadMoreButton.setOnClickListener(v -> {
+            loadMoreButton.setEnabled(false);
+            listener.onLoadMore(getAdapterPosition());
+        });
+
     }
 
 }

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/TimelineAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/TimelineAdapter.java
@@ -71,8 +71,7 @@ public final class TimelineAdapter extends RecyclerView.Adapter {
         StatusViewData status = dataSource.getItemAt(position);
         if (status instanceof StatusViewData.Placeholder) {
             PlaceholderViewHolder holder = (PlaceholderViewHolder) viewHolder;
-            holder.setup(!((StatusViewData.Placeholder) status).isLoading(),
-                    statusListener, ((StatusViewData.Placeholder) status).isLoading());
+            holder.setup(statusListener, ((StatusViewData.Placeholder) status).isLoading());
         } else {
             StatusViewHolder holder = (StatusViewHolder) viewHolder;
             holder.setupWithStatus((StatusViewData.Concrete) status,

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -43,7 +43,6 @@ import android.widget.TextView;
 
 import com.keylesspalace.tusky.MainActivity;
 import com.keylesspalace.tusky.R;
-import com.keylesspalace.tusky.adapter.FooterViewHolder;
 import com.keylesspalace.tusky.adapter.NotificationsAdapter;
 import com.keylesspalace.tusky.appstore.EventHub;
 import com.keylesspalace.tusky.appstore.BlockEvent;
@@ -210,6 +209,8 @@ public class NotificationsFragment extends SFragment implements
 
         ((SimpleItemAnimator) recyclerView.getItemAnimator()).setSupportsChangeAnimations(false);
         setupNothingView();
+
+        sendFetchNotificationsRequest(null, topId, FetchEnd.TOP, -1);
 
         return rootView;
     }
@@ -576,7 +577,7 @@ public class NotificationsFragment extends SFragment implements
             /* When this is called by the EndlessScrollListener it cannot refresh the footer state
              * using adapter.notifyItemChanged. So its necessary to postpone doing so until a
              * convenient time for the UI thread using a Runnable. */
-            recyclerView.post(() -> adapter.setFooterState(FooterViewHolder.State.LOADING));
+       //     recyclerView.post(() -> adapter.setFooterState(FooterViewHolder.State.LOADING));
         }
 
         Call<List<Notification>> call = mastodonApi.notifications(fromId, uptoId, LOAD_AT_ONCE);
@@ -645,10 +646,10 @@ public class NotificationsFragment extends SFragment implements
         saveNewestNotificationId(notifications);
 
         fulfillAnyQueuedFetches(fetchEnd);
-        if (notifications.size() == 0 && adapter.getItemCount() == 1) {
-            adapter.setFooterState(FooterViewHolder.State.EMPTY);
+        if (notifications.size() == 0 && adapter.getItemCount() == 0) {
+            nothingMessageView.setVisibility(View.VISIBLE);
         } else {
-            adapter.setFooterState(FooterViewHolder.State.END);
+            nothingMessageView.setVisibility(View.GONE);
         }
         swipeRefreshLayout.setRefreshing(false);
         progressBar.setVisibility(View.GONE);


### PR DESCRIPTION
There where two progressbars showing when the notification tab did its initial load.
I removed the progressbar of the footer.

Still missing - loading bar at the bottom when scrolling completely down