### PR TITLE
Update Notification Adapter to support status created timestamp refresh

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -44,9 +44,10 @@ import at.connyduck.sparkbutton.SparkEventListener;
 import kotlin.collections.CollectionsKt;
 
 public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
-    public static class Key{
+    public static class Key {
         public static final String KEY_CREATED = "created";
     }
+
     private TextView displayName;
     private TextView username;
     private ImageButton replyButton;
@@ -540,8 +541,9 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
     protected void setupWithStatus(StatusViewData.Concrete status, final StatusActionListener listener,
                                    boolean mediaPreviewEnabled) {
-        this.setupWithStatus(status,listener,mediaPreviewEnabled,null);
+        this.setupWithStatus(status, listener, mediaPreviewEnabled, null);
     }
+
     protected void setupWithStatus(StatusViewData.Concrete status, final StatusActionListener listener,
                                    boolean mediaPreviewEnabled, @Nullable Object payloads) {
         if (payloads == null) {
@@ -584,14 +586,13 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             // fetches another one from its delegate because it checks that it's set so we remove it
             // and let RecyclerView ask for a new delegate.
             itemView.setAccessibilityDelegate(null);
-        }
-        else{
+        } else {
             if (payloads instanceof List)
-            for (Object item:(List)payloads) {
-                if (Key.KEY_CREATED.equals(item)){
-                    setCreatedAt(status.getCreatedAt());
+                for (Object item : (List) payloads) {
+                    if (Key.KEY_CREATED.equals(item)) {
+                        setCreatedAt(status.getCreatedAt());
+                    }
                 }
-            }
 
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -31,6 +31,7 @@ import com.google.android.material.tabs.TabLayout;
 import com.keylesspalace.tusky.MainActivity;
 import com.keylesspalace.tusky.R;
 import com.keylesspalace.tusky.adapter.NotificationsAdapter;
+import com.keylesspalace.tusky.adapter.StatusBaseViewHolder;
 import com.keylesspalace.tusky.appstore.BlockEvent;
 import com.keylesspalace.tusky.appstore.EventHub;
 import com.keylesspalace.tusky.appstore.FavoriteEvent;
@@ -57,9 +58,11 @@ import com.keylesspalace.tusky.viewdata.NotificationViewData;
 import com.keylesspalace.tusky.viewdata.StatusViewData;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
@@ -78,6 +81,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.SimpleItemAnimator;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import at.connyduck.sparkbutton.helpers.Utils;
+import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import kotlin.Unit;
 import kotlin.collections.CollectionsKt;
@@ -929,7 +933,46 @@ public class NotificationsFragment extends SFragment implements
 
         @Override
         public boolean areContentsTheSame(NotificationViewData oldItem, NotificationViewData newItem) {
-            return oldItem.deepEquals(newItem);
+            return false;
+        }
+
+        @Nullable
+        @Override
+        public Object getChangePayload(@NonNull NotificationViewData oldItem, @NonNull NotificationViewData newItem) {
+            if (oldItem.deepEquals(newItem)){
+                //If items are equal - update timestamp only
+                List<String> payload = new ArrayList<>();
+                payload.add(StatusBaseViewHolder.Key.KEY_CREATED);
+                return payload;
+            }
+            else
+                // If items are different - update a whole view holder
+                return null;
         }
     };
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        startUpdateTimestamp();
+    }
+
+    /**
+     * Start to update adapter every minute to refresh timestamp
+     * If setting absoluteTimeView is false
+     * Auto dispose observable on pause
+     */
+    private void startUpdateTimestamp() {
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        boolean useAbsoluteTime = preferences.getBoolean("absoluteTimeView", false);
+        if (!useAbsoluteTime) {
+            Observable.interval(1, TimeUnit.MINUTES)
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .as(autoDisposable(from(this, Lifecycle.Event.ON_PAUSE)))
+                    .subscribe(
+                            interval -> updateAdapter()
+                    );
+        }
+
+    }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -939,13 +939,12 @@ public class NotificationsFragment extends SFragment implements
         @Nullable
         @Override
         public Object getChangePayload(@NonNull NotificationViewData oldItem, @NonNull NotificationViewData newItem) {
-            if (oldItem.deepEquals(newItem)){
+            if (oldItem.deepEquals(newItem)) {
                 //If items are equal - update timestamp only
                 List<String> payload = new ArrayList<>();
                 payload.add(StatusBaseViewHolder.Key.KEY_CREATED);
                 return payload;
-            }
-            else
+            } else
                 // If items are different - update a whole view holder
                 return null;
         }


### PR DESCRIPTION
Issue #452 
Refresh items timestamp at the Notification fragment with 1 minute interval.
Implemented the same logic as at the pull request #1113 