### PR TITLE
Fix a lot of easy-to-fix warnings

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
@@ -314,7 +314,9 @@ public final class ComposeActivity
                     if(emojiList == null) {
                         emojiList = Collections.emptyList();
                     }
-                    Collections.sort(emojiList, (a, b) -> a.getShortcode().toLowerCase().compareTo(b.getShortcode().toLowerCase()));
+                    Collections.sort(emojiList, (a, b) ->
+                        a.getShortcode().toLowerCase(Locale.ROOT).compareTo(
+                            b.getShortcode().toLowerCase(Locale.ROOT)));
                     setEmojiList(emojiList);
                     cacheInstanceMetadata(activeAccount);
                 }

--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -250,7 +250,7 @@
             android:layout_marginEnd="4dp"
             android:contentDescription="@string/action_content_warning"
             android:padding="4dp"
-            android:text="CW"
+            android:text="@string/text_content_warning_button"
             android:textColor="?android:textColorTertiary"
             android:tooltipText="@string/action_content_warning" />
 

--- a/app/src/main/res/layout/item_emoji_pref.xml
+++ b/app/src/main/res/layout/item_emoji_pref.xml
@@ -36,7 +36,7 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:text="@string/system_default" />
 
-    <!--A short caption...-->
+    <!--A short caption…-->
     <TextView
         android:id="@+id/emojicompat_caption"
         android:layout_width="0dp"

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -94,9 +94,9 @@
     <string name="download_image">S\'està baixant %1$s</string>
 
     <string name="action_copy_link">Copia l\'enllaç</string>
-  
-    <string name="send_status_link_to">Comparteix l\'URL del toot a...</string>
-    <string name="send_status_content_to">Comparteix el toot a...</string>
+
+    <string name="send_status_link_to">Comparteix l\'URL del toot a…</string>
+    <string name="send_status_content_to">Comparteix el toot a…</string>
 
     <string name="confirmation_reported">Enviat!</string>
     <string name="confirmation_unblocked">Usuari desblocat</string>
@@ -107,7 +107,7 @@
     <string name="hint_content_warning">Avís de contingut</string>
     <string name="hint_display_name">Nom visible</string>
     <string name="hint_note">Biografia</string>
-    <string name="hint_search">Cerca...</string>
+    <string name="hint_search">Cerca…</string>
 
     <string name="search_no_results">No hi ha cap resulat</string>
 
@@ -116,7 +116,7 @@
 
     <string name="link_whats_an_instance">Què és una instància?</string>
 
-    <string name="login_connection">S\'està connectant...</string>
+    <string name="login_connection">S\'està connectant…</string>
 
     <string name="dialog_whats_an_instance">Aquí pots introduir l\'adreça o domini de qualsevol instància,
         com ara mastodont.cat, mastodon.social, icosahedron.website o
@@ -127,7 +127,7 @@
         \n\nTens més informació a <a href="https://joinmastodon.org">joinmastodon.org</a>.
     </string>
     <string name="dialog_title_finishing_media_upload">S\'està finalitzant la pujada de materila multimèdia</string>
-    <string name="dialog_message_uploading_media">S\'està pujant...</string>
+    <string name="dialog_message_uploading_media">S\'està pujant…</string>
     <string name="dialog_download_image">Baixa</string>
     <string name="dialog_unfollow_warning">Vols deixar de seguir aquest compte?</string>
 
@@ -174,7 +174,7 @@
         <!--<item>Mitjana</item>-->
         <!--<item>Gran</item>-->
     <!--</string-array>-->
-    
+
     <string name="notification_channel_mention_name">Mencions noves</string>
     <string name="notification_channel_mention_descriptions">Notificacions sobre mencions noves</string>
     <string name="notification_channel_follow_name">Seguidors nous</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -311,7 +311,7 @@
     <string name="emoji_style">Arddull emoji</string>
     <string name="system_default">Rhagosodiad system</string>
     <string name="download_fonts">Bydd angen i chi lawrlwytho\'r setiau emoji hyn yn gyntaf </string>
