### PR TITLE
fix repeating toots in timelines

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -139,9 +139,9 @@ public class TimelineFragment extends SFragment implements
     private boolean bottomLoading;
 
     @Nullable
-    private String bottomId;
+    private String bottomId = null;
     @Nullable
-    private String topId;
+    private String topId = null;
     private long maxPlaceholderId = -1;
     private boolean didLoadEverythingBottom;
 
@@ -226,9 +226,6 @@ public class TimelineFragment extends SFragment implements
         updateAdapter();
         setupTimelinePreferences();
         setupNothingView();
-
-        bottomId = null;
-        topId = null;
 
         if (statuses.isEmpty()) {
             progressBar.setVisibility(View.VISIBLE);


### PR DESCRIPTION
steps to reproduce: Cold start Tusky, go to federated timeline. Go to home timeline, scroll down.

The problem was that the fragments got recreated incorrectly. Toots were preserved, but not indices.