### PR TITLE
Update Android Gradle plugin to 3.3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build.jetifier:jetifier-processor:1.0.0-beta02'
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Supporting the latest stable version of Android Studio

https://androidstudio.googleblog.com/2019/03/android-studio-332-available.html