-    <string name="performing_lookup_title">Wrthi\'n chwilio...</string>
+    <string name="performing_lookup_title">Wrthi\'n chwilio…</string>
     <string name="expand_collapse_all_statuses">Chwyddo/lleihau pob statws </string>
     <string name="action_open_toot">Agor tŵt</string>
     <string name="restart_required">Angen ailddechrau\'r app</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -128,7 +128,7 @@
 
     <string name="search_no_results">Sin resultados</string>
 
-    <string name="label_quick_reply">Respuesta...</string>
+    <string name="label_quick_reply">Respuesta…</string>
     <string name="label_avatar">Avatar</string>
     <string name="label_header">Cabecera</string>
 
@@ -296,7 +296,7 @@
     <string name="lock_account_label">Proteger cuenta</string>
     <string name="lock_account_label_description">Tendrá que admitir los seguidores manualmente</string>
     <string name="compose_save_draft">¿Guardar borrador?</string>
-    <string name="send_toot_notification_title">Eliminando estado...</string>
+    <string name="send_toot_notification_title">Eliminando estado…</string>
     <string name="send_toot_notification_error_title">Error enviando estado</string>
     <string name="send_toot_notification_channel_name">Enviando estado</string>
     <string name="send_toot_notification_cancel_title">Envío cancelado</string>
@@ -308,7 +308,7 @@
     <string name="emoji_style">Estilo de los emojis</string>
     <string name="system_default">Sistema</string>
     <string name="download_fonts">Tendrás que descargarlos primero</string>
-    <string name="performing_lookup_title">Buscando...</string>
+    <string name="performing_lookup_title">Buscando…</string>
     <string name="expand_collapse_all_statuses">Expandir/ocultar todos los estados</string>
     <string name="action_open_toot">Abrir</string>
     <string name="restart_required">Reinicio requerido</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -133,7 +133,7 @@
 
     <string name="search_no_results">Emaitzarik ez</string>
 
-    <string name="label_quick_reply">Erantzuna...</string>
+    <string name="label_quick_reply">Erantzuna…</string>
     <string name="label_avatar">Irudia</string>
     <string name="label_header">Goiburua</string>
 
@@ -307,7 +307,7 @@
     <string name="lock_account_label">Kontua babestu</string>
     <string name="lock_account_label_description">Jarraitzaileak eskuz onartu beharko dituzu</string>
     <string name="compose_save_draft">Zirriborroa gorde?</string>
-    <string name="send_toot_notification_title">Tuta ezabatzen...</string>
+    <string name="send_toot_notification_title">Tuta ezabatzen…</string>
     <string name="send_toot_notification_error_title">Errorea tuta bidaltzerakoan</string>
     <string name="send_toot_notification_channel_name">Tuta bidaltzen</string>
     <string name="send_toot_notification_cancel_title">Bidalketa ezeztatua</string>
@@ -319,7 +319,7 @@
     <string name="emoji_style">Emojien estiloa</string>
     <string name="system_default">Sistema</string>
     <string name="download_fonts">Lehenago jaitsi beharko dituzu</string>
-    <string name="performing_lookup_title">Bilatzen...</string>
+    <string name="performing_lookup_title">Bilatzen…</string>
     <string name="expand_collapse_all_statuses">Tut guztiak ezkutatu/zabaldu</string>
     <string name="action_open_toot">Ireki</string>
     <string name="restart_required">Berrabiaraztea beharrezkoa da</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -132,13 +132,13 @@
 
     <string name="search_no_results" >نتیجه ای نیست</string>
 
-    <string name="label_quick_reply" >پاسخ ...</string>
+    <string name="label_quick_reply" >پاسخ …</string>
     <string name="label_avatar" >آواتار</string>
     <string name="label_header" >سرتیتر</string>
 
     <string name="link_whats_an_instance" >یک سرور نمونه چیست؟</string>
 
