### PR TITLE
Basic support for delete & redraft

### DIFF
--- a/app/src/main/res/menu/status_more_for_user.xml
+++ b/app/src/main/res/menu/status_more_for_user.xml
@@ -29,4 +29,7 @@
     <item
         android:id="@+id/status_delete"
         android:title="@string/action_delete" />
+    <item
+	android:title="@string/action_redraft"
+	android:id="@+id/status_redraft" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -403,6 +403,8 @@
 
     <string name="unpin_action">Unpin</string>
     <string name="pin_action">Pin</string>
+    <string name="action_redraft">Delete and Redraft</string>
+    <string name="dialog_redraft_toot_warning">Are you sure you want to delete this status and re-draft it? Favourites and boosts will be lost, and replies to the original post will be orphaned. Additionally, all attached media and descriptions will be discarded.</string>
 
     <plurals name="favs">
         <item quantity="one">&lt;b>%1$s&lt;/b> Favourite</item>


### PR DESCRIPTION
Adding support for delete&redraft of statuses

It still doesn't support persisting media attachments, but that doesn't seem very straightforward, and this has just been sitting in my fork for months, so maybe it's better to just land this version, warn users that their attachments will be discarded, and add attachment persistence whenever somebody has the motivation to do so.