### PR TITLE
Fix wrong notification avatar being displayed sometimes

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -503,7 +503,6 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
                 Picasso.with(context)
                         .load(notificationAvatarUrl)
                         .placeholder(R.drawable.avatar_default)
-                        .fit()
                         .into(notificationAvatar);
             }
         }


### PR DESCRIPTION
bug report: https://github.com/tuskyapp/Tusky/pull/1130#issuecomment-477482909 thx @kyori19 

Im not sure it is actually caused by #1130, it probably just made the bug appear more often.

Removing the `fit()` fixes the problem. The weird thing was that only the notification icon was wrong - so it had to have something to do with Picasso. If it was a recycling issue more stuff would have been wrong.