-    <string name="login_connection" >در حال اتصال ...</string>
+    <string name="login_connection" >در حال اتصال …</string>
 
     <string name="dialog_whats_an_instance" >آدرس یا دامنه هر سروری را میتوانید وارد کنید مثلا mastodon.social, icosahedron.website, social.tchncs.de, و         &lt;a href="https://instances.social" &gt;بیشتر!\n\n اگر شما هنوز حساب کاربری ندارید، می توانید نام نمونه مورد نظر را وارد کنید از اینجا بپیوندید و حساب کاربری ایجاد کنید\n\n نمونه جایی است که حساب کاربری شما میزبان آن است اما شما به راحتی میتوانید با افراد دیگر در نمونه های دیگر ارتباط برقرار کنید و آنها را دنبال کنید شما درست مثل اینکه در  یکجا باشید.\n\n برای اطلاعات بیشتر به اینجا مراجعه کنید <a href="https://joinmastodon.org">joinmastodon.org</a>.</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -206,6 +206,8 @@
         <item>Public</item>
         <item>Non listé</item>
         <item>Abonné·e·s uniquement</item>
+        <item>Direct</item>
+        <item>Inconnu</item>
     </string-array>
 
     <string name="pref_status_text_size">Taille du texte pour les statuts</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <string name="error_generic">Si è verificato un errore.</string>
     <string name="error_empty">Questo non può esser vuoto.</string>
@@ -145,8 +145,8 @@
 	qui, come mastodon.social, icosahedron.website, social.tchncs.de, e
 	<a href="https://instances.social">altro!</a>
 	\n\nSe non hai ancora un account, puoi inserire il nome di un\'istanza alla quale vuoi iscriverti
-	e creare un account.\n\nUn\'istanza è il luogo dove l\'account è custodito, 
-	ma puoi facilmente comunicare e seguire gente su altre istanze 
+	e creare un account.\n\nUn\'istanza è il luogo dove l\'account è custodito,
+	ma puoi facilmente comunicare e seguire gente su altre istanze
 	come se fossero sullo stesso sito.
 	\n\nPiù info possono essere trovate su <a href="https://joinmastodon.org">joinmastodon.org</a>.
 	</string>
@@ -312,7 +312,7 @@
     <string name="emoji_style">Stile di emoji</string>
     <string name="system_default">Predefiniti del sistema</string>
     <string name="download_fonts">Dovrai prima scaricare questo pacchetto di emoji</string>
-    <string name="performing_lookup_title">Eseguendo una ricerca...</string>
+    <string name="performing_lookup_title">Eseguendo una ricerca…</string>
     <string name="expand_collapse_all_statuses">Espandi/Riduci tutti gli stati</string>
     <string name="action_open_toot">Apri toot</string>
     <string name="restart_required">Riavvio dell\'app richiesto</string>
@@ -320,7 +320,7 @@
     <string name="later">Più tardi</string>
     <string name="restart">Riavvia</string>
     <string name="caption_systememoji">Le emoji predefinite del tuo dispositivo</string>
-    <string name="caption_blobmoji">Le emoji Blob conosciute da Android 4.4-7.1</string>
+    <string name="caption_blobmoji" tools:ignore="TypographyDashes">Le emoji Blob conosciute da Android 4.4-7.1</string>
     <string name="caption_twemoji">Le emoji standard di Mastodon</string>
 
     <string name="download_failed">Scaricamento fallito</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <string name="error_generic">エラーが発生しました。</string>
     <string name="error_empty">本文なしでは投稿できません。</string>
@@ -319,7 +319,7 @@
     <string name="emoji_style">絵文字スタイル</string>
     <string name="system_default">システムのデフォルト</string>
     <string name="download_fonts">最初にこれらの絵文字セットをダウンロードする必要があります</string>
-    <string name="performing_lookup_title">検索中...</string>
+    <string name="performing_lookup_title">検索中…</string>
     <string name="expand_collapse_all_statuses">全て開く/閉じる</string>
     <string name="action_open_toot">トゥートを開く</string>
     <string name="restart_required">アプリの再起動が必要です</string>
