### PR TITLE
fix crash in NotificationsFragment

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/TabPreferenceActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/TabPreferenceActivity.kt
@@ -47,6 +47,8 @@ class TabPreferenceActivity : BaseActivity(), Injectable, ItemInteractionListene
     private lateinit var touchHelper: ItemTouchHelper
     private lateinit var addTabAdapter: TabAdapter
 
+    private var tabsChanged = false
+
     private val selectedItemElevation by lazy { resources.getDimension(R.dimen.selected_drag_item_elevation) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -188,6 +190,7 @@ class TabPreferenceActivity : BaseActivity(), Injectable, ItemInteractionListene
                     .subscribe()
 
         }
+        tabsChanged = true
     }
 
     override fun onBackPressed() {
@@ -208,7 +211,9 @@ class TabPreferenceActivity : BaseActivity(), Injectable, ItemInteractionListene
 
     override fun onPause() {
         super.onPause()
-        eventHub.dispatch(MainTabsChangedEvent(currentTabs))
+        if(tabsChanged) {
+            eventHub.dispatch(MainTabsChangedEvent(currentTabs))
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -215,16 +215,17 @@ public class NotificationsFragment extends SFragment implements
         adapter.setUseAbsoluteTime(useAbsoluteTime);
         recyclerView.setAdapter(adapter);
 
-        notifications.clear();
         topLoading = false;
         bottomLoading = false;
         bottomId = null;
 
+        if (notifications.isEmpty()) {
+            sendFetchNotificationsRequest(null, null, FetchEnd.BOTTOM, -1);
+        } else {
+            progressBar.setVisibility(View.GONE);
+        }
+
         ((SimpleItemAnimator) recyclerView.getItemAnimator()).setSupportsChangeAnimations(false);
-
-        updateAdapter();
-
-        sendFetchNotificationsRequest(null, null, FetchEnd.BOTTOM, -1);
 
         return rootView;
     }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -219,6 +219,8 @@ public class NotificationsFragment extends SFragment implements
         bottomLoading = false;
         bottomId = null;
 
+        updateAdapter();
+
         if (notifications.isEmpty()) {
             sendFetchNotificationsRequest(null, null, FetchEnd.BOTTOM, -1);
         } else {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -222,6 +222,8 @@ public class NotificationsFragment extends SFragment implements
 
         ((SimpleItemAnimator) recyclerView.getItemAnimator()).setSupportsChangeAnimations(false);
 
+        updateAdapter();
+
         sendFetchNotificationsRequest(null, null, FetchEnd.BOTTOM, -1);
 
         return rootView;


### PR DESCRIPTION
Steps to reproduce:
Have the default tab setup. Go to Account Settings -> Tabs. Go back. After a short time, crash.

<details>
<summary>Stacktrace</summary>

```
 java.lang.ArrayIndexOutOfBoundsException: length=33; index=-1
        at java.util.ArrayList.get(ArrayList.java:439)
        at com.keylesspalace.tusky.util.PairedList.get(PairedList.java:53)
        at com.keylesspalace.tusky.fragment.NotificationsFragment.addItems(NotificationsFragment.java:818)
        at com.keylesspalace.tusky.fragment.NotificationsFragment.onFetchNotificationsSuccess(NotificationsFragment.java:705)
        at com.keylesspalace.tusky.fragment.NotificationsFragment.access$400(NotificationsFragment.java:93)
        at com.keylesspalace.tusky.fragment.NotificationsFragment$4.onResponse(NotificationsFragment.java:665)
        at retrofit2.ExecutorCallAdapterFactory$ExecutorCallbackCall$1$1.run(ExecutorCallAdapterFactory.java:71)
        at android.os.Handler.handleCallback(Handler.java:873)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6718)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```

</details>


Regression from #985 

Seems like the notifications array gets cleared but the adapter content does not when the fragment gets recreated. Calling `updateAdapter()` syncs the two and it no longer crashes.

I also added a check to not dispatch the `MainTabsChangedEvent` when nothing changed.