### PR TITLE
Fix large image attachments not showing

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -284,6 +284,9 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
         final int n = Math.min(attachments.size(), Status.MAX_MEDIA_ATTACHMENTS);
 
+        final int maxW = context.getResources().getInteger(R.integer.media_max_width);
+        final int maxH = context.getResources().getInteger(R.integer.media_max_height);
+
         for (int i = 0; i < n; i++) {
             String previewUrl = attachments.get(i).getPreviewUrl();
             String description = attachments.get(i).getDescription();
@@ -299,6 +302,9 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             if (TextUtils.isEmpty(previewUrl)) {
                 Picasso.with(context)
                         .load(mediaPreviewUnloadedId)
+                        .resize(maxW, maxH)
+                        .onlyScaleDown()
+                        .centerInside()
                         .into(mediaPreviews[i]);
             } else {
                 MetaData meta = attachments.get(i).getMeta();
@@ -310,6 +316,9 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                     Picasso.with(context)
                             .load(previewUrl)
                             .placeholder(mediaPreviewUnloadedId)
+                            .resize(maxW, maxH)
+                            .onlyScaleDown()
+                            .centerInside()
                             // Also pass the mediaPreview as a callback to ensure it is called
                             // initially when the image gets loaded:
                             .into(mediaPreviews[i], mediaPreviews[i]);
@@ -319,6 +328,9 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                     Picasso.with(context)
                             .load(previewUrl)
                             .placeholder(mediaPreviewUnloadedId)
+                            .resize(maxW, maxH)
+                            .onlyScaleDown()
+                            .centerInside()
                             .into(mediaPreviews[i]);
                 }
             }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/AccountMediaFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/AccountMediaFragment.kt
@@ -302,8 +302,8 @@ class AccountMediaFragment : BaseFragment(), Injectable {
             holder.imageView.setBackgroundColor(Color.HSVToColor(itemBgBaseHSV))
             val item = items[position]
 
-            val maxW = context!!.resources.getInteger(R.integer.media_max_width)
-            val maxH = context!!.resources.getInteger(R.integer.media_max_height)
+            val maxW = holder.imageView.context.resources.getInteger(R.integer.media_max_width)
+            val maxH = holder.imageView.context.resources.getInteger(R.integer.media_max_height)
 
             Picasso.with(holder.imageView.context)
                     .load(item.attachment.previewUrl)

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/AccountMediaFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/AccountMediaFragment.kt
@@ -301,8 +301,15 @@ class AccountMediaFragment : BaseFragment(), Injectable {
             itemBgBaseHSV[2] = random.nextFloat() * (1f - 0.3f) + 0.3f
             holder.imageView.setBackgroundColor(Color.HSVToColor(itemBgBaseHSV))
             val item = items[position]
+
+            val maxW = context!!.resources.getInteger(R.integer.media_max_width)
+            val maxH = context!!.resources.getInteger(R.integer.media_max_height)
+
             Picasso.with(holder.imageView.context)
                     .load(item.attachment.previewUrl)
+                    .resize(maxW, maxH)
+                    .onlyScaleDown()
+                    .centerInside()
                     .into(holder.imageView)
         }
 

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewImageFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewImageFragment.kt
@@ -74,6 +74,9 @@ class ViewImageFragment : ViewMediaFragment() {
             result
         }
 
+        val maxW = context!!.resources.getInteger(R.integer.media_max_width)
+        val maxH = context!!.resources.getInteger(R.integer.media_max_height)
+
         // If we are the view to be shown initially...
         if (arguments!!.getBoolean(ViewMediaFragment.ARG_START_POSTPONED_TRANSITION)) {
             // Try to load image from disk.
@@ -81,6 +84,9 @@ class ViewImageFragment : ViewMediaFragment() {
                     .load(url)
                     .noFade()
                     .networkPolicy(NetworkPolicy.OFFLINE)
+                    .resize(maxW, maxH)
+                    .onlyScaleDown()
+                    .centerInside()
                     .into(photoView, object : Callback {
                         override fun onSuccess() {
                             // if we loaded image from disk, we should check that view is attached.
@@ -169,10 +175,15 @@ class ViewImageFragment : ViewMediaFragment() {
     }
 
     private fun loadImageFromNetwork(url: String, photoView: ImageView) {
+        val maxW = context!!.resources.getInteger(R.integer.media_max_width)
+        val maxH = context!!.resources.getInteger(R.integer.media_max_height)
+
         Picasso.with(context)
                 .load(url)
                 .noPlaceholder()
                 .networkPolicy(NetworkPolicy.NO_STORE)
+                .resize(maxW, maxH)
+                .onlyScaleDown()
                 .into(photoView, object : Callback {
                     override fun onSuccess() {
                         finishLoadingSuccessfully()

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewImageFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewImageFragment.kt
@@ -74,8 +74,8 @@ class ViewImageFragment : ViewMediaFragment() {
             result
         }
 
-        val maxW = context!!.resources.getInteger(R.integer.media_max_width)
-        val maxH = context!!.resources.getInteger(R.integer.media_max_height)
+        val maxW = photoView.context.resources.getInteger(R.integer.media_max_width)
+        val maxH = photoView.context.resources.getInteger(R.integer.media_max_height)
 
         // If we are the view to be shown initially...
         if (arguments!!.getBoolean(ViewMediaFragment.ARG_START_POSTPONED_TRANSITION)) {
@@ -175,8 +175,8 @@ class ViewImageFragment : ViewMediaFragment() {
     }
 
     private fun loadImageFromNetwork(url: String, photoView: ImageView) {
-        val maxW = context!!.resources.getInteger(R.integer.media_max_width)
-        val maxH = context!!.resources.getInteger(R.integer.media_max_height)
+        val maxW = photoView.context.resources.getInteger(R.integer.media_max_width)
+        val maxH = photoView.context.resources.getInteger(R.integer.media_max_height)
 
         Picasso.with(context)
                 .load(url)

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <integer name="profile_media_column_count">3</integer>
+
+    <!-- Images larger than this will be downscaled to avoid OpenGL errors -->
+    <integer name="media_max_width">1920</integer>
+    <integer name="media_max_height">1920</integer>
 </resources>


### PR DESCRIPTION
this is a fix for the following error on oneplus one with lineageos, viewing large photos uploaded to Pleroma

```
W OpenGLRenderer: Bitmap too large to be uploaded into a texture (4160x3120, max=4096x4096)
W OpenGLRenderer: Shape too large to be rendered into a texture (4172x3132, max=4096x4096)
W OpenGLRenderer: Bitmap too large to be uploaded into a texture (4160x3120, max=4096x4096)
```

there are still some errors in the log, but the images show OK.
- `E/BufferItemConsumer: [unnamed-4641-1] Failed to release buffer: Unknown error -1 (1)`
- `W/Adreno-EGL: <qeglDrvAPI_eglGetConfigAttrib:607>: EGL_BAD_ATTRIBUTE`

this *might* break true animated gifs (i.e. not mastodon video gifs). I'm not at all sure if they worked before, but they certainly don't now.

the size is 1920 because 1920x1080 and also it seemed to work a little better than 2048. but that may be a coincidence. At any rate 4096 caused horrible lag in the timeline. 2048 was mostly OK too 