### PR TITLE
fix crash in TimelineFragment

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -467,17 +467,17 @@ public class TimelineFragment extends SFragment implements
                                 removeAllByAccountId(id);
                             }
                         } else if (event instanceof BlockEvent) {
-                            if (kind != Kind.USER && kind != Kind.USER_WITH_REPLIES) {
+                            if (kind != Kind.USER && kind != Kind.USER_WITH_REPLIES && kind != Kind.USER_PINNED) {
                                 String id = ((BlockEvent) event).getAccountId();
                                 removeAllByAccountId(id);
                             }
                         } else if (event instanceof MuteEvent) {
-                            if (kind != Kind.USER && kind != Kind.USER_WITH_REPLIES) {
+                            if (kind != Kind.USER && kind != Kind.USER_WITH_REPLIES && kind != Kind.USER_PINNED) {
                                 String id = ((MuteEvent) event).getAccountId();
                                 removeAllByAccountId(id);
                             }
                         } else if (event instanceof StatusDeletedEvent) {
-                            if (kind != Kind.USER && kind != Kind.USER_WITH_REPLIES) {
+                            if (kind != Kind.USER && kind != Kind.USER_WITH_REPLIES && kind != Kind.USER_PINNED) {
                                 String id = ((StatusDeletedEvent) event).getStatusId();
                                 deleteStatusById(id);
                             }


### PR DESCRIPTION
Steps to reproduce: Go to a profile where the user has pinned tabs. Mute the user. Crash because `removeAllByAccountId` got called in a timeline where all posts are from one user.