### PR TITLE
Fix unhandled NPE when sharing an image from ViewMediaActivity

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
@@ -272,11 +272,11 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
                 }
             }
 
-            override fun onBitmapFailed(errorDrawable: Drawable) {
+            override fun onBitmapFailed(errorDrawable: Drawable?) {
                 Log.e(TAG, "Error loading temporary media.")
             }
 
-            override fun onPrepareLoad(placeHolderDrawable: Drawable) { }
+            override fun onPrepareLoad(placeHolderDrawable: Drawable?) { }
         })
 
         shareFile(file, "image/png")


### PR DESCRIPTION
Steps to reproduce:
- Open media view for an image
- Click share button in the toolbar

Behavior before PR: NPE

Behavior after PR: Share sheet opens as expected