### PR TITLE
Fix visibility of answer from DM column, from private to direct

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationEntity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationEntity.kt
@@ -147,7 +147,7 @@ data class ConversationStatusEntity(
                 favourited = favourited,
                 sensitive= sensitive,
                 spoilerText = spoilerText,
-                visibility = Status.Visibility.PRIVATE,
+                visibility = Status.Visibility.DIRECT,
                 attachments = attachments,
                 mentions = mentions,
                 application = null,


### PR DESCRIPTION
#1012 hardcoded visibility level when answering from a toot displayed in the DM column to `private` but direct messages have the visibility level `direct`, so this PR corrects the value.

Also, since people can post by mistake to their followers instead of directly, I think you should consider releasing a minor version of Tusky containing this fix.