### PR TITLE
Fix crash on Android 9 when replying from notification

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/receiver/SendStatusBroadcastReceiver.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/receiver/SendStatusBroadcastReceiver.kt
@@ -133,6 +133,8 @@ class SendStatusBroadcastReceiver : BroadcastReceiver() {
                     .replyingStatusContent(citedText)
                     .build(context)
 
+            composeIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
             context.startActivity(composeIntent)
         }
     }


### PR DESCRIPTION
`android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag.`