### PR TITLE
remove unnecessary divider styling

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ReportActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ReportActivity.java
@@ -16,7 +16,6 @@
 package com.keylesspalace.tusky;
 
 import android.content.Intent;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
@@ -30,7 +29,6 @@ import com.keylesspalace.tusky.di.Injectable;
 import com.keylesspalace.tusky.entity.Status;
 import com.keylesspalace.tusky.network.MastodonApi;
 import com.keylesspalace.tusky.util.HtmlUtils;
-import com.keylesspalace.tusky.util.ThemeUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -93,9 +91,6 @@ public class ReportActivity extends BaseActivity implements Injectable {
 
         DividerItemDecoration divider = new DividerItemDecoration(
                 this, layoutManager.getOrientation());
-        Drawable drawable = ThemeUtils.getDrawable(this, R.attr.report_status_divider_drawable,
-                R.drawable.report_status_divider_dark);
-        divider.setDrawable(drawable);
         recyclerView.addItemDecoration(divider);
 
         ReportAdapter.ReportStatus reportStatus = new ReportAdapter.ReportStatus(statusId,

--- a/app/src/main/java/com/keylesspalace/tusky/SavedTootActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/SavedTootActivity.java
@@ -16,7 +16,6 @@
 package com.keylesspalace.tusky;
 
 import android.content.Intent;
-import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.view.MenuItem;
@@ -31,7 +30,6 @@ import com.keylesspalace.tusky.db.TootDao;
 import com.keylesspalace.tusky.db.TootEntity;
 import com.keylesspalace.tusky.di.Injectable;
 import com.keylesspalace.tusky.util.SaveTootHelper;
-import com.keylesspalace.tusky.util.ThemeUtils;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -99,9 +97,6 @@ public final class SavedTootActivity extends BaseActivity implements SavedTootAd
         recyclerView.setLayoutManager(layoutManager);
         DividerItemDecoration divider = new DividerItemDecoration(
                 this, layoutManager.getOrientation());
-        Drawable drawable = ThemeUtils.getDrawable(this, R.attr.status_divider_drawable,
-                R.drawable.status_divider_dark);
-        divider.setDrawable(drawable);
         recyclerView.addItemDecoration(divider);
         adapter = new SavedTootAdapter(this);
         recyclerView.setAdapter(adapter);

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
@@ -39,7 +39,6 @@ import com.keylesspalace.tusky.network.TimelineCases
 import com.keylesspalace.tusky.util.NetworkState
 import com.keylesspalace.tusky.util.ThemeUtils
 import com.keylesspalace.tusky.util.hide
-import com.keylesspalace.tusky.util.show
 import kotlinx.android.synthetic.main.fragment_timeline.*
 import javax.inject.Inject
 
@@ -73,10 +72,7 @@ class ConversationsFragment : SFragment(), StatusActionListener, Injectable {
 
         adapter = ConversationAdapter(useAbsoluteTime, mediaPreviewEnabled,this, ::onTopLoaded, viewModel::retry)
 
-        val divider = DividerItemDecoration(view.context, DividerItemDecoration.VERTICAL)
-        val drawable = ThemeUtils.getDrawable(view.context, R.attr.status_divider_drawable, R.drawable.status_divider_dark)
-        divider.setDrawable(drawable)
-        recyclerView.addItemDecoration(divider)
+        recyclerView.addItemDecoration(DividerItemDecoration(view.context, DividerItemDecoration.VERTICAL))
         recyclerView.layoutManager = LinearLayoutManager(view.context)
         recyclerView.adapter = adapter
         (recyclerView.itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/AccountListFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/AccountListFragment.kt
@@ -35,7 +35,6 @@ import com.keylesspalace.tusky.entity.Relationship
 import com.keylesspalace.tusky.interfaces.AccountActionListener
 import com.keylesspalace.tusky.network.MastodonApi
 import com.keylesspalace.tusky.util.HttpHeaderLink
-import com.keylesspalace.tusky.util.ThemeUtils
 import com.keylesspalace.tusky.util.hide
 import com.keylesspalace.tusky.util.show
 import com.keylesspalace.tusky.view.EndlessOnScrollListener
@@ -74,10 +73,8 @@ class AccountListFragment : BaseFragment(), AccountActionListener, Injectable {
         recyclerView.setHasFixedSize(true)
         val layoutManager = LinearLayoutManager(view.context)
         recyclerView.layoutManager = layoutManager
-        val divider = DividerItemDecoration(view.context, layoutManager.orientation)
-        val drawable = ThemeUtils.getDrawable(view.context, R.attr.status_divider_drawable, R.drawable.status_divider_dark)
-        divider.setDrawable(drawable)
-        recyclerView.addItemDecoration(divider)
+
+        recyclerView.addItemDecoration(DividerItemDecoration(view.context, DividerItemDecoration.VERTICAL))
 
         adapter = when (type) {
             Type.BLOCKS -> BlocksAdapter(this)

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -18,7 +18,6 @@ package com.keylesspalace.tusky.fragment;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.util.Log;
@@ -58,7 +57,6 @@ import com.keylesspalace.tusky.viewdata.NotificationViewData;
 import com.keylesspalace.tusky.viewdata.StatusViewData;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -188,12 +186,8 @@ public class NotificationsFragment extends SFragment implements
         recyclerView.setHasFixedSize(true);
         layoutManager = new LinearLayoutManager(context);
         recyclerView.setLayoutManager(layoutManager);
-        DividerItemDecoration divider = new DividerItemDecoration(
-                context, layoutManager.getOrientation());
-        Drawable drawable = ThemeUtils.getDrawable(context, R.attr.status_divider_drawable,
-                R.drawable.status_divider_dark);
-        divider.setDrawable(drawable);
-        recyclerView.addItemDecoration(divider);
+
+        recyclerView.addItemDecoration(new DividerItemDecoration(context, DividerItemDecoration.VERTICAL));
 
         adapter = new NotificationsAdapter(this, this);
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -17,7 +17,6 @@ package com.keylesspalace.tusky.fragment;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.util.Log;
@@ -61,7 +60,6 @@ import com.keylesspalace.tusky.view.EndlessOnScrollListener;
 import com.keylesspalace.tusky.viewdata.StatusViewData;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -355,9 +353,6 @@ public class TimelineFragment extends SFragment implements
         recyclerView.setLayoutManager(layoutManager);
         DividerItemDecoration divider = new DividerItemDecoration(
                 context, layoutManager.getOrientation());
-        Drawable drawable = ThemeUtils.getDrawable(context, R.attr.status_divider_drawable,
-                R.drawable.status_divider_dark);
-        divider.setDrawable(drawable);
         recyclerView.addItemDecoration(divider);
 
         // CWs are expanded without animation, buttons animate itself, we don't need it basically

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -149,9 +149,6 @@ public final class ViewThreadFragment extends SFragment implements
         recyclerView.setLayoutManager(layoutManager);
         DividerItemDecoration divider = new DividerItemDecoration(
                 context, layoutManager.getOrientation());
-        Drawable dividerDrawable = ThemeUtils.getDrawable(context, R.attr.status_divider_drawable,
-                R.drawable.status_divider_dark);
-        divider.setDrawable(dividerDrawable);
         recyclerView.addItemDecoration(divider);
 
         Drawable threadLineDrawable = ThemeUtils.getDrawable(context, R.attr.conversation_thread_line_drawable,

--- a/app/src/main/res/drawable/report_status_divider_dark.xml
+++ b/app/src/main/res/drawable/report_status_divider_dark.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <size android:height="1dp" />
-    <solid android:color="@color/report_status_divider_dark" />
-</shape>

--- a/app/src/main/res/drawable/report_status_divider_light.xml
+++ b/app/src/main/res/drawable/report_status_divider_light.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <size android:height="1dp" />
-    <solid android:color="@color/report_status_divider_light" />
-</shape>

--- a/app/src/main/res/layout/item_status_detailed.xml
+++ b/app/src/main/res/layout/item_status_detailed.xml
@@ -339,7 +339,7 @@
         android:layout_height="1dp"
         android:layout_below="@id/status_timestamp_info"
         android:layout_marginTop="6dp"
-        android:background="?attr/status_divider_drawable"
+        android:background="?android:attr/listDivider"
         android:paddingStart="16dp"
         android:paddingEnd="16dp"
         app:layout_constraintTop_toBottomOf="@id/status_timestamp_info" />
@@ -384,7 +384,7 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginTop="6dp"
-        android:background="?attr/status_divider_drawable"
+        android:background="?android:attr/listDivider"
         android:paddingStart="16dp"
         android:paddingEnd="16dp"
         app:layout_constraintTop_toBottomOf="@id/status_counters_barrier" />

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -39,7 +39,7 @@
         <item name="content_warning_button">@drawable/toggle_small</item>
         <item name="sensitive_media_warning_background_color">@color/color_background_dark</item>
         <item name="media_preview_unloaded_drawable">@drawable/media_preview_unloaded_dark</item>
-        <item name="status_divider_drawable">@drawable/status_divider_dark</item>
+        <item name="android:listDivider">@drawable/status_divider_dark</item>
         <item name="conversation_thread_line_drawable">@drawable/conversation_thread_line_dark</item>
         <item name="tab_icon_selected_tint">@color/tusky_blue</item>
         <item name="tab_page_margin_drawable">@drawable/tab_page_margin_dark</item>
@@ -53,7 +53,6 @@
         <item name="compose_reply_content_background">@color/compose_reply_content_background_dark</item>
 
         <item name="report_status_background_color">@color/color_background_dark</item>
-        <item name="report_status_divider_drawable">@drawable/status_divider_dark</item>
 
         <item name="material_drawer_background">@color/window_background_dark</item>
         <item name="material_drawer_primary_text">@color/text_color_primary_dark</item>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -24,7 +24,6 @@
     <attr name="content_warning_button" format="reference" />
     <attr name="sensitive_media_warning_background_color" format="reference|color" />
     <attr name="media_preview_unloaded_drawable" format="reference" />
-    <attr name="status_divider_drawable" format="reference" />
     <attr name="conversation_thread_line_drawable" format="reference" />
     <attr name="tab_icon_selected_tint" format="reference|color" />
     <attr name="tab_page_margin_drawable" format="reference" />
@@ -36,7 +35,6 @@
     <attr name="compose_content_warning_bar_background" format="reference" />
     <attr name="compose_reply_content_background" format="reference|color" />
     <attr name="report_status_background_color" format="reference|color" />
-    <attr name="report_status_divider_drawable" format="reference" />
     <attr name="card_background" format="reference|color" />
     <attr name="card_image_background" format="reference|color" />
     <attr name="compound_button_color" format="reference" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -26,7 +26,6 @@
     <color name="tab_page_margin_dark">#1a1c23</color>
     <color name="account_toolbar_icon_collapsed_dark">#ffffff</color>
     <color name="compose_media_button_disabled_dark">#586173</color>
-    <color name="report_status_divider_dark">#2F2F2F</color>
     <color name="custom_tab_toolbar_dark">#313543</color>
     <color name="compose_reply_content_background_dark">#373c4b</color>
     <!--Black Theme Colors-->
@@ -57,7 +56,6 @@
     <color name="account_toolbar_icon_collapsed_light">#DE000000</color>
     <color name="compose_media_button_disabled_light">#a3a5ab</color>
     <color name="report_status_background_light">#EFEFEF</color>
-    <color name="report_status_divider_light">#9F9F9F</color>
     <color name="custom_tab_toolbar_light">#ffffff</color>
     <color name="compose_reply_content_background_light">#e0e1e6</color>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -84,7 +84,7 @@
         <item name="content_warning_button">@drawable/toggle_small_light</item>
         <item name="sensitive_media_warning_background_color">@color/sensitive_media_warning_background_light</item>
         <item name="media_preview_unloaded_drawable">@drawable/media_preview_unloaded_light</item>
-        <item name="status_divider_drawable">@drawable/status_divider_light</item>
+        <item name="android:listDivider">@drawable/status_divider_light</item>
         <item name="conversation_thread_line_drawable">@drawable/conversation_thread_line_light</item>
         <item name="tab_icon_selected_tint">@color/tusky_blue</item>
         <item name="tab_page_margin_drawable">@drawable/tab_page_margin_light</item>
@@ -99,7 +99,6 @@
         <item name="compose_reply_content_background">@color/compose_reply_content_background_light</item>
 
         <item name="report_status_background_color">@color/report_status_background_light</item>
-        <item name="report_status_divider_drawable">@drawable/report_status_divider_light</item>
 
         <item name="material_drawer_background">@color/window_background_light</item>
         <item name="material_drawer_primary_text">@color/text_color_primary_light</item>


### PR DESCRIPTION
Turns out `DividerItemDecoration` has built in support for theming, no need to roll our own :D 
I also deleted the special handling for `ReportActivity`, since it will be redesigned for Tusky 6 anyway #971 