### PR TITLE
fix mentions and more menu after a fresh login

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
@@ -19,7 +19,6 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityOptionsCompat;
@@ -58,8 +57,6 @@ import javax.inject.Inject;
  * overlap functionality. So, I'm momentarily leaving it and hopefully working on those will clear
  * up what needs to be where. */
 public abstract class SFragment extends BaseFragment {
-    protected String loggedInAccountId;
-    protected String loggedInUsername;
 
     protected abstract TimelineCases timelineCases();
 
@@ -73,16 +70,6 @@ public abstract class SFragment extends BaseFragment {
     public MastodonApi mastodonApi;
     @Inject
     public AccountManager accountManager;
-
-    @Override
-    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-        AccountEntity activeAccount = accountManager.getActiveAccount();
-        if (activeAccount != null) {
-            loggedInAccountId = activeAccount.getAccountId();
-            loggedInUsername = activeAccount.getUsername();
-        }
-    }
 
     @Override
     public void startActivity(Intent intent) {
@@ -125,6 +112,11 @@ public abstract class SFragment extends BaseFragment {
         Status.Mention[] mentions = actionableStatus.getMentions();
         Set<String> mentionedUsernames = new LinkedHashSet<>();
         mentionedUsernames.add(actionableStatus.getAccount().getUsername());
+        String loggedInUsername = null;
+        AccountEntity activeAccount = accountManager.getActiveAccount();
+        if(activeAccount != null) {
+            loggedInUsername = activeAccount.getUsername();
+        }
         for (Status.Mention mention : mentions) {
             mentionedUsernames.add(mention.getUsername());
         }
@@ -146,6 +138,12 @@ public abstract class SFragment extends BaseFragment {
         final String accountUsername = status.getActionableStatus().getAccount().getUsername();
         final Spanned content = status.getActionableStatus().getContent();
         final String statusUrl = status.getActionableStatus().getUrl();
+        String loggedInAccountId = null;
+        AccountEntity activeAccount = accountManager.getActiveAccount();
+        if(activeAccount != null) {
+            loggedInAccountId = activeAccount.getAccountId();
+        }
+
         PopupMenu popup = new PopupMenu(getContext(), view);
         // Give a different menu depending on whether this is the user's own toot or not.
         if (loggedInAccountId == null || !loggedInAccountId.equals(accountId)) {


### PR DESCRIPTION
When a user logs in, the `AccountEntity` object does not have a username or id when creating fragments because the network request has not returned yet -> the wrong more menu will be shown & replies will contain the own username. Fixed by deferring the loading of the username and id in `SFragment`.

Annoys me as hell, but real users probably don't log in as often as i do :)