### PR TITLE
disable language splitting for app bundle builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,6 +72,12 @@ android {
         exclude 'LICENSE_OFL'
         exclude 'LICENSE_UNICODE'
     }
+    bundle {
+        language {
+            // bundle all languages in every apk so the dynamic language switching works
+            enableSplit = false
+        }
+    }
 }
 
 ext.daggerVersion = '2.21'


### PR DESCRIPTION
The dynamic language switching is not working with apks downloaded from Google Play because Play does not deliver all languages in the split apks. 
There are 2 ways of fixing that: https://stackoverflow.com/questions/52731670/android-app-bundle-with-in-app-locale-change
I don't want to use this PlayCore API as it seems to be proprietary, so lets go with this.