### PR TITLE
Add support for language switching

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
@@ -59,8 +59,6 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
 
     protected static final int PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE = 1;
 
-    private final String TAG = "BaseActivity";
-
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
@@ -102,7 +102,6 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
     @Override
     protected void attachBaseContext(Context base) {
         super.attachBaseContext(TuskyApplication.localeManager.setLocale(base));
-        Log.d(TAG, "attachBaseContext");
     }
 
     protected boolean requiresLogin() {

--- a/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
@@ -16,6 +16,7 @@
 package com.keylesspalace.tusky;
 
 import android.app.ActivityManager;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
@@ -58,6 +59,8 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
 
     protected static final int PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE = 1;
 
+    private final String TAG = "BaseActivity";
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -94,6 +97,12 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
         }
 
         callList = new ArrayList<>();
+    }
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(TuskyApplication.localeManager.setLocale(base));
+        Log.d(TAG, "attachBaseContext");
     }
 
     protected boolean requiresLogin() {

--- a/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.kt
@@ -135,10 +135,6 @@ class PreferencesActivity : BaseActivity(), SharedPreferences.OnSharedPreference
                 restartActivitiesOnExit = true
             }
             "language" -> {
-                val language = sharedPreferences.getNonNullString("language", "en")
-                Log.d("activeLanguage", language)
-                sharedPreferences.edit().putString("language", language).apply()
-
                 restartActivitiesOnExit = true
                 this.restartCurrentActivity()
             }

--- a/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.kt
@@ -124,19 +124,9 @@ class PreferencesActivity : BaseActivity(), SharedPreferences.OnSharedPreference
                 val theme = sharedPreferences.getNonNullString("appTheme", ThemeUtils.APP_THEME_DEFAULT)
                 Log.d("activeTheme", theme)
                 ThemeUtils.setAppNightMode(theme, this)
-                restartActivitiesOnExit = true
-
-                // recreate() could be used instead, but it doesn't have an animation B).
-                intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
-                val savedInstanceState = Bundle()
-                saveInstanceState(savedInstanceState)
-                intent.putExtras(savedInstanceState)
-                startActivityWithSlideInAnimation(intent)
-                finish()
-                overridePendingTransition(R.anim.fade_in, R.anim.fade_out)
 
                 restartActivitiesOnExit = true
-
+                this.restartCurrentActivity()
             }
             "statusTextSize" -> {
                 restartActivitiesOnExit = true
@@ -144,11 +134,28 @@ class PreferencesActivity : BaseActivity(), SharedPreferences.OnSharedPreference
             "absoluteTimeView" -> {
                 restartActivitiesOnExit = true
             }
+            "language" -> {
+                val language = sharedPreferences.getNonNullString("language", "en")
+                Log.d("activeLanguage", language)
+                sharedPreferences.edit().putString("language", language).apply()
+
+                restartActivitiesOnExit = true
+                this.restartCurrentActivity()
+            }
         }
 
         eventHub.dispatch(PreferenceChangedEvent(key))
     }
 
