### PR TITLE
Fix word boundary detection in filters

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -69,7 +69,6 @@ import com.keylesspalace.tusky.viewdata.StatusViewData;
 import java.util.ArrayList;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -364,7 +363,7 @@ public class TimelineFragment extends SFragment implements
 
     private static String filterToRegexToken(Filter filter) {
         String phrase = Pattern.quote(filter.getPhrase());
-        return filter.getWholeWord() ? String.format("\\b%s\\b", phrase) : phrase;
+        return filter.getWholeWord() ? String.format("(^|\\W)%s($|\\W)", phrase) : phrase;
     }
 
     private void applyFilters(List<Filter> filters, boolean refresh) {


### PR DESCRIPTION
It was failing for "whole-word" filters where the beginning or end of the filter was a non-word character, e.g. `#meh`, because the word-boundary class doesn't match for two adjacent non-word characters.

I thought this was too straightforward to warrant test coverage; looks like the joke's on me. I'll add some in a followup PR.

