### PR TITLE
add hashtag tabs

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/TabData.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/TabData.kt
@@ -29,20 +29,22 @@ const val NOTIFICATIONS = "Notifications"
 const val LOCAL = "Local"
 const val FEDERATED = "Federated"
 const val DIRECT = "Direct"
+const val HASHTAG = "Hashtag"
 
 data class TabData(val id: String,
                    @StringRes val text: Int,
                    @DrawableRes val icon: Int,
-                   val fragment: () -> Fragment)
+                   val fragment: (List<String>) -> Fragment,
+                   val arguments: List<String> = emptyList())
 
-
-fun createTabDataFromId(id: String): TabData {
+fun createTabDataFromId(id: String, arguments: List<String> = emptyList()): TabData {
     return when (id) {
-        HOME -> TabData(HOME, R.string.title_home, R.drawable.ic_home_24dp) { TimelineFragment.newInstance(TimelineFragment.Kind.HOME) }
-        NOTIFICATIONS -> TabData(NOTIFICATIONS, R.string.title_notifications, R.drawable.ic_notifications_24dp) { NotificationsFragment.newInstance() }
-        LOCAL -> TabData(LOCAL, R.string.title_public_local, R.drawable.ic_local_24dp) { TimelineFragment.newInstance(TimelineFragment.Kind.PUBLIC_LOCAL) }
-        FEDERATED -> TabData(FEDERATED, R.string.title_public_federated, R.drawable.ic_public_24dp) { TimelineFragment.newInstance(TimelineFragment.Kind.PUBLIC_FEDERATED) }
-        DIRECT -> TabData(DIRECT, R.string.title_direct_messages, R.drawable.reblog_direct_dark) { ConversationsFragment.newInstance() }
+        HOME -> TabData(HOME, R.string.title_home, R.drawable.ic_home_24dp, { TimelineFragment.newInstance(TimelineFragment.Kind.HOME) })
+        NOTIFICATIONS -> TabData(NOTIFICATIONS, R.string.title_notifications, R.drawable.ic_notifications_24dp, { NotificationsFragment.newInstance() })
+        LOCAL -> TabData(LOCAL, R.string.title_public_local, R.drawable.ic_local_24dp, { TimelineFragment.newInstance(TimelineFragment.Kind.PUBLIC_LOCAL) })
+        FEDERATED -> TabData(FEDERATED, R.string.title_public_federated, R.drawable.ic_public_24dp, { TimelineFragment.newInstance(TimelineFragment.Kind.PUBLIC_FEDERATED) })
+        DIRECT -> TabData(DIRECT, R.string.title_direct_messages, R.drawable.reblog_direct_dark, { ConversationsFragment.newInstance() })
+        HASHTAG -> TabData(HASHTAG, R.string.hashtag, R.drawable.ic_hashtag, { args -> TimelineFragment.newInstance(TimelineFragment.Kind.TAG, args.getOrNull(0).orEmpty()) }, arguments)
         else -> throw IllegalArgumentException("unknown tab type")
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/TabAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/TabAdapter.kt
@@ -19,15 +19,14 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
-
 import androidx.recyclerview.widget.RecyclerView
 import com.keylesspalace.tusky.HASHTAG
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.TabData
 import com.keylesspalace.tusky.util.ThemeUtils
-import kotlinx.android.synthetic.main.item_tab_preference.view.*
 import com.keylesspalace.tusky.util.hide
 import com.keylesspalace.tusky.util.show
+import kotlinx.android.synthetic.main.item_tab_preference.view.*
 
 
 interface ItemInteractionListener {
@@ -47,7 +46,7 @@ class TabAdapter(private var data: List<TabData>,
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val layoutId = if(small) {
+        val layoutId = if (small) {
             R.layout.item_tab_preference_small
         } else {
             R.layout.item_tab_preference
@@ -61,13 +60,13 @@ class TabAdapter(private var data: List<TabData>,
         holder.itemView.textView.setText(data[position].text)
         val iconDrawable = ThemeUtils.getTintedDrawable(context, data[position].icon, android.R.attr.textColorSecondary)
         holder.itemView.textView.setCompoundDrawablesRelativeWithIntrinsicBounds(iconDrawable, null, null, null)
-        if(small) {
+        if (small) {
             holder.itemView.textView.setOnClickListener {
                 listener?.onTabAdded(data[position])
             }
         }
         holder.itemView.imageView?.setOnTouchListener { _, event ->
-            if(event.action == MotionEvent.ACTION_DOWN) {
+            if (event.action == MotionEvent.ACTION_DOWN) {
                 listener?.onStartDrag(holder)
                 true
             } else {
@@ -75,13 +74,12 @@ class TabAdapter(private var data: List<TabData>,
             }
         }
 
-        if(!small) {
+        if (!small) {
 
             if (data[position].id == HASHTAG) {
                 holder.itemView.chipGroup.show()
                 holder.itemView.actionChip.text = data[position].arguments[0]
 
-                // starting from O we use the adaptive drawable that does not need theming
                 holder.itemView.actionChip.setChipIconResource(R.drawable.ic_edit_chip)
 
                 holder.itemView.actionChip.chipIcon = context.getDrawable(R.drawable.ic_edit_chip)

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/TabAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/TabAdapter.kt
@@ -21,20 +21,25 @@ import android.view.View
 import android.view.ViewGroup
 
 import androidx.recyclerview.widget.RecyclerView
+import com.keylesspalace.tusky.HASHTAG
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.TabData
 import com.keylesspalace.tusky.util.ThemeUtils
 import kotlinx.android.synthetic.main.item_tab_preference.view.*
+import com.keylesspalace.tusky.util.hide
+import com.keylesspalace.tusky.util.show
+
 
 interface ItemInteractionListener {
     fun onTabAdded(tab: TabData)
     fun onStartDelete(viewHolder: RecyclerView.ViewHolder)
     fun onStartDrag(viewHolder: RecyclerView.ViewHolder)
+    fun onActionChipClicked(tab: TabData)
 }
 
-class TabAdapter(var data: List<TabData>,
-                 val small: Boolean = false,
-                 val listener: ItemInteractionListener? = null) : RecyclerView.Adapter<TabAdapter.ViewHolder>() {
+class TabAdapter(private var data: List<TabData>,
+                 private val small: Boolean = false,
+                 private val listener: ItemInteractionListener? = null) : RecyclerView.Adapter<TabAdapter.ViewHolder>() {
 
     fun updateData(newData: List<TabData>) {
         this.data = newData
@@ -52,8 +57,9 @@ class TabAdapter(var data: List<TabData>,
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val context = holder.itemView.context
         holder.itemView.textView.setText(data[position].text)
-        val iconDrawable = ThemeUtils.getTintedDrawable(holder.itemView.context, data[position].icon, android.R.attr.textColorSecondary)
+        val iconDrawable = ThemeUtils.getTintedDrawable(context, data[position].icon, android.R.attr.textColorSecondary)
         holder.itemView.textView.setCompoundDrawablesRelativeWithIntrinsicBounds(iconDrawable, null, null, null)
         if(small) {
             holder.itemView.textView.setOnClickListener {
@@ -68,9 +74,26 @@ class TabAdapter(var data: List<TabData>,
                 false
             }
         }
+
+        if(!small) {
+
+            if (data[position].id == HASHTAG) {
+                holder.itemView.chipGroup.show()
+                holder.itemView.actionChip.text = data[position].arguments[0]
+
+                // starting from O we use the adaptive drawable that does not need theming
+                holder.itemView.actionChip.setChipIconResource(R.drawable.ic_edit_chip)
+
+                holder.itemView.actionChip.chipIcon = context.getDrawable(R.drawable.ic_edit_chip)
+                holder.itemView.actionChip.setOnClickListener {
+                    listener?.onActionChipClicked(data[position])
+                }
+
+            } else {
+                holder.itemView.chipGroup.hide()
+            }
+        }
     }
-
-
 
     override fun getItemCount(): Int {
         return data.size

--- a/app/src/main/java/com/keylesspalace/tusky/db/Converters.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/Converters.kt
@@ -58,12 +58,15 @@ class Converters {
     @TypeConverter
     fun stringToTabData(str: String?): List<TabData>? {
         return str?.split(";")
-                ?.map { createTabDataFromId(it) }
+                ?.map {
+                    val data = it.split(":")
+                    createTabDataFromId(data[0], data.drop(1))
+                }
     }
 
     @TypeConverter
     fun tabDataToString(tabData: List<TabData>?): String? {
-        return tabData?.joinToString(";") { it.id }
+        return tabData?.joinToString(";") { it.id + ":" + it.arguments.joinToString(":") }
     }
 
     @TypeConverter

--- a/app/src/main/java/com/keylesspalace/tusky/pager/MainPagerAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/pager/MainPagerAdapter.kt
@@ -24,7 +24,8 @@ import com.keylesspalace.tusky.TabData
 class MainPagerAdapter(val tabs: List<TabData>, manager: FragmentManager) : FragmentPagerAdapter(manager) {
 
     override fun getItem(position: Int): Fragment {
-        return tabs[position].fragment()
+        val tab = tabs[position]
+        return tab.fragment(tab.arguments)
     }
 
     override fun getCount(): Int {
@@ -36,7 +37,7 @@ class MainPagerAdapter(val tabs: List<TabData>, manager: FragmentManager) : Frag
     }
 
     override fun getItemId(position: Int): Long {
-        return tabs[position].id.hashCode().toLong()
+        return tabs[position].hashCode() + position.toLong()
     }
 
     override fun getItemPosition(item: Any): Int {

--- a/app/src/main/java/com/keylesspalace/tusky/util/ViewExtensions.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ViewExtensions.kt
@@ -34,20 +34,20 @@ fun View.visible(visible: Boolean, or: Int = View.GONE) {
 }
 
 open class DefaultTextWatcher : TextWatcher {
-    override fun afterTextChanged(s: Editable?) {
+    override fun afterTextChanged(s: Editable) {
     }
 
-    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+    override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {
     }
 
-    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+    override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
     }
 }
 
 inline fun EditText.onTextChanged(
-        crossinline callback: (s: CharSequence?, start: Int, before: Int, count: Int) -> Unit) {
+        crossinline callback: (s: CharSequence, start: Int, before: Int, count: Int) -> Unit) {
     addTextChangedListener(object : DefaultTextWatcher() {
-        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+        override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
             callback(s, start, before, count)
         }
     })

--- a/app/src/main/res/drawable-v26/ic_edit_chip.xml
+++ b/app/src/main/res/drawable-v26/ic_edit_chip.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="24dp"
+    android:layout_height="24dp">
+    <background android:drawable="@color/tusky_blue" />
+    <foreground>
+        <inset
+            android:drawable="@drawable/ic_create_24dp"
+            android:inset="30%" />
+    </foreground>
+</adaptive-icon>

--- a/app/src/main/res/drawable/ic_edit_chip.xml
+++ b/app/src/main/res/drawable/ic_edit_chip.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?android:attr/textColorPrimary"
+        android:pathData="m4.5088,16.3703v3.1209H7.6297L16.8342,10.2866 13.7134,7.1658ZM19.2477,7.8732c0.3246,-0.3246 0.3246,-0.8489 0,-1.1735l-1.9474,-1.9474c-0.3246,-0.3246 -0.8489,-0.3246 -1.1735,0l-1.523,1.523 3.1209,3.1209z" />
+</vector>

--- a/app/src/main/res/drawable/ic_hashtag.xml
+++ b/app/src/main/res/drawable/ic_hashtag.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#000" android:pathData="M5.41,21L6.12,17H2.12L2.47,15H6.47L7.53,9H3.53L3.88,7H7.88L8.59,3H10.59L9.88,7H15.88L16.59,3H18.59L17.88,7H21.88L21.53,9H17.53L16.47,15H20.47L20.12,17H16.12L15.41,21H13.41L14.12,17H8.12L7.41,21H5.41M9.53,9L8.47,15H14.47L15.53,9H9.53Z" />
+</vector>

--- a/app/src/main/res/layout/item_tab_preference.xml
+++ b/app/src/main/res/layout/item_tab_preference.xml
@@ -6,7 +6,9 @@
     android:layout_height="wrap_content"
     android:background="?android:colorBackground"
     android:orientation="horizontal"
-    android:padding="16dp">
+    android:paddingStart="16dp"
+    android:paddingTop="16dp"
+    android:paddingEnd="16dp">
 
     <ImageView
         android:id="@+id/imageView"
@@ -30,6 +32,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/imageView"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_goneMarginBottom="16dp"
         tools:drawableStart="@drawable/ic_home_24dp"
         tools:text="Home" />
 
@@ -38,6 +41,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="32dp"
+        android:layout_marginBottom="8dp"
         android:paddingTop="8dp"
         app:layout_constraintBottom_toBottomOf="parent">
 

--- a/app/src/main/res/layout/item_tab_preference.xml
+++ b/app/src/main/res/layout/item_tab_preference.xml
@@ -1,28 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="?android:colorBackground"
-        android:orientation="horizontal"
-        android:padding="16dp">
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:colorBackground"
+    android:orientation="horizontal"
+    android:padding="16dp">
+
     <ImageView
         android:id="@+id/imageView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_gravity="end"
         android:src="@drawable/ic_drag_indicator_24dp"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/textView"
-            android:textSize="?attr/status_text_large"
-            android:textColor="?android:attr/textColorSecondary"
-            android:drawableStart="@drawable/ic_home_24dp"
-            android:layout_width="0dp"
-            android:layout_marginStart="8dp"
-            android:drawablePadding="12dp"
-            android:layout_weight="1"
-            android:layout_height="wrap_content"/>
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_weight="1"
+        android:drawablePadding="12dp"
+        android:textColor="?android:attr/textColorSecondary"
+        android:textSize="?attr/status_text_large"
+        app:layout_constraintBottom_toTopOf="@id/chipGroup"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/imageView"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:drawableStart="@drawable/ic_home_24dp"
+        tools:text="Home" />
 
+    <com.google.android.material.chip.ChipGroup
+        android:id="@+id/chipGroup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:paddingTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent">
 
-    </LinearLayout>
+        <com.google.android.material.chip.Chip
+            android:id="@+id/actionChip"
+            style="@style/Widget.MaterialComponents.Chip.Action"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checkable="false"
+            tools:text="add hashtag" />
+
+    </com.google.android.material.chip.ChipGroup>
+
+</androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -447,4 +447,9 @@
 
     <string name="hint_list_name">List name</string>
 
+    <string name="edit_hashtag_title">Edit hashtag</string>
+    <string name="edit_hashtag_message">Hashtag without #</string>
+    <string name="hashtag">Hashtag</string>
+
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -458,7 +458,7 @@
     <string name="hint_list_name">List name</string>
 
     <string name="edit_hashtag_title">Edit hashtag</string>
-    <string name="edit_hashtag_message">Hashtag without #</string>
+    <string name="edit_hashtag_hint">Hashtag without #</string>
     <string name="hashtag">Hashtag</string>
 
 


### PR DESCRIPTION
- For now, supporting only one hashtag. But datastructure and layout is ready for multiple hashtags. I think we need to use the search endpoint with pagination for multiple hashtags.
- there can be multiple hashtag tabs, as opposed to the other tab types

![device-2019-03-23-120346](https://user-images.githubusercontent.com/10157047/54865308-ed4f2980-4d63-11e9-80b0-e0515205d62d.png)