@@ -327,7 +327,7 @@
     <string name="later">後で</string>
     <string name="restart">再起動</string>
     <string name="caption_systememoji">あなたのデバイスのデフォルト絵文字セットです</string>
-    <string name="caption_blobmoji">Android 4.4-7.1で知られる、Blob絵文字です</string>
+    <string name="caption_blobmoji" tools:ignore="TypographyDashes">Android 4.4-7.1で知られる、Blob絵文字です</string>
     <string name="caption_twemoji">Mastodonの標準絵文字セットです</string>
 
     <string name="download_failed">ダウンロード失敗</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -305,7 +305,7 @@
     <string name="emoji_style">Estil dels Emoji</string>
     <string name="system_default">Çò del sistèma</string>
     <string name="download_fonts">D’en primièr vos cal telecargar los emojis seguents</string>
-    <string name="performing_lookup_title">Recèrca...</string>
+    <string name="performing_lookup_title">Recèrca…</string>
     <string name="expand_collapse_all_statuses">Desplegar/Plegar totes los estatuts</string>
     <string name="action_open_toot">Dobrir lo tut</string>
     <string name="restart_required">Reaviada necessària</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -128,7 +128,7 @@
 
     <string name="search_no_results">Sem resultados</string>
 
-    <string name="label_quick_reply">Responder...</string>
+    <string name="label_quick_reply">Responder…</string>
     <string name="label_avatar">Avatar</string>
     <string name="label_header">Cabeçalho</string>
 
@@ -289,7 +289,7 @@
     <string name="lock_account_label">Trancar conta</string>
     <string name="lock_account_label_description">Requer aprovação manual de seguidores</string>
     <string name="compose_save_draft">Salvar rascunho?</string>
-    <string name="send_toot_notification_title">Enviando toot...</string>
+    <string name="send_toot_notification_title">Enviando toot…</string>
     <string name="send_toot_notification_error_title">Erro ao enviar toot</string>
     <string name="send_toot_notification_channel_name">Enviando toots</string>
     <string name="send_toot_notification_cancel_title">Envio cancelado</string>
@@ -301,7 +301,7 @@
     <string name="emoji_style">Estilo de emoji</string>
     <string name="system_default">Padrão do sistema</string>
     <string name="download_fonts">É necessário baixar esses conjuntos antes de usá-los</string>
-    <string name="performing_lookup_title">Realizando consulta...</string>
+    <string name="performing_lookup_title">Realizando consulta…</string>
     <string name="expand_collapse_all_statuses">Expandir/Esconder todas as postagens</string>
     <string name="action_open_toot">Abrir toot</string>
     <string name="restart_required">Reinicialização mandatória</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <string name="error_generic">Произошла ошибка.</string>
     <string name="error_empty">Не может быть пустым.</string>
@@ -123,7 +123,7 @@
 
     <string name="status_sent">Отправлено!</string>
     <string name="status_sent_long">Ответ успешно отправлен.</string>
-    
+
     <string name="hint_domain">Какой узел?</string>
     <string name="hint_compose">Что происходит?</string>
     <string name="hint_content_warning">Предупреждение о содержании</string>
@@ -166,7 +166,7 @@
     <string name="pref_title_notification_alert_sound">Звуковые уведомления</string>
     <string name="pref_title_notification_alert_vibrate">Использовать вибрацию</string>
     <string name="pref_title_notification_alert_light">Световые уведомления</string>
-    <string name="pref_title_notification_filters">Уведомлять когда...</string>
+    <string name="pref_title_notification_filters">Уведомлять когда…</string>
     <string name="pref_title_notification_filter_mentions">упомянули</string>
     <string name="pref_title_notification_filter_follows">подписались</string>
     <string name="pref_title_notification_filter_reblogs">мой пост продвинули</string>
@@ -308,7 +308,7 @@
     <string name="emoji_style">Стиль эмодзи</string>
     <string name="system_default">Системный</string>
     <string name="download_fonts">Для начала эти наборы эмодзи нужно скачать</string>
