### PR TITLE
Do not show "Pin" in "more" menu of direct status.

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/entity/Status.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Status.kt
@@ -102,6 +102,10 @@ data class Status(
         return (visibility != Visibility.DIRECT && visibility != Visibility.UNKNOWN)
     }
 
+    fun isPinned(): Boolean {
+        return pinned ?: false
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || javaClass != other.javaClass) return false

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
@@ -153,15 +153,21 @@ public abstract class SFragment extends BaseFragment {
         } else {
             popup.inflate(R.menu.status_more_for_user);
             Menu menu = popup.getMenu();
-            if (status.getVisibility() == Status.Visibility.PRIVATE) {
-                boolean reblogged = status.getReblogged();
-                if (status.getReblog() != null) reblogged = status.getReblog().getReblogged();
-                menu.findItem(R.id.status_reblog_private).setVisible(!reblogged);
-                menu.findItem(R.id.status_unreblog_private).setVisible(reblogged);
-            } else {
-                final String textId =
-                        getString(status.getPinned() ? R.string.unpin_action : R.string.pin_action);
-                menu.add(0, R.id.pin, 1, textId);
+            switch (status.getVisibility()) {
+                case PUBLIC:
+                case UNLISTED: {
+                    final String textId =
+                            getString(status.isPinned() ? R.string.unpin_action : R.string.pin_action);
+                    menu.add(0, R.id.pin, 1, textId);
+                    break;
+                }
+                case PRIVATE: {
+                    boolean reblogged = status.getReblogged();
+                    if (status.getReblog() != null) reblogged = status.getReblog().getReblogged();
+                    menu.findItem(R.id.status_reblog_private).setVisible(!reblogged);
+                    menu.findItem(R.id.status_unreblog_private).setVisible(reblogged);
+                    break;
+                }
             }
         }
         popup.setOnMenuItemClickListener(item -> {
@@ -219,7 +225,7 @@ public abstract class SFragment extends BaseFragment {
                     return true;
                 }
                 case R.id.pin: {
-                    timelineCases().pin(status, !status.getPinned());
+                    timelineCases().pin(status, !status.isPinned());
                     return true;
                 }
             }


### PR DESCRIPTION
`status.getPinned()` generates NullPointerException when show menu of direct toot.
So I made a new method which returns only true or false.
https://github.com/accelforce/Tusky/blob/7e4798e2e37923afd90065cf186c397aa931c489/app/src/main/java/com/keylesspalace/tusky/entity/Status.kt#L105-L107
And changed not to show "Pin" option in direct toot's menu.
https://github.com/accelforce/Tusky/blob/7e4798e2e37923afd90065cf186c397aa931c489/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java#L156-L163