### PR TITLE
Display mentions toot hidden

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -9,7 +9,6 @@ import android.support.v7.content.res.AppCompatResources;
 import android.support.v7.widget.RecyclerView;
 import android.text.InputFilter;
 import android.text.Spanned;
-import android.text.style.URLSpan;
 import android.text.TextUtils;
 import android.view.View;
 import android.view.ViewGroup;
@@ -131,8 +130,6 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         Spanned emojifiedText = CustomEmojiHelper.emojifyText(content, emojis, this.content);
         LinkHelper.setClickableText(this.content, emojifiedText, mentions, listener);
         this.contentText = this.content.getText();
-
-        this.mentionsOnlyContentText = LinkHelper.makeMentionsText(mentions, listener);
     }
 
     void setAvatar(String url, @Nullable String rebloggedUrl) {
@@ -424,10 +421,12 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         if (visible) {
             content.setText(this.contentText);
             this.content.setVisibility(View.VISIBLE);
-        } else if (this.mentionsOnlyContentText == null) {
-            this.content.setVisibility(View.GONE);
         } else {
-            content.setText(this.mentionsOnlyContentText);
+            if (this.mentionsOnlyContentText == null) {
+                this.content.setVisibility(View.GONE);
+            } else {
+                content.setText(this.mentionsOnlyContentText);
+            }
         }
     }
 
@@ -528,9 +527,12 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
         setupButtons(listener, status.getSenderId());
         setRebloggingEnabled(status.getRebloggingEnabled(), status.getVisibility());
+
+        setContent(status.getContent(), status.getMentions(), status.getStatusEmojis(), listener);
         if (status.getSpoilerText() == null || status.getSpoilerText().isEmpty()) {
             hideSpoilerText();
         } else {
+            this.mentionsOnlyContentText = LinkHelper.makeMentionsText(status.getMentions(), listener);
             setSpoilerText(status.getSpoilerText(), status.getStatusEmojis(), status.isExpanded(), listener);
         }
 
@@ -557,7 +559,5 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                 content.setFilters(NO_INPUT_FILTER);
             }
         }
-
-        setContent(status.getContent(), status.getMentions(), status.getStatusEmojis(), listener);
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -9,8 +9,6 @@ import android.support.v7.content.res.AppCompatResources;
 import android.support.v7.widget.RecyclerView;
 import android.text.InputFilter;
 import android.text.Spanned;
-import android.text.Spannable;
-import android.text.SpannableStringBuilder;
 import android.text.style.URLSpan;
 import android.text.TextUtils;
 import android.view.View;
@@ -39,7 +37,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.lang.StringBuilder;
+import java.lang.CharSequence;
 
 import at.connyduck.sparkbutton.SparkButton;
 import at.connyduck.sparkbutton.SparkEventListener;
@@ -54,8 +52,8 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
     private SparkButton reblogButton;
     private SparkButton favouriteButton;
     private ImageButton moreButton;
-    private Spannable contentText;
-    private Spannable mentionsOnlyContentText;
+    private CharSequence contentText;
+    private @Nullable CharSequence mentionsOnlyContentText;
     private boolean favourited;
     private boolean reblogged;
     private ImageView[] mediaPreviews;
