### PR TITLE
Implement "Open status as (another account)" #958

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
@@ -94,6 +94,7 @@ public final class MainActivity extends BottomSheetActivity implements ActionBut
     private static final long DRAWER_ITEM_ABOUT = 7;
     private static final long DRAWER_ITEM_LOG_OUT = 8;
     private static final long DRAWER_ITEM_FOLLOW_REQUESTS = 9;
+    public static final String STATUS_URL = "statusUrl";
 
     @Inject
     public DispatchingAndroidInjector<Fragment> fragmentInjector;
@@ -271,6 +272,18 @@ public final class MainActivity extends BottomSheetActivity implements ActionBut
             }
         }
         return super.onKeyDown(keyCode, event);
+    }
+
+    @Override
+    public void onPostCreate(Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
+        Intent intent = getIntent();
+        if (intent != null) {
+            String statusUrl = intent.getStringExtra(STATUS_URL);
+            if (statusUrl != null) {
+                viewUrl(statusUrl);
+            }
+        }
     }
 
     private void tintTab(TabLayout.Tab tab, boolean tinted) {

--- a/app/src/main/res/menu/status_more.xml
+++ b/app/src/main/res/menu/status_more.xml
@@ -16,6 +16,9 @@
         android:id="@+id/status_copy_link"
         android:title="@string/action_copy_link" />
     <item
+        android:id="@+id/status_open_as"
+        android:title="@string/action_open_as" />
+    <item
         android:id="@+id/status_mute"
         android:title="@string/action_mute" />
     <item

--- a/app/src/main/res/menu/status_more_for_user.xml
+++ b/app/src/main/res/menu/status_more_for_user.xml
@@ -16,6 +16,9 @@
         android:id="@+id/status_copy_link"
         android:title="@string/action_copy_link" />
     <item
+        android:id="@+id/status_open_as"
+        android:title="@string/action_open_as" />
+    <item
         android:id="@+id/status_reblog_private"
         android:title="@string/reblog_private"
         android:visible="false" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,7 @@
     <string name="download_image">Downloading %1$s</string>
 
     <string name="action_copy_link">Copy the link</string>
+    <string name="action_open_as">Open as %s</string>
 
     <string name="send_status_link_to">Share toot URL to…</string>
     <string name="send_status_content_to">Share toot to…</string>


### PR DESCRIPTION
Adds a context action to open statuses as a different account.
if the user only has one account registered, the action is hidden.
If the user has exactly two accounts, the action is presented as "Open as @You@YourOtherInstance".
If the user has more than two accounts, the action is presented as "Open as …", and the user gets a list popup.