### PR TITLE
fix crash in TimelineFragment

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -853,6 +853,12 @@ public class TimelineFragment extends SFragment implements
         if (didLoadEverythingBottom || bottomLoading) {
             return;
         }
+
+        if(statuses.size() == 0) {
+            sendInitialRequest();
+            return;
+        }
+
         bottomLoading = true;
 
         Either<Placeholder, Status> last = statuses.get(statuses.size() - 1);


### PR DESCRIPTION
Fix this shit AGAIN, this time for real hopefully.

The steps to reproduce it this time are:
- Find a hashtag where only one users posts, go to that hashtags timeline (or add it as a tab)
- mute that one user
- crash

thx to @MasterGroosha for finding it

closes #1087