### PR TITLE
Fix resizing image uniformly when opening an image

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewImageFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewImageFragment.kt
@@ -184,6 +184,7 @@ class ViewImageFragment : ViewMediaFragment() {
                 .networkPolicy(NetworkPolicy.NO_STORE)
                 .resize(maxW, maxH)
                 .onlyScaleDown()
+                .centerInside()
                 .into(photoView, object : Callback {
                     override fun onSuccess() {
                         finishLoadingSuccessfully()


### PR DESCRIPTION
FIxes a missing `centerInside()` in `ViewImageFragment`. Because of that some images were not resized correctly. @mal0ki send me an example but it's non-shareable so I've managed to make another one (it was trickier than I expected): https://birb.site/@charlag/101648643731741697

cc @MightyPork 