### PR TITLE
fix crash when EmojiCompat was not initialized

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
@@ -516,7 +516,11 @@ public final class MainActivity extends BottomSheetActivity implements ActionBut
 
         for (AccountEntity acc : allAccounts) {
             CharSequence emojifiedName = CustomEmojiHelper.emojifyString(acc.getDisplayName(), acc.getEmojis(), headerResult.getView());
-            emojifiedName = EmojiCompat.get().process(emojifiedName);
+            try {
+                emojifiedName = EmojiCompat.get().process(emojifiedName);
+            } catch (IllegalArgumentException e) {
+                Log.w("MainActivity", e);
+            }
 
             profiles.add(0,
                     new ProfileDrawerItem()


### PR DESCRIPTION
Seems like this time its a racecondition because it does not crash every time like when we had this Problem in `AccountActivity` and the font did not work?  Any ideas @C1710?