-    <string name="performing_lookup_title">Производится поиск...</string>
+    <string name="performing_lookup_title">Производится поиск…</string>
     <string name="expand_collapse_all_statuses">Раскрыть/свернуть все статусы</string>
     <string name="action_open_toot">Перейти к посту</string>
     <string name="restart_required">Необходимо перезапустить приложение</string>
@@ -316,7 +316,7 @@
     <string name="later">Не сейчас</string>
     <string name="restart">Перезапустить</string>
     <string name="caption_systememoji">Набор эмодзи по умолчанию</string>
-    <string name="caption_blobmoji">Набор эмодзи Blob из Android 4.4-7.1</string>
+    <string name="caption_blobmoji" tools:ignore="TypographyDashes">Набор эмодзи Blob из Android 4.4-7.1</string>
     <string name="caption_twemoji">Стандартный набор эмодзи в Mastodon</string>
 
     <string name="download_failed">Загрузка не удалась</string>
@@ -331,7 +331,7 @@
     <string name="license_apache_2">Используется лицензия Apache License (копия ниже)</string>
     <string name="license_cc_by_4">CC-BY 4.0</string>
     <string name="license_cc_by_sa_4">CC-BY-SA 4.0</string>
-    
+
     <string name="profile_metadata_label">Метаданные профиля</string>
     <string name="profile_metadata_add">добавить данные</string>
     <string name="profile_metadata_label_label">Заголовок</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -114,9 +114,9 @@
 
     <string name="action_copy_link">Kopiera länken</string>
 
-    <string name="send_status_link_to">Dela toot-URL till...</string>
-    <string name="send_status_content_to">Dela toot till...</string>
-    <string name="send_media_to">Dela media till...</string>
+    <string name="send_status_link_to">Dela toot-URL till…</string>
+    <string name="send_status_content_to">Dela toot till…</string>
+    <string name="send_media_to">Dela media till…</string>
 
     <string name="confirmation_reported">Skickat!</string>
     <string name="confirmation_unblocked">Användare avblockerad</string>
@@ -140,7 +140,7 @@
 
     <string name="link_whats_an_instance">Vad är en instans?</string>
 
-    <string name="login_connection">Ansluter...</string>
+    <string name="login_connection">Ansluter…</string>
 
     <string name="dialog_whats_an_instance">Adressen eller domänen för varje instans kan anges 
 		här, till exempel mastodon.social, icosahedron.website, social.tchncs.de och 
@@ -152,7 +152,7 @@
     
 	</string>
     <string name="dialog_title_finishing_media_upload">Uppladdning av media</string>
-    <string name="dialog_message_uploading_media">Laddar upp...</string>
+    <string name="dialog_message_uploading_media">Laddar upp…</string>
     <string name="dialog_download_image">Ladda ned</string>
     <string name="dialog_message_cancel_follow_request">Återkalla följningsförfrågan?</string>
     <string name="dialog_unfollow_warning">Avfölja detta konto?</string>
@@ -312,7 +312,7 @@
     <string name="lock_account_label">Lås konto</string>
     <string name="lock_account_label_description">Kräver att du manuellt godkänner följare</string>
     <string name="compose_save_draft">Spara utkast?</string>
-    <string name="send_toot_notification_title">Skickar toot...</string>
+    <string name="send_toot_notification_title">Skickar toot…</string>
     <string name="send_toot_notification_error_title">Fel vid sändning av toot</string>
     <string name="send_toot_notification_channel_name">Skickar toot</string>
     <string name="send_toot_notification_cancel_title">Sändning avbruten</string>
@@ -324,7 +324,7 @@
     <string name="emoji_style">Emojis</string>
     <string name="system_default">Systemstandard</string>
     <string name="download_fonts">Du behöver ladda ned dessa emojis först</string>
