### PR TITLE
Added "Warning" icon instead of "CW" text.

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
@@ -29,6 +29,7 @@ import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
+import android.media.Image;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
@@ -202,7 +203,7 @@ public final class ComposeActivity
     private TootButton tootButton;
     private ImageButton pickButton;
     private ImageButton visibilityButton;
-    private Button contentWarningButton;
+    private ImageButton contentWarningButton;
     private ImageButton emojiButton;
     private ImageButton hideMediaToggle;
 
@@ -1480,12 +1481,10 @@ public final class ComposeActivity
         if (show) {
             statusMarkSensitive = true;
             contentWarningBar.setVisibility(View.VISIBLE);
-            contentWarningButton.setTextColor(ContextCompat.getColor(this, R.color.tusky_blue));
             contentWarningEditor.setSelection(contentWarningEditor.getText().length());
             contentWarningEditor.requestFocus();
         } else {
             contentWarningBar.setVisibility(View.GONE);
-            contentWarningButton.setTextColor(ThemeUtils.getColor(this, android.R.attr.textColorTertiary));
         }
         updateHideMediaToggle();
 

--- a/app/src/main/res/drawable/ic_cw_24dp.xml
+++ b/app/src/main/res/drawable/ic_cw_24dp.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+    <path android:fillColor="#FF000000" android:pathData="M32,464h448L256,48 32,464zM280,400h-48v-48h48v48zM280,320h-48v-96h48v96z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_cw_24dp.xml
+++ b/app/src/main/res/drawable/ic_cw_24dp.xml
@@ -1,7 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="24dp"
     android:width="24dp"
-    android:viewportWidth="512"
-    android:viewportHeight="512">
-    <path android:fillColor="#FF000000" android:pathData="M32,464h448L256,48 32,464zM280,400h-48v-48h48v48zM280,320h-48v-96h48v96z"/>
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M20,2L4,2c-1.1,0 -1.99,0.9 -1.99,2L2,22l4,-4h14c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM13,14h-2v-2h2v2zM13,10h-2L11,6h2v4z"/>
 </vector>

--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -242,17 +242,16 @@
             android:visibility="gone"
             tools:src="@drawable/ic_eye_24dp" />
 
-        <androidx.appcompat.widget.AppCompatButton
+        <ImageButton
             android:id="@+id/composeContentWarningButton"
             style="?attr/image_button_style"
             android:layout_width="36dp"
             android:layout_height="36dp"
             android:layout_marginEnd="4dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/action_content_warning"
             android:padding="4dp"
-            android:text="@string/text_content_warning_button"
-            android:tooltipText="@string/action_content_warning" />
+            android:tooltipText="@string/action_content_warning"
+            app:srcCompat="@drawable/ic_cw_24dp"/>
 
         <ImageButton
             android:id="@+id/composeEmojiButton"


### PR DESCRIPTION
> **Disclaimer**: this needs to be tested, since I haven't touched Android development (with all its things) for years.


In short: I don't like "CW" text in toot compose screen, since it _has_ to be translated and there's no space for 3+ characters. I went to https://ionicons.com, grabbed "Warning" icon (AFAIK they are under MIT Licence, so I can do that) and placed instead of "CW" text.

Screenshot:
![image](https://user-images.githubusercontent.com/2780044/54719382-c62f0700-4b6d-11e9-86d0-a9a82bcc901f.png)
