### PR TITLE
fix night mode bug

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
@@ -72,7 +72,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
         if (theme.equals("black")) {
             setTheme(R.style.TuskyBlackTheme);
         }
-        ThemeUtils.setAppNightMode(theme, this);
+        ThemeUtils.setAppNightMode(theme);
 
         /* set the taskdescription programmatically, the theme would turn it blue */
         String appName = getString(R.string.app_name);

--- a/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.kt
@@ -123,7 +123,7 @@ class PreferencesActivity : BaseActivity(), SharedPreferences.OnSharedPreference
             "appTheme" -> {
                 val theme = sharedPreferences.getNonNullString("appTheme", ThemeUtils.APP_THEME_DEFAULT)
                 Log.d("activeTheme", theme)
-                ThemeUtils.setAppNightMode(theme, this)
+                ThemeUtils.setAppNightMode(theme)
                 restartActivitiesOnExit = true
 
                 // recreate() could be used instead, but it doesn't have an animation B).

--- a/app/src/main/java/com/keylesspalace/tusky/util/ThemeUtils.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ThemeUtils.java
@@ -103,7 +103,7 @@ public class ThemeUtils {
         drawable.setColorFilter(getColor(context, attribute), PorterDuff.Mode.SRC_IN);
     }
 
-    public static void setAppNightMode(String flavor, Context context) {
+    public static void setAppNightMode(String flavor) {
         int mode;
         switch (flavor) {
             default:
@@ -121,12 +121,7 @@ public class ThemeUtils {
                 break;
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            UiModeManager uiModeManager = (UiModeManager)context.getApplicationContext().getSystemService(Context.UI_MODE_SERVICE);
-            uiModeManager.setNightMode(mode);
-        } else {
-            AppCompatDelegate.setDefaultNightMode(mode);
-        }
+        AppCompatDelegate.setDefaultNightMode(mode);
 
     }
 }


### PR DESCRIPTION
fixes #671

https://developer.android.com/reference/android/app/UiModeManager#setNightMode(int) 
>Developers interested in an app-local implementation of night mode should consider using `AppCompatDelegate.setDefaultNightMode(int)` to manage the -night qualifier locally.

Creating this PR so Bitrise creates a build that people experiencing this issue can confirm this fix. @bernd289 @nadszeg

On my devices this works as before.