### PR TITLE
fix crash when filter request returns an error

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -319,13 +319,18 @@ public class TimelineFragment extends SFragment implements
     private void reloadFilters(boolean refresh) {
         mastodonApi.getFilters().enqueue(new Callback<List<Filter>>() {
             @Override
-            public void onResponse(Call<List<Filter>> call, Response<List<Filter>> response) {
-                applyFilters(response.body(), refresh);
+            public void onResponse(@NonNull Call<List<Filter>> call, @NonNull Response<List<Filter>> response) {
+                List<Filter> filterList = response.body();
+                if(response.isSuccessful() && filterList != null) {
+                    applyFilters(filterList, refresh);
+                } else {
+                    Log.e(TAG, "Error getting filters from server");
+                }
             }
 
             @Override
-            public void onFailure(Call<List<Filter>> call, Throwable t) {
-                Log.e(TAG, "Error getting filters from server");
+            public void onFailure(@NonNull Call<List<Filter>> call, @NonNull Throwable t) {
+                Log.e(TAG, "Error getting filters from server", t);
             }
         });
     }


### PR DESCRIPTION
happens, for example, when the instance is on a mastodon version that does not support filters yet

cc @Tak 