-    <string name="performing_lookup_title">Utför sökning...</string>
+    <string name="performing_lookup_title">Utför sökning…</string>
     <string name="expand_collapse_all_statuses">Expandera/Dölj alla status</string>
     <string name="action_open_toot">Öppna toot</string>
     <string name="restart_required">Omstart av appen krävs</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -126,7 +126,7 @@
     <string name="hint_content_warning">உள்ளடக்க எச்சரிக்கை</string>
     <string name="hint_display_name">காட்சி பெயர்</string>
     <string name="hint_note">சுயவிவரம்</string>
-    <string name="hint_search">தேடல்...</string>
+    <string name="hint_search">தேடல்…</string>
 
     <string name="search_no_results">முடிவுகள் ஏதுமில்லை</string>
     <string name="label_quick_reply">பதிலளி…</string>
@@ -135,7 +135,7 @@
 
     <string name="link_whats_an_instance">Instance(களம்) என்றால் என்ன?</string>
 
-    <string name="login_connection">இணைக்கபடுகிறது...</string>
+    <string name="login_connection">இணைக்கபடுகிறது…</string>
 
     <string name="dialog_whats_an_instance">ஏதேனும் instance-ன் முகவரியையோ அல்லது களத்தின் முகவரியையோ இங்கு உள்ளிடவும், உதாரணமாக mastodon.social, icosahedron.website, social.tchncs.de, மற்றும்
         <a href="https://instances.social">மேலும்!</a>
@@ -143,7 +143,7 @@
         \n\nமேலும் தகவல்கள் அறிய <a href="https://joinmastodon.org">joinmastodon.org</a>.
     </string>
     <string name="dialog_title_finishing_media_upload">மீடியா பதிவேற்றம் முடிகிறது</string>
-    <string name="dialog_message_uploading_media">ஏற்றுகிறது ...</string>
+    <string name="dialog_message_uploading_media">ஏற்றுகிறது …</string>
     <string name="dialog_download_image">பதிவிறக்க</string>
     <string name="dialog_unfollow_warning">இந்த கணக்கை பின்பற்ற வேண்டாமா?</string>
 
@@ -295,7 +295,7 @@
     <string name="emoji_style">Emoji பாணி</string>
     <string name="system_default">அமைப்பின் இயல்புநிலை</string>
     <string name="download_fonts">தாங்கள் முதலில் இந்த Emoji sets-னை பதிவிறக்கவேண்டும்</string>
-    <string name="performing_lookup_title">சேயல்பாட்டு தேடல்...</string>
+    <string name="performing_lookup_title">சேயல்பாட்டு தேடல்…</string>
     <string name="expand_collapse_all_statuses">அதிகமாக்கு/கம்மியாக்கு பற்றிய நிலைகள்</string>
     <string name="action_open_toot">Tootயை திற</string>
     <string name="restart_required">செயலி மறுதொடக்கம் தேவைபடுகிறது</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -6,6 +6,7 @@
     <string name="oauth_scheme" translatable="false">oauth2redirect</string>
     <string name="preferences_file_key" translatable="false">com.keylesspalace.tusky.PREFERENCES</string>
 
+    <string name="text_content_warning_button">CW</string>
     <string name="status_sensitive_media_template" translatable="false">&lt;b>%1$s&lt;/b>&lt;br>%2$s</string>
 
     <string-array name="post_privacy_values">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,7 +326,7 @@
     <string name="emoji_style">Emoji style</string>
     <string name="system_default">System default</string>
     <string name="download_fonts">You\'ll need to download these emoji sets first</string>
-    <string name="performing_lookup_title">Performing lookup...</string>
+    <string name="performing_lookup_title">Performing lookup…</string>
     <string name="expand_collapse_all_statuses">Expand/Collapse all statuses</string>
     <string name="action_open_toot">Open toot</string>
     <string name="restart_required">App restart required</string>


### PR DESCRIPTION
Reduce warnings produced by `./gradlew lint` from 108 to 53 (half less!).

I added annotation to ignore some warnings on big SVG since I don’t see a way to optimize them without reducing their quality.

Finally, I edited very slightly the French translation to add strings required by a change introduced in #901.