+    private fun restartCurrentActivity() {
+        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+        val savedInstanceState = Bundle()
+        saveInstanceState(savedInstanceState)
+        intent.putExtras(savedInstanceState)
+        startActivityWithSlideInAnimation(intent)
+        finish()
+        overridePendingTransition(R.anim.fade_in, R.anim.fade_out)
+    }
 
     override fun onBackPressed() {
         /* Switching themes won't actually change the theme of activities on the back stack.

--- a/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.java
+++ b/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.java
@@ -121,7 +121,6 @@ public class TuskyApplication extends Application implements HasActivityInjector
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
         localeManager.setLocale(this);
-        Log.d(TAG, "onConfigurationChanged: " + newConfig.locale.toString());
     }
 
     /**

--- a/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.java
+++ b/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.java
@@ -115,16 +115,14 @@ public class TuskyApplication extends Application implements HasActivityInjector
     protected void attachBaseContext(Context base) {
         localeManager = new LocaleManager(base);
         super.attachBaseContext(localeManager.setLocale(base));
-        Log.d(TAG, "attachBaseContext");
     }
 
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
         localeManager.setLocale(this);
-        Log.d(TAG, "onConfigurationChanged: " + newConfig.locale.getLanguage());
+        Log.d(TAG, "onConfigurationChanged: " + newConfig.locale.toString());
     }
-
 
     /**
      * This method will load the EmojiCompat font which has been selected.

--- a/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.java
+++ b/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.java
@@ -20,7 +20,10 @@ import android.app.Application;
 import android.app.Service;
 import androidx.room.Room;
 import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.res.Configuration;
 import android.preference.PreferenceManager;
+import android.util.Log;
 import androidx.emoji.text.EmojiCompat;
 
 import com.evernote.android.job.JobManager;
@@ -29,6 +32,7 @@ import com.keylesspalace.tusky.db.AccountManager;
 import com.keylesspalace.tusky.db.AppDatabase;
 import com.keylesspalace.tusky.di.AppInjector;
 import com.keylesspalace.tusky.util.EmojiCompatFont;
+import com.keylesspalace.tusky.util.LocaleManager;
 import com.keylesspalace.tusky.util.NotificationPullJobCreator;
 import com.squareup.picasso.Picasso;
 
@@ -61,6 +65,10 @@ public class TuskyApplication extends Application implements HasActivityInjector
     private AccountManager accountManager;
 
     private ServiceLocator serviceLocator;
+
+    public static LocaleManager localeManager;
+
+    private final String TAG = "TuskyApplication";
 
     @Override
     public void onCreate() {
@@ -102,6 +110,21 @@ public class TuskyApplication extends Application implements HasActivityInjector
     protected void initSecurityProvider() {
         Security.insertProviderAt(Conscrypt.newProvider(), 1);
     }
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        localeManager = new LocaleManager(base);
+        super.attachBaseContext(localeManager.setLocale(base));
+        Log.d(TAG, "attachBaseContext");
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        localeManager.setLocale(this);
+        Log.d(TAG, "onConfigurationChanged: " + newConfig.locale.getLanguage());
+    }
+
 
     /**
      * This method will load the EmojiCompat font which has been selected.

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/preference/PreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/preference/PreferencesFragment.kt
@@ -61,6 +61,9 @@ class PreferencesFragment : PreferenceFragmentCompat() {
             }
             true
         }
+
+        val languagePreference: Preference = findPreference("language")
+        languagePreference.icon = IconicsDrawable(languagePreference.context, GoogleMaterial.Icon.gmd_translate).sizePx(iconSize).color(ThemeUtils.getColor(languagePreference.context, R.attr.toolbar_icon_tint))
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/preference/PreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/preference/PreferencesFragment.kt
@@ -61,7 +61,6 @@ class PreferencesFragment : PreferenceFragmentCompat() {
             }
             true
         }
-
     }
 
     override fun onResume() {
@@ -75,22 +74,22 @@ class PreferencesFragment : PreferenceFragmentCompat() {
 
         val sharedPreferences = preferenceManager.sharedPreferences
 
-            val httpProxyEnabled = sharedPreferences.getBoolean("httpProxyEnabled", false)
+        val httpProxyEnabled = sharedPreferences.getBoolean("httpProxyEnabled", false)
 
-            val httpServer = sharedPreferences.getNonNullString("httpProxyServer", "")
+        val httpServer = sharedPreferences.getNonNullString("httpProxyServer", "")
 
-            try {
-                val httpPort = sharedPreferences.getNonNullString("httpProxyPort", "-1").toInt()
+        try {
+            val httpPort = sharedPreferences.getNonNullString("httpProxyPort", "-1").toInt()
 
-                if (httpProxyEnabled && httpServer.isNotBlank() && httpPort > 0 && httpPort < 65535) {
-                    httpProxyPref.summary = "$httpServer:$httpPort"
-                    return
-                }
-            } catch (e: NumberFormatException) {
-                // user has entered wrong port, fall back to empty summary
+            if (httpProxyEnabled && httpServer.isNotBlank() && httpPort > 0 && httpPort < 65535) {
+                httpProxyPref.summary = "$httpServer:$httpPort"
+                return
             }
+        } catch (e: NumberFormatException) {
+            // user has entered wrong port, fall back to empty summary
+        }
 
-            httpProxyPref.summary = ""
+        httpProxyPref.summary = ""
 
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/util/LocaleManager.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LocaleManager.kt
@@ -1,0 +1,47 @@
+/* Copyright 2019 Mélanie Chauvel (ariasuni)
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>. */
+
+package com.keylesspalace.tusky.util
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.preference.PreferenceManager
+
+import java.util.Locale
+
+import com.keylesspalace.tusky.util.getNonNullString
+
+
+class LocaleManager(context: Context) {
+
+    private var prefs: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+
+    fun setLocale(context: Context): Context {
+        val language = prefs.getNonNullString("language", "")
+        if (language.equals("default")) {
+            return context;
+        }
+        val locale = Locale.forLanguageTag(language)
+        Locale.setDefault(locale)
+
+        val res = context.getResources()
+        val config = Configuration(res.getConfiguration());
+        config.setLocale(locale)
+        return context.createConfigurationContext(config)
+    }
+}

--- a/app/src/main/java/com/keylesspalace/tusky/util/LocaleManager.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LocaleManager.kt
@@ -15,7 +15,6 @@
 
 package com.keylesspalace.tusky.util
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.res.Configuration
@@ -32,7 +31,7 @@ class LocaleManager(context: Context) {
     private var prefs: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
 
     fun setLocale(context: Context): Context {
-        val language = prefs.getNonNullString("language", "")
+        val language = prefs.getNonNullString("language", "default")
         if (language.equals("default")) {
             return context;
         }

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -30,4 +30,65 @@
         <item>auto</item>
     </string-array>
 
+    <string-array name="language_entries">
+        <item>@string/system_default</item>
+        <item>Català</item>
+        <item>Cymraeg</item>
+        <item>Deutsch</item>
+        <item>English</item>
+        <item>Español</item>
+        <item>Euskara</item>
+        <item>Français</item>
+        <item>Italiano</item>
+        <item>Magyar</item>
+        <item>Nederlands</item>
+        <item>Occitan</item>
+        <item>Polski</item>
+        <item>Português (Brasil)</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Русский</item>
+        <item>العَرَبِيَّة‎</item>
+        <item>فارسی</item>
+        <item>தமிழ்</item>
+        <item>한국어</item>
+        <item>中文(台灣)</item>
+        <item>中文(新加坡)</item>
+        <item>中文(澳門)</item>
+        <item>中文(简体)</item>
+        <item>中文(香港)</item>
+        <item>日本語</item>
+    </string-array>
+
+    <string-array name="language_values">
+        <item>default</item>
+        <item>ca</item>
+        <item>cy</item>
+        <item>de</item>
+        <item>en</item>
+        <item>es</item>
+        <item>eu</item>
+        <item>fr</item>
+        <item>it</item>
+        <item>hu</item>
+        <item>nl</item>
+        <item>oc</item>
+        <item>pl</item>
+        <item>pt-BR</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>ru</item>
+        <item>ar</item>
+        <item>fa</item>
+        <item>ta</item>
+        <item>ko</item>
+        <item>zh-TW</item>
+        <item>zh-SG</item>
+        <item>zh-MO</item>
+        <item>zh-CN</item>
+        <item>zh-HK</item>
+        <item>ja</item>
+    </string-array>
+
+    <string name="pref_title_language_settings">Language</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,6 +210,7 @@
     <string name="pref_title_browser_settings">Browser</string>
     <string name="pref_title_custom_tabs">Use Chrome Custom Tabs</string>
     <string name="pref_title_hide_follow_button">Hide compose button while scrolling</string>
+    <string name="pref_title_language">Language</string>
     <string name="pref_title_status_filter">Timeline filtering</string>
     <string name="pref_title_status_tabs">Tabs</string>
     <string name="pref_title_show_boosts">Show boosts</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -39,6 +39,14 @@
             android:key="absoluteTimeView"
             android:title="@string/pref_title_absolute_time" />
 
+        <ListPreference
+            android:defaultValue="default"
+            android:entries="@array/language_entries"
+            android:entryValues="@array/language_values"
+            android:key="language"
+            android:summary="%s"
+            android:title="@string/pref_title_language_settings" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -22,6 +22,14 @@
             android:title="@string/emoji_style" />
 
         <ListPreference
+            android:defaultValue="default"
+            android:entries="@array/language_entries"
+            android:entryValues="@array/language_values"
+            android:key="language"
+            android:summary="%s"
+            android:title="@string/pref_title_language" />
+
+        <ListPreference
             android:defaultValue="medium"
             android:entries="@array/status_text_size_names"
             android:entryValues="@array/status_text_size_values"
@@ -38,14 +46,6 @@
             android:defaultValue="false"
             android:key="absoluteTimeView"
             android:title="@string/pref_title_absolute_time" />
-
-        <ListPreference
-            android:defaultValue="default"
-            android:entries="@array/language_entries"
-            android:entryValues="@array/language_values"
-            android:key="language"
-            android:summary="%s"
-            android:title="@string/pref_title_language_settings" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
Fix #644 

I mostly followed [this tutorial](https://proandroiddev.com/change-language-programmatically-at-runtime-on-android-5e6bc15c758), adapting it to Tusky.

* Use default system language or any language added to Tusky (language list is static and needs to be updated when a new translation is added, but it is the simpler way)
* Language change immediately, similarly to theme change but with a bit more code here and there to correctly update locale.
* Works with locales that are more than two letters (e.g. `pt-rBR` or `zh-rTW`).

Possible changes, based on your feedback:

* I hardcoded the current locales in `donottranslate.xml`, because it is the simplest yet clean solution. See [here](https://stackoverflow.com/questions/11611065/get-the-applications-resources-languages) for other ways to do it that you might find better.
* The code from the tutorial suggest that the class `LocaleManager` should be provided to different classes through dependency injection, but I do not know if it’s relevant here or how to do it.