### PR TITLE
Register ComposeActivity as a Shortcut

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -78,6 +78,13 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="video/*" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
         <activity
             android:name=".ViewThreadActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,9 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
         <activity
             android:name=".SavedTootActivity"
@@ -78,13 +81,6 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="video/*" />
             </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-            <meta-data
-                android:name="android.app.shortcuts"
-                android:resource="@xml/shortcuts" />
         </activity>
         <activity
             android:name=".ViewThreadActivity"

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -2,7 +2,7 @@
     <shortcut
         android:shortcutId="compose"
         android:enabled="true"
-        android:icon="@drawable/ic_create_24dp"
+        android:icon="@mipmap/ic_launcher"
         android:shortcutShortLabel="@string/action_compose_shortcut"
         android:shortcutLongLabel="@string/action_compose_shortcut"
         android:shortcutDisabledMessage="@string/action_compose_shortcut">

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -10,10 +10,6 @@
             android:action="android.intent.action.VIEW"
             android:targetPackage="com.keylesspalace.tusky"
             android:targetClass="com.keylesspalace.tusky.ComposeActivity" />
-        <!-- If your shortcut is associated with multiple intents, include them
-            here. The last intent in the list determines what the user sees when
-            they launch this shortcut. -->
         <categories android:name="android.shortcut.conversation" />
     </shortcut>
-    <!-- Specify more shortcuts here. -->
 </shortcuts>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,19 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="compose"
+        android:enabled="true"
+        android:icon="@drawable/ic_create"
+        android:shortcutShortLabel="@string/action_compose_shortcut"
+        android:shortcutLongLabel="@string/action_compose_shortcut"
+        android:shortcutDisabledMessage="@string/action_compose_shortcut">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.keylesspalace.tusky"
+            android:targetClass="com.keylesspalace.tusky.ComposeActivity" />
+        <!-- If your shortcut is associated with multiple intents, include them
+            here. The last intent in the list determines what the user sees when
+            they launch this shortcut. -->
+        <categories android:name="android.shortcut.conversation" />
+    </shortcut>
+    <!-- Specify more shortcuts here. -->
+</shortcuts>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -2,7 +2,7 @@
     <shortcut
         android:shortcutId="compose"
         android:enabled="true"
-        android:icon="@drawable/ic_create"
+        android:icon="@drawable/ic_create_24dp"
         android:shortcutShortLabel="@string/action_compose_shortcut"
         android:shortcutLongLabel="@string/action_compose_shortcut"
         android:shortcutDisabledMessage="@string/action_compose_shortcut">


### PR DESCRIPTION
Adds the metadata element and "shortcuts.xml" file necessary to register the "ComposeActivity" activity as a shortcut that will be shown when long-pressing the launcher icon.

**Warning:** I haven't tested this, because I don't want to set up a build environment.