### PR TITLE
sort emojis alphabetically

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/EmojiAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/EmojiAdapter.kt
@@ -27,7 +27,7 @@ class EmojiAdapter(emojiList: List<Emoji>, private val onEmojiSelectedListener: 
     private val emojiList : List<Emoji>
 
     init {
-        this.emojiList = emojiList.filter { emoji -> emoji.visibleInPicker == null || emoji.visibleInPicker }
+        this.emojiList = emojiList.sortedWith(compareBy<Emoji> { it.shortcode }).filter { emoji -> emoji.visibleInPicker == null || emoji.visibleInPicker }
     }
 
     override fun getItemCount(): Int {


### PR DESCRIPTION
Hello!
One thing that has always annoyed me about Tusky is that when using emojis I have to search for the correct one.

Many instances have over 100 emojis enabled, and Tusky's emoji picker does not handle this well.
Most instances have sets of emojis that act as font replacements and it is annoying to have to run around and find each letter.

Here is a one line fix that solves this problem by sorting emojis in the emoji picker by shortcode.

Thanks!