### PR TITLE
fix crash in account activity

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
@@ -463,10 +463,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasSupportF
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.account_toolbar, menu)
-        return super.onCreateOptionsMenu(menu)
-    }
 
-    override fun onPrepareOptionsMenu(menu: Menu): Boolean {
         if (!isSelf) {
             val follow = menu.findItem(R.id.action_follow)
             follow.title = if (followState == FollowState.NOT_FOLLOWING) {
@@ -510,7 +507,8 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasSupportF
             menu.removeItem(R.id.action_mute)
             menu.removeItem(R.id.action_show_reblogs)
         }
-        return super.onPrepareOptionsMenu(menu)
+
+        return super.onCreateOptionsMenu(menu)
     }
 
     private fun showFollowRequestPendingDialog() {


### PR DESCRIPTION
A try to fix this mysterious crash I keep seeing in Google Play crash reports. 
https://gist.github.com/connyduck/bdf1c765fbdd526e590c4ef390948f23

Its only on Android 8 and the approach is to just not override this method anymore.