### PR TITLE
wait for EmojiCompat to be initialized before using it

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
@@ -387,7 +387,12 @@ public final class MainActivity extends BottomSheetActivity implements ActionBut
             drawer.addItem(debugItem);
         }
 
-        updateProfiles();
+        EmojiCompat.get().registerInitCallback(new EmojiCompat.InitCallback() {
+            @Override
+            public void onInitialized() {
+                updateProfiles();
+            }
+        });
     }
 
     private boolean handleProfileClick(IProfile profile, boolean current) {


### PR DESCRIPTION
better fix than #778 

Theoretically it could still be possible that the network callback is faster than the EmojiCompat initialization, but I dont think thats gonna happen for real