### PR TITLE
update media limits for Mastodon 2.5

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
@@ -159,8 +159,9 @@ public final class ComposeActivity
 
     private static final String TAG = "ComposeActivity"; // logging tag
     static final int STATUS_CHARACTER_LIMIT = 500;
-    private static final int STATUS_MEDIA_SIZE_LIMIT = 8388608; // 8MiB
-    private static final int STATUS_MEDIA_PIXEL_SIZE_LIMIT = 16777216; // 4096^2 Pixels
+    private static final int STATUS_IMAGE_SIZE_LIMIT = 8388608; // 8MiB
+    private static final int STATUS_VIDEO_SIZE_LIMIT = 41943040; // 40MiB
+    private static final int STATUS_IMAGE_PIXEL_SIZE_LIMIT = 16777216; // 4096^2 Pixels
     private static final int MEDIA_PICK_RESULT = 1;
     private static final int MEDIA_TAKE_PHOTO_RESULT = 2;
     private static final int PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE = 1;
@@ -1088,7 +1089,7 @@ public final class ComposeActivity
 
             try {
                 if (type == QueuedMedia.Type.IMAGE &&
-                        (mediaSize > STATUS_MEDIA_SIZE_LIMIT || MediaUtils.getImageSquarePixels(getContentResolver(), item.uri) > STATUS_MEDIA_PIXEL_SIZE_LIMIT)) {
+                        (mediaSize > STATUS_IMAGE_SIZE_LIMIT || MediaUtils.getImageSquarePixels(getContentResolver(), item.uri) > STATUS_IMAGE_PIXEL_SIZE_LIMIT)) {
                     downsizeMedia(item);
                 } else {
                     uploadMedia(item);
@@ -1226,7 +1227,7 @@ public final class ComposeActivity
     private void downsizeMedia(final QueuedMedia item) {
         item.readyStage = QueuedMedia.ReadyStage.DOWNSIZING;
 
-        new DownsizeImageTask(STATUS_MEDIA_SIZE_LIMIT, getContentResolver(),
+        new DownsizeImageTask(STATUS_IMAGE_SIZE_LIMIT, getContentResolver(),
                 new DownsizeImageTask.Listener() {
                     @Override
                     public void onSuccess(List<byte[]> contentList) {
@@ -1242,7 +1243,7 @@ public final class ComposeActivity
     }
 
     private void onMediaDownsizeFailure(QueuedMedia item) {
-        displayTransientError(R.string.error_media_upload_size);
+        displayTransientError(R.string.error_image_upload_size);
         removeMediaFromQueue(item);
     }
 
@@ -1378,8 +1379,8 @@ public final class ComposeActivity
             String topLevelType = mimeType.substring(0, mimeType.indexOf('/'));
             switch (topLevelType) {
                 case "video": {
-                    if (mediaSize > STATUS_MEDIA_SIZE_LIMIT) {
-                        displayTransientError(R.string.error_media_upload_size);
+                    if (mediaSize > STATUS_VIDEO_SIZE_LIMIT) {
+                        displayTransientError(R.string.error_image_upload_size);
                         return;
                     }
                     if (mediaQueued.size() > 0

--- a/app/src/main/java/com/keylesspalace/tusky/EditProfileActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/EditProfileActivity.kt
@@ -53,8 +53,8 @@ class EditProfileActivity : BaseActivity(), Injectable {
 
     companion object {
         const val AVATAR_SIZE = 400
-        const val HEADER_WIDTH = 700
-        const val HEADER_HEIGHT = 335
+        const val HEADER_WIDTH = 1500
+        const val HEADER_HEIGHT = 500
 
         private const val AVATAR_PICK_RESULT = 1
         private const val HEADER_PICK_RESULT = 2

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">تم رفض التصريح.</string>
     <string name="error_retrieving_oauth_token">فشل الحصول على رمز الدخول.</string>
     <string name="error_compose_character_limit">المنشور طويل جدا !</string>
-    <string name="error_media_upload_size">يجب أن يكون حجم الملف أقل من 4 ميغابايت.</string>
+    <string name="error_image_upload_size">يجب أن يكون حجم الملف أقل من 4 ميغابايت.</string>
     <string name="error_media_upload_type">لا يمكن رفع هذا النوع من الملفات.</string>
     <string name="error_media_upload_opening">تعذر فتح ذاك الملف.</string>
     <string name="error_media_upload_permission">التصريح لازم لقراءة الوسائط</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">L\'autorització s\'ha denegat.</string>
     <string name="error_retrieving_oauth_token">L\'obtenció del testimoni d\'inici de sessió ha fallat.</string>
     <string name="error_compose_character_limit">L\'estat és massa llarg!</string>
-    <string name="error_media_upload_size">El fitxer ha de ser inferior a 8MB.</string>
+    <string name="error_image_upload_size">El fitxer ha de ser inferior a 8MB.</string>
     <string name="error_media_upload_type">Aquest tipus de fitxer no es pot pujar.</string>
     <string name="error_media_upload_opening">Aquest tipus de fitxer no es pot obrir.</string>
     <string name="error_media_upload_permission">Cal permís de lectura del mitjà.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">Autorisierung fehlgeschlagen.</string>
     <string name="error_retrieving_oauth_token">Es konnte kein Login-Token abgerufen werden.</string>
     <string name="error_compose_character_limit">Der Beitrag ist zu lang!</string>
-    <string name="error_media_upload_size">Die Datei muss kleiner als 8MB sein.</string>
+    <string name="error_image_upload_size">Die Datei muss kleiner als 8MB sein.</string>
     <string name="error_media_upload_type">Dieser Dateityp darf nicht hochgeladen werden.</string>
     <string name="error_media_upload_opening">Die Datei konnte nicht geöffnet werden.</string>
     <string name="error_media_upload_permission">Eine Leseberechtigung wird für das Hochladen der Mediendatei benötigt.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">La autorización falló.</string>
     <string name="error_retrieving_oauth_token">Fallo al obtener identificador de login.</string>
     <string name="error_compose_character_limit">¡El estado es demasiado largo!</string>
-    <string name="error_media_upload_size">El archivo debe ser inferior a 8MB.</string>
+    <string name="error_image_upload_size">El archivo debe ser inferior a 8MB.</string>
     <string name="error_media_upload_type">No se admite este tipo de archivo.</string>
     <string name="error_media_upload_opening">No pudo abrirse el fichero.</string>
     <string name="error_media_upload_permission">Se requiere permiso para acceder al almacenamiento.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">Authentification refusée.</string>
     <string name="error_retrieving_oauth_token">Impossible de récupérer le jeton d’authentification.</string>
     <string name="error_compose_character_limit">Votre pouet est trop long !</string>
-    <string name="error_media_upload_size">Le fichier doit peser moins de 8 Mo.</string>
+    <string name="error_image_upload_size">Le fichier doit peser moins de 8 Mo.</string>
     <string name="error_media_upload_type">Ce type de fichier n’est pas accepté.</string>
     <string name="error_media_upload_opening">Le fichier ne peut pas être ouvert.</string>
     <string name="error_media_upload_permission">Permission requise pour lire ce média.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">Engedélyezés letiltva.</string>
     <string name="error_retrieving_oauth_token">Bejelentkezési token megszerzése sikertelen.</string>
     <string name="error_compose_character_limit">Túl hosszú a tülkölés!</string>
-    <string name="error_media_upload_size">A fájl kisebb kell legyen mint 8MB.</string>
+    <string name="error_image_upload_size">A fájl kisebb kell legyen mint 8MB.</string>
     <string name="error_media_upload_type">Fájl feltöltése sikertelen.</string>
     <string name="error_media_upload_opening">Fájl megnyitása sikertelen.</string>
     <string name="error_media_upload_permission">Média olvasási engedély szükséges.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">L\'autorizzazione è stata negata.</string>
     <string name="error_retrieving_oauth_token">Errore nell\'acquisizione del token di accesso.</string>
     <string name="error_compose_character_limit">Lo stato è troppo lungo!</string>
-    <string name="error_media_upload_size">La dimensione del file deve essere inferiore a 8MB.</string>
+    <string name="error_image_upload_size">La dimensione del file deve essere inferiore a 8MB.</string>
     <string name="error_media_upload_type">Questo tipo di file non può essere caricato.</string>
     <string name="error_media_upload_opening">Questo file non può essere aperto.</string>
     <string name="error_media_upload_permission">Il permesso di lettura della scheda sd è richiesto.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">承認が拒否されました。</string>
     <string name="error_retrieving_oauth_token">ログイントークンの取得に失敗しました。</string>
     <string name="error_compose_character_limit">投稿文が長すぎます！</string>
-    <string name="error_media_upload_size">ファイルは4MB未満にしてください。</string>
+    <string name="error_image_upload_size">ファイルは4MB未満にしてください。</string>
     <string name="error_media_upload_type">その形式のファイルはアップロードできません。</string>
     <string name="error_media_upload_opening">ファイルを開けませんでした。</string>
     <string name="error_media_upload_permission">メディアの読み取り許可が必要です。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -10,7 +10,7 @@
     <string name="error_authorization_denied">인증이 거부되었습니다.</string>
     <string name="error_retrieving_oauth_token">로그인 토큰을 가져오는 데 실패했습니다.</string>
     <string name="error_compose_character_limit">툿이 너무 깁니다!</string>
-    <string name="error_media_upload_size">파일은 8MB보다 작아야 합니다.</string>
+    <string name="error_image_upload_size">파일은 8MB보다 작아야 합니다.</string>
     <string name="error_media_upload_type">이 형태의 파일은 업로드될 수 없습니다.</string>
     <string name="error_media_upload_opening">그 파일은 열 수 없습니다.</string>
     <string name="error_media_upload_permission">미디어를 읽기 위한 권한이 필요합니다.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">Autorisatie werd geweigerd.</string>
     <string name="error_retrieving_oauth_token">Kon geen inlogsleutel verkrijgen.</string>
     <string name="error_compose_character_limit">Tekst van deze toot is te lang!</string>
-    <string name="error_media_upload_size">Bestand moet kleiner zijn dan 8MB.</string>
+    <string name="error_image_upload_size">Bestand moet kleiner zijn dan 8MB.</string>
     <string name="error_media_upload_type">Bestandstype kan niet worden geüpload.</string>
     <string name="error_media_upload_opening">Bestand kon niet worden geopend.</string>
     <string name="error_media_upload_permission">Er is toestemming nodig om deze media te lezen.</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">L\'autoritzacion es estada regetada.</string>
     <string name="error_retrieving_oauth_token">Fracàs de l’obtencion del testimoni d\'iniciacion de session.</string>
     <string name="error_compose_character_limit">L\'estatut es tròp long !</string>
-    <string name="error_media_upload_size">Lo fichièr a d’èsser inferior a 8Mo.</string>
+    <string name="error_image_upload_size">Lo fichièr a d’èsser inferior a 8Mo.</string>
     <string name="error_media_upload_type">Aqueste tip de fichièr se pòt pas mandar.</string>
     <string name="error_media_upload_opening">Aqueste tip de fichièr se pòt pas dobrir.</string>
     <string name="error_media_upload_permission">Cal permís de lectura del mèdia.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">Odmówiono autoryzacji.</string>
     <string name="error_retrieving_oauth_token">Nie udało się uzyskać tokenu logowania.</string>
     <string name="error_compose_character_limit">Zbyt długi wpis!</string>
-    <string name="error_media_upload_size">Plik może mieć maksymalnie 8 MB.</string>
+    <string name="error_image_upload_size">Plik może mieć maksymalnie 8 MB.</string>
     <string name="error_media_upload_type">Ten format pliku nie może zostać wysłany.</string>
     <string name="error_media_upload_opening">Nie można otworzyć tego pliku.</string>
     <string name="error_media_upload_permission">Wymagane jest pozwolenie na dostęp do plików z urządzenia.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">Autorização negada.</string>
     <string name="error_retrieving_oauth_token">Falha ao adquirir token de entrada.</string>
     <string name="error_compose_character_limit">A postagem é muito longa!</string>
-    <string name="error_media_upload_size">O arquivo deve ser menor que 8MB.</string>
+    <string name="error_image_upload_size">O arquivo deve ser menor que 8MB.</string>
     <string name="error_media_upload_type">Esse tipo de arquivo não pode ser enviado.</string>
     <string name="error_media_upload_opening">Esse arquvo não pode ser aberto.</string>
     <string name="error_media_upload_permission">Permissão para ler mídia é necessária.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">Авторизация была отклонена.</string>
     <string name="error_retrieving_oauth_token">Не удалось получить токен авторизации.</string>
     <string name="error_compose_character_limit">Статус слишком длинный!</string>
-    <string name="error_media_upload_size">Файл должен быть не больше 8 Мбайт.</string>
+    <string name="error_image_upload_size">Файл должен быть не больше 8 Мбайт.</string>
     <string name="error_media_upload_type">Данный тип файла не может быть загружен.</string>
     <string name="error_media_upload_opening">Файл не может быть открыт.</string>
     <string name="error_media_upload_permission">Необходимо разрешение на чтение медиаконтента.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -10,7 +10,7 @@
     <string name="error_authorization_denied">Ingen behörighet.</string>
     <string name="error_retrieving_oauth_token">Misslyckades med att få en inloggnings-token.</string>
     <string name="error_compose_character_limit">Statusen är för lång!</string>
-    <string name="error_media_upload_size">Filen måste vara mindre än 8MB.</string>
+    <string name="error_image_upload_size">Filen måste vara mindre än 8MB.</string>
     <string name="error_media_upload_type">Den typen av fil kan inte laddas upp.</string>
     <string name="error_media_upload_opening">Den filen kunde inte öppnas.</string>
     <string name="error_media_upload_permission">Tillstånd att läsa media krävs.</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -8,7 +8,7 @@
     <string name="error_authorization_denied">அங்கீகாரம் மறுக்கப்பட்டுள்ளது</string>
     <string name="error_retrieving_oauth_token">உள்நுழைவு டோக்கனைப் பெறுவதில் தோல்வி.</string>
     <string name="error_compose_character_limit">நிலை மிக நீளமாக உள்ளது!</string>
-    <string name="error_media_upload_size">கோப்பு 4MB-க்கும் குறைவாக இருக்க வேண்டும்.</string>
+    <string name="error_image_upload_size">கோப்பு 4MB-க்கும் குறைவாக இருக்க வேண்டும்.</string>
     <string name="error_media_upload_type">இந்த வகை கோப்பை பதிவேற்ற முடியாது.</string>
     <string name="error_media_upload_opening">அந்த கோப்பை திறக்க முடியவில்லை.</string>
     <string name="error_media_upload_permission">ஊடகத்தை படிக்க அனுமதி தேவை.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">Kimlik doğrulama reddedildi.</string>
     <string name="error_retrieving_oauth_token">Giriş jetonu alınamadı.</string>
     <string name="error_compose_character_limit">İleti fazlasıyla uzun!</string>
-    <string name="error_media_upload_size">Dosya 8MB\'ten küçük olmalı.</string>
+    <string name="error_image_upload_size">Dosya 8MB\'ten küçük olmalı.</string>
     <string name="error_media_upload_type">O biçim dosya yüklenmez.</string>
     <string name="error_media_upload_opening">O dosya açılamadı.</string>
     <string name="error_media_upload_permission">Medya okuma izni gerekiyor.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">授权被拒绝。</string>
     <string name="error_retrieving_oauth_token">无法获取登录信息。</string>
     <string name="error_compose_character_limit">嘟文太长了！</string>
-    <string name="error_media_upload_size">文件大小限制 8MB。</string>
+    <string name="error_image_upload_size">文件大小限制 8MB。</string>
     <string name="error_media_upload_type">无法上传此类型的文件。</string>
     <string name="error_media_upload_opening">此文件无法打开。</string>
     <string name="error_media_upload_permission">需要授予 Tusky 读取媒体文件的权限。</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">授權被拒絕。</string>
     <string name="error_retrieving_oauth_token">無法獲取登錄信息。</string>
     <string name="error_compose_character_limit">嘟文太長了！</string>
-    <string name="error_media_upload_size">文件大小限制 8MB。</string>
+    <string name="error_image_upload_size">文件大小限制 8MB。</string>
     <string name="error_media_upload_type">無法上傳此類型的文件。</string>
     <string name="error_media_upload_opening">此文件無法打開。</string>
     <string name="error_media_upload_permission">需要授予 Tusky 讀取媒體文件的權限。</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">授權被拒絕。</string>
     <string name="error_retrieving_oauth_token">無法獲取登錄信息。</string>
     <string name="error_compose_character_limit">嘟文太長了！</string>
-    <string name="error_media_upload_size">文件大小限制 8MB。</string>
+    <string name="error_image_upload_size">文件大小限制 8MB。</string>
     <string name="error_media_upload_type">無法上傳此類型的文件。</string>
     <string name="error_media_upload_opening">此文件無法打開。</string>
     <string name="error_media_upload_permission">需要授予 Tusky 讀取媒體文件的權限。</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">授权被拒绝。</string>
     <string name="error_retrieving_oauth_token">无法获取登录信息。</string>
     <string name="error_compose_character_limit">嘟文太长了！</string>
-    <string name="error_media_upload_size">文件大小限制 8MB。</string>
+    <string name="error_image_upload_size">文件大小限制 8MB。</string>
     <string name="error_media_upload_type">无法上传此类型的文件。</string>
     <string name="error_media_upload_opening">此文件无法打开。</string>
     <string name="error_media_upload_permission">需要授予 Tusky 读取媒体文件的权限。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -9,7 +9,7 @@
     <string name="error_authorization_denied">授權被拒絕。</string>
     <string name="error_retrieving_oauth_token">無法獲取登錄信息。</string>
     <string name="error_compose_character_limit">嘟文太長了！</string>
-    <string name="error_media_upload_size">文件大小限制 8MB。</string>
+    <string name="error_image_upload_size">文件大小限制 8MB。</string>
     <string name="error_media_upload_type">無法上傳此類型的文件。</string>
     <string name="error_media_upload_opening">此文件無法打開。</string>
     <string name="error_media_upload_permission">需要授予 Tusky 讀取媒體文件的權限。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,7 +9,8 @@
     <string name="error_authorization_denied">Authorization was denied.</string>
     <string name="error_retrieving_oauth_token">Failed getting a login token.</string>
     <string name="error_compose_character_limit">The status is too long!</string>
-    <string name="error_media_upload_size">The file must be less than 8MB.</string>
+    <string name="error_image_upload_size">The file must be less than 8MB.</string>
+    <string name="error_video_upload_size">Video files must be less than 40MB.</string>
     <string name="error_media_upload_type">That type of file cannot be uploaded.</string>
     <string name="error_media_upload_opening">That file could not be opened.</string>
     <string name="error_media_upload_permission">Permission to read media is required.</string>


### PR DESCRIPTION
Header images are now 1500x500 and video files can have up to 40MB.

TODO: We are loading the whole file into the memory when uploading, this needs to be fixed because otherwise a 40mb upload will throw out of memory most of the time.