### PR TITLE
Fix crash with unknown notification type

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -136,6 +136,7 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
                     (NotificationViewData.Concrete) notification;
             Notification.Type type = concreteNotificaton.getType();
             switch (type) {
+                default:
                 case MENTION: {
                     StatusViewHolder holder = (StatusViewHolder) viewHolder;
                     StatusViewData.Concrete status = concreteNotificaton.getStatusViewData();

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Notification.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Notification.kt
@@ -16,7 +16,6 @@
 package com.keylesspalace.tusky.entity
 
 import com.google.gson.annotations.JsonAdapter
-import com.google.gson.annotations.SerializedName
 import com.keylesspalace.tusky.json.NotificationTypeAdapter
 
 data class Notification(
@@ -28,13 +27,9 @@ data class Notification(
     @JsonAdapter(NotificationTypeAdapter::class)
     enum class Type {
         UNKNOWN,
-        @SerializedName("mention")
         MENTION,
-        @SerializedName("reblog")
         REBLOG,
-        @SerializedName("favourite")
         FAVOURITE,
-        @SerializedName("follow")
         FOLLOW;
 
         companion object {

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Notification.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Notification.kt
@@ -24,6 +24,7 @@ data class Notification(
         val status: Status?) {
 
     enum class Type {
+        UNKNOWN,
         @SerializedName("mention")
         MENTION,
         @SerializedName("reblog")

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Notification.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Notification.kt
@@ -15,7 +15,9 @@
 
 package com.keylesspalace.tusky.entity
 
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import com.keylesspalace.tusky.json.NotificationTypeAdapter
 
 data class Notification(
         val type: Type,
@@ -23,6 +25,7 @@ data class Notification(
         val account: Account,
         val status: Status?) {
 
+    @JsonAdapter(NotificationTypeAdapter::class)
     enum class Type {
         UNKNOWN,
         @SerializedName("mention")
@@ -32,7 +35,22 @@ data class Notification(
         @SerializedName("favourite")
         FAVOURITE,
         @SerializedName("follow")
-        FOLLOW
+        FOLLOW;
+
+        companion object {
+
+            @JvmStatic
+            fun byString(s: String): Type {
+                return when (s) {
+                    "mention" -> MENTION
+                    "reblog" -> REBLOG
+                    "favourite" -> FAVOURITE
+                    "follow" -> FOLLOW
+                    else -> UNKNOWN
+                }
+            }
+
+        }
     }
 
     override fun hashCode(): Int {

--- a/app/src/main/java/com/keylesspalace/tusky/json/NotificationTypeAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/json/NotificationTypeAdapter.kt
@@ -1,0 +1,18 @@
+package com.keylesspalace.tusky.json
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonParseException
+import com.keylesspalace.tusky.entity.Notification
+
+import java.lang.reflect.Type
+
+class NotificationTypeAdapter : JsonDeserializer<Notification.Type> {
+
+    @Throws(JsonParseException::class)
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): Notification.Type {
+        return Notification.Type.byString(json.asString)
+    }
+
+}

--- a/app/src/main/java/com/keylesspalace/tusky/viewdata/NotificationViewData.java
+++ b/app/src/main/java/com/keylesspalace/tusky/viewdata/NotificationViewData.java
@@ -59,7 +59,7 @@ public abstract class NotificationViewData {
         }
 
         public Notification.Type getType() {
-            return type;
+            return type == null ? Notification.Type.UNKNOWN : type;
         }
 
         public String getId() {

--- a/app/src/main/java/com/keylesspalace/tusky/viewdata/NotificationViewData.java
+++ b/app/src/main/java/com/keylesspalace/tusky/viewdata/NotificationViewData.java
@@ -59,7 +59,7 @@ public abstract class NotificationViewData {
         }
 
         public Notification.Type getType() {
-            return type == null ? Notification.Type.UNKNOWN : type;
+            return type;
         }
 
         public String getId() {


### PR DESCRIPTION
Fix part of #1102 .

If there's "Your poll has ended." notification in user's notification list, app crashes.
This is a fatal problem because once app started to crash, we can't even switch account.
So I fixed not to crash app for now.