### PR TITLE
Fix #1132

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
@@ -623,7 +623,11 @@ public final class ComposeActivity
                         String text = intent.getStringExtra(Intent.EXTRA_TEXT);
                         String shareBody = null;
                         if(subject != null && text != null){
-                            shareBody = String.format("%s\n%s", subject, text);
+                            if(!subject.equals(text) && !text.contains(subject)){
+                                shareBody = String.format("%s\n%s", subject, text);
+                            }else{
+                                shareBody = text;
+                            }
                         }else if(text != null){
                             shareBody = text;
                         }else if(subject != null){


### PR DESCRIPTION
Fixes duplicate title when sharing from Feedly or Google News to Tusky
Fixes #1132 