### PR TITLE
Fix crash when sharing to Tusky while not logged in

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
@@ -119,6 +119,11 @@ public final class MainActivity extends BottomSheetActivity implements ActionBut
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        if(accountManager.getActiveAccount() == null) {
+            // will be redirected to LoginActivity by BaseActivity
+            return;
+        }
+
         Intent intent = getIntent();
         boolean showNotificationTab = false;
 


### PR DESCRIPTION
Steps to reproduce: Be not logged into Tusky. Share something to Tusky. Crash.
Expected behavior: After sharing user sees the login screen.