### PR TITLE
Never use 0 account ids to prevent caching problems

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/db/AccountManager.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/AccountManager.kt
@@ -58,7 +58,9 @@ class AccountManager(db: AppDatabase) {
             accountDao.insertOrReplace(it)
         }
 
-        activeAccount = AccountEntity(id = 0, domain = domain.toLowerCase(), accessToken = accessToken, isActive = true)
+        val maxAccountId = accounts.maxBy { it.id }?.id ?: 0
+        val newAccountId = maxAccountId + 1
+        activeAccount = AccountEntity(id = newAccountId, domain = domain.toLowerCase(), accessToken = accessToken, isActive = true)
 
     }
 


### PR DESCRIPTION
closes #990 

Note that the `(autoGenerate = true)` could now be removed from `AccountEntity.id`, but I am leaving it so we don't have to do another database migration.