### PR TITLE
fix crash in AccountListFragment

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/AccountListFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/AccountListFragment.kt
@@ -44,7 +44,6 @@ import com.uber.autodispose.android.lifecycle.AndroidLifecycleScopeProvider.from
 import com.uber.autodispose.autoDisposable
 import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.fragment_account_list.*
 import retrofit2.Call
 import retrofit2.Callback
@@ -278,7 +277,6 @@ class AccountListFragment : BaseFragment(), AccountActionListener, Injectable {
         }
 
         getFetchCallByListType(type, id)
-                .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .autoDisposable(from(this, Lifecycle.Event.ON_DESTROY))
                 .subscribe({ response ->

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.java
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.java
@@ -38,6 +38,7 @@ import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
+import retrofit2.Response;
 import retrofit2.http.DELETE;
 import retrofit2.http.Field;
 import retrofit2.http.FormUrlEncoded;
@@ -139,12 +140,12 @@ public interface MastodonApi {
     Call<StatusContext> statusContext(@Path("id") String statusId);
 
     @GET("api/v1/statuses/{id}/reblogged_by")
-    Call<List<Account>> statusRebloggedBy(
+    Single<Response<List<Account>>> statusRebloggedBy(
             @Path("id") String statusId,
             @Query("max_id") String maxId);
 
     @GET("api/v1/statuses/{id}/favourited_by")
-    Call<List<Account>> statusFavouritedBy(
+    Single<Response<List<Account>>> statusFavouritedBy(
             @Path("id") String statusId,
             @Query("max_id") String maxId);
 
@@ -223,12 +224,12 @@ public interface MastodonApi {
             @Nullable @Query("pinned") Boolean pinned);
 
     @GET("api/v1/accounts/{id}/followers")
-    Call<List<Account>> accountFollowers(
+    Single<Response<List<Account>>> accountFollowers(
             @Path("id") String accountId,
             @Query("max_id") String maxId);
 
     @GET("api/v1/accounts/{id}/following")
-    Call<List<Account>> accountFollowing(
+    Single<Response<List<Account>>> accountFollowing(
             @Path("id") String accountId,
             @Query("max_id") String maxId);
 
@@ -255,10 +256,10 @@ public interface MastodonApi {
     Call<List<Relationship>> relationships(@Query("id[]") List<String> accountIds);
 
     @GET("api/v1/blocks")
-    Call<List<Account>> blocks(@Query("max_id") String maxId);
+    Single<Response<List<Account>>> blocks(@Query("max_id") String maxId);
 
     @GET("api/v1/mutes")
-    Call<List<Account>> mutes(@Query("max_id") String maxId);
+    Single<Response<List<Account>>> mutes(@Query("max_id") String maxId);
 
     @GET("api/v1/favourites")
     Call<List<Status>> favourites(
@@ -267,7 +268,7 @@ public interface MastodonApi {
             @Query("limit") Integer limit);
 
     @GET("api/v1/follow_requests")
-    Call<List<Account>> followRequests(@Query("max_id") String maxId);
+    Single<Response<List<Account>>> followRequests(@Query("max_id") String maxId);
 
     @POST("api/v1/follow_requests/{id}/authorize")
     Call<Relationship> authorizeFollowRequest(@Path("id") String accountId);


### PR DESCRIPTION
Steps to reproduce: Go on a slow internet connection. Open and close one of the `AccountListFragment`s very fast. If the network request returns after the Fragment was closed, it crashed.

```
java.lang.NullPointerException: 
  at com.keylesspalace.tusky.util.ViewExtensionsKt.show (ViewExtensionsKt.java:6)
  at com.keylesspalace.tusky.fragment.AccountListFragment.onFetchAccountsFailure (AccountListFragment.java:327)
```

I moved the api requests to `Single`s, because if they get cancelled the callback is not invoked so it does not crash anymore. With the `callList` the error callback was invoked when cancelled.

This is the only crash I could find in Google Play for Tusky 5.0 beta 1.