@@ -132,24 +130,9 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                             StatusActionListener listener) {
         Spanned emojifiedText = CustomEmojiHelper.emojifyText(content, emojis, this.content);
         LinkHelper.setClickableText(this.content, emojifiedText, mentions, listener);
-        this.contentText = (Spannable) this.content.getText();
+        this.contentText = this.content.getText();
 
-        SpannableStringBuilder builder = new SpannableStringBuilder();
-        for(Status.Mention mention : mentions) {
-            builder.append("@");
-            builder.append(mention.getUsername());
-            builder.append(" ");
-        }
-        // SpannableStringBuilder builder = new SpannableStringBuilder(emojifiedText);
-        // for(URLSpan span: content.getSpans(0, content.length(), URLSpan.class)) {
-        //     int start = builder.getSpanStart(span);
-        //     int end = builder.getSpanEnd(span);
-        //     CharSequence text = builder.subSequence(start, end);
-        //     if(text.charAt(0) != '@') {
-        //         builder.removeSpan(span);
-        //     }
-        // }
-        this.mentionsOnlyContentText = LinkHelper.makeClickableText(builder, mentions, listener);
+        this.mentionsOnlyContentText = LinkHelper.makeMentionsText(mentions, listener);
     }
 
     void setAvatar(String url, @Nullable String rebloggedUrl) {
@@ -438,8 +421,11 @@ abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
     }
 
     private void setTextVisible(boolean visible) {
-        if(visible) {
+        if (visible) {
             content.setText(this.contentText);
+            this.content.setVisibility(View.VISIBLE);
+        } else if (this.mentionsOnlyContentText == null) {
+            this.content.setVisibility(View.GONE);
         } else {
             content.setText(this.mentionsOnlyContentText);
         }

--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.java
@@ -160,12 +160,6 @@ public class LinkHelper {
                 public void onClick(View widget) { listener.onViewAccount(accountId); }
             };
 
-            customSpan = new CustomURLSpan(mention.getUrl()) {
-                @Override
-                public void onClick(View widget) {
-                    listener.onViewUrl(getURL());
-                }
-            };
             end += 1 + accountUsername.length(); // length of @ + username
             flags = builder.getSpanFlags(customSpan);
             if (firstMention) {

--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.java
@@ -117,17 +117,10 @@ public class LinkHelper {
             /* Add zero-width space after links in end of line to fix its too large hitbox.
              * See also : https://github.com/tuskyapp/Tusky/issues/846
              *            https://github.com/tuskyapp/Tusky/pull/916 */
-            if (end >= builder.length()){
+            if (end >= builder.length() ||
+                    builder.subSequence(end, end + 1).toString().equals("\n")){
                 builder.insert(end, "\u200B");
-            } else {
-                if(builder.subSequence(end, end + 1).toString().equals("\n")){
-                    builder.insert(end, "\u200B");
-                }
             }
-            // if (end >= builder.length() ||
-            //         builder.subSequence(end, end + 1).toString().equals("\n")){
-            //     builder.insert(end, "\u200B");
-            // }
         }
 
         view.setText(builder);

--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.java
@@ -136,16 +136,18 @@ public class LinkHelper {
     }
 
     /**
-     * Make a text listing mentions and makes them clickable, associating them with
-     * callbacks to notify when they're clicked.
+     * Put mentions in a piece of text and makes them clickable, associating them with callbacks to
+     * notify when they're clicked.
      *
+     * @param view the returned text will be put in
      * @param mentions any '@' mentions which are known to be in the content
      * @param listener to notify about particular spans that are clicked
      */
-    public static @Nullable CharSequence makeMentionsText(
-            @Nullable Status.Mention[] mentions, final LinkListener listener) {
+    public static void setClickableMentions(
+            TextView view, @Nullable Status.Mention[] mentions, final LinkListener listener) {
         if (mentions == null || mentions.length == 0) {
-            return null;
+            view.setText(null);
+            return;
         }
         SpannableStringBuilder builder = new SpannableStringBuilder();
         int start = 0;
@@ -172,11 +174,11 @@ public class LinkHelper {
             builder.append("@");
             builder.append(accountUsername);
             builder.setSpan(customSpan, start, end, flags);
-            builder.append("\u200B");
+            builder.append("\u200B"); // same reasonning than in setClickableText
             end += 1; // shift position to take the previous character into account
             start = end;
         }
-        return builder;
+        view.setText(builder);
     }
 
     /**


### PR DESCRIPTION
Fix #292 

The core of the functionality is here but there is still some bugs:

- Toots aren’t hidden by default even if they should be
- On timelines (it works on notifications mentions and threaded view), toots with clickable elements don’t hide (but somehow make a hide animation)

So it definitely looks like what I do in `StatusBaseViewHolder` is overridden under some conditions.