### PR TITLE
fix crash when opening a thread in the browser

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
@@ -98,7 +98,8 @@ public abstract class SFragment extends BaseFragment {
     }
 
     protected void viewThread(Status status) {
-        bottomSheetActivity.viewThread(status.getActionableId(), status.getUrl());
+        Status actionableStatus = status.getActionableStatus();
+        bottomSheetActivity.viewThread(actionableStatus.getActionableId(), actionableStatus.getUrl());
     }
 
     protected void viewAccount(String accountId) {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
@@ -99,7 +99,7 @@ public abstract class SFragment extends BaseFragment {
 
     protected void viewThread(Status status) {
         Status actionableStatus = status.getActionableStatus();
-        bottomSheetActivity.viewThread(actionableStatus.getActionableId(), actionableStatus.getUrl());
+        bottomSheetActivity.viewThread(actionableStatus.getId(), actionableStatus.getUrl());
     }
 
     protected void viewAccount(String accountId) {


### PR DESCRIPTION
Steps to reproduce: see a reblog in the timeline, open it. Click "open in browser" in the menu -> crash