### PR TITLE
Add bot indicator overlay to avatars

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.kt
@@ -143,6 +143,9 @@ class PreferencesActivity : BaseActivity(), SharedPreferences.OnSharedPreference
             "absoluteTimeView" -> {
                 restartActivitiesOnExit = true
             }
+            "showBotOverlay" -> {
+                restartActivitiesOnExit = true
+            }
             "language" -> {
                 restartActivitiesOnExit = true
                 this.restartCurrentActivity()

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/AccountViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/AccountViewHolder.java
@@ -17,6 +17,7 @@ class AccountViewHolder extends RecyclerView.ViewHolder {
     private TextView username;
     private TextView displayName;
     private ImageView avatar;
+    private ImageView avatarInset;
     private String accountId;
 
     AccountViewHolder(View itemView) {
@@ -24,6 +25,7 @@ class AccountViewHolder extends RecyclerView.ViewHolder {
         username = itemView.findViewById(R.id.account_username);
         displayName = itemView.findViewById(R.id.account_display_name);
         avatar = itemView.findViewById(R.id.account_avatar);
+        avatarInset = itemView.findViewById(R.id.account_avatar_inset);
     }
 
     void setupWithAccount(Account account) {
@@ -38,6 +40,13 @@ class AccountViewHolder extends RecyclerView.ViewHolder {
                 .load(account.getAvatar())
                 .placeholder(R.drawable.avatar_default)
                 .into(avatar);
+        if (account.getBot()) {
+            avatarInset.setVisibility(View.VISIBLE);
+            avatarInset.setImageResource(R.drawable.ic_bot_24dp);
+            avatarInset.setBackgroundColor(0x50ffffff);
+        } else {
+            avatarInset.setVisibility(View.GONE);
+        }
     }
 
     void setupActionListener(final AccountActionListener listener) {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/AccountViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/AccountViewHolder.java
@@ -2,6 +2,8 @@ package com.keylesspalace.tusky.adapter;
 
 import android.content.Context;
 import androidx.recyclerview.widget.RecyclerView;
+
+import android.preference.PreferenceManager;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -19,6 +21,7 @@ class AccountViewHolder extends RecyclerView.ViewHolder {
     private ImageView avatar;
     private ImageView avatarInset;
     private String accountId;
+    private boolean showBotOverlay;
 
     AccountViewHolder(View itemView) {
         super(itemView);
@@ -26,6 +29,7 @@ class AccountViewHolder extends RecyclerView.ViewHolder {
         displayName = itemView.findViewById(R.id.account_display_name);
         avatar = itemView.findViewById(R.id.account_avatar);
         avatarInset = itemView.findViewById(R.id.account_avatar_inset);
+        showBotOverlay = PreferenceManager.getDefaultSharedPreferences(itemView.getContext()).getBoolean("showBotOverlay", true);
     }
 
     void setupWithAccount(Account account) {
@@ -40,7 +44,7 @@ class AccountViewHolder extends RecyclerView.ViewHolder {
                 .load(account.getAvatar())
                 .placeholder(R.drawable.avatar_default)
                 .into(avatar);
-        if (account.getBot()) {
+        if (showBotOverlay && account.getBot()) {
             avatarInset.setVisibility(View.VISIBLE);
             avatarInset.setImageResource(R.drawable.ic_bot_24dp);
             avatarInset.setBackgroundColor(0x50ffffff);

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -2,6 +2,7 @@ package com.keylesspalace.tusky.adapter;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
+import android.preference.PreferenceManager;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.view.View;
@@ -72,6 +73,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
     private boolean useAbsoluteTime;
     private SimpleDateFormat shortSdf;
     private SimpleDateFormat longSdf;
+    private boolean showBotOverlay;
 
     private final NumberFormat numberFormat = NumberFormat.getNumberInstance();
 
@@ -110,6 +112,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         this.useAbsoluteTime = useAbsoluteTime;
         shortSdf = new SimpleDateFormat("HH:mm:ss", Locale.getDefault());
         longSdf = new SimpleDateFormat("MM/dd HH:mm:ss", Locale.getDefault());
+        showBotOverlay = PreferenceManager.getDefaultSharedPreferences(itemView.getContext()).getBoolean("showBotOverlay", true);
     }
 
     protected abstract int getMediaPreviewHeight(Context context);
@@ -185,7 +188,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                     .into(avatar);
         }
 
-        if (isBot && TextUtils.isEmpty(rebloggedUrl)) {
+        if (showBotOverlay && isBot && TextUtils.isEmpty(rebloggedUrl)) {
             avatarInset.setVisibility(View.VISIBLE);
             avatarInset.setImageResource(R.drawable.ic_bot_24dp);
             avatarInset.setBackgroundColor(0x50ffffff);

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -188,7 +188,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         if (isBot && TextUtils.isEmpty(rebloggedUrl)) {
             avatarInset.setVisibility(View.VISIBLE);
             avatarInset.setImageResource(R.drawable.ic_bot_24dp);
-            avatarInset.setBackgroundColor(0x80ffffff);
+            avatarInset.setBackgroundColor(0x50ffffff);
         } else {
             avatarInset.setVisibility(View.GONE);
         }

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -62,6 +62,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
     private View sensitiveMediaShow;
     protected TextView mediaLabel;
     private ToggleButton contentWarningButton;
+    protected ImageView avatarInset;
 
     public ImageView avatar;
     public TextView timestampInfo;
@@ -82,7 +83,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         content = itemView.findViewById(R.id.status_content);
         avatar = itemView.findViewById(R.id.status_avatar);
         replyButton = itemView.findViewById(R.id.status_reply);
-        reblogButton = itemView.findViewById(R.id.status_reblog);
+        reblogButton = itemView.findViewById(R.id.status_inset);
         favouriteButton = itemView.findViewById(R.id.status_favourite);
         moreButton = itemView.findViewById(R.id.status_more);
         reblogged = false;
@@ -104,6 +105,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         mediaLabel = itemView.findViewById(R.id.status_media_label);
         contentWarningDescription = itemView.findViewById(R.id.status_content_warning_description);
         contentWarningButton = itemView.findViewById(R.id.status_content_warning_button);
+        avatarInset = itemView.findViewById(R.id.status_avatar_inset);
 
         this.useAbsoluteTime = useAbsoluteTime;
         shortSdf = new SimpleDateFormat("HH:mm:ss", Locale.getDefault());
@@ -173,7 +175,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         }
     }
 
-    protected void setAvatar(String url, @Nullable String rebloggedUrl) {
+    protected void setAvatar(String url, @Nullable String rebloggedUrl, boolean isBot) {
         if (TextUtils.isEmpty(url)) {
             avatar.setImageResource(R.drawable.avatar_default);
         } else {
@@ -181,6 +183,14 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                     .load(url)
                     .placeholder(R.drawable.avatar_default)
                     .into(avatar);
+        }
+
+        if (isBot && TextUtils.isEmpty(rebloggedUrl)) {
+            avatarInset.setVisibility(View.VISIBLE);
+            avatarInset.setImageResource(R.drawable.ic_bot_24dp);
+            avatarInset.setBackgroundColor(0x80ffffff);
+        } else {
+            avatarInset.setVisibility(View.GONE);
         }
     }
 
@@ -555,7 +565,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             setUsername(status.getNickname());
             setCreatedAt(status.getCreatedAt());
             setIsReply(status.getInReplyToId() != null);
-            setAvatar(status.getAvatar(), status.getRebloggedAvatar());
+            setAvatar(status.getAvatar(), status.getRebloggedAvatar(), status.isBot());
             setReblogged(status.isReblogged());
             setFavourited(status.isFavourited());
             List<Attachment> attachments = status.getAttachments();

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusViewHolder.java
@@ -17,6 +17,7 @@ package com.keylesspalace.tusky.adapter;
 
 import android.content.Context;
 import android.text.InputFilter;
+import android.text.TextUtils;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -36,35 +37,28 @@ public class StatusViewHolder extends StatusBaseViewHolder {
     private static final InputFilter[] COLLAPSE_INPUT_FILTER = new InputFilter[]{SmartLengthInputFilter.INSTANCE};
     private static final InputFilter[] NO_INPUT_FILTER = new InputFilter[0];
 
-    private ImageView avatarReblog;
     private TextView rebloggedBar;
     private ToggleButton contentCollapseButton;
 
     StatusViewHolder(View itemView, boolean useAbsoluteTime) {
         super(itemView, useAbsoluteTime);
-        avatarReblog = itemView.findViewById(R.id.status_avatar_reblog);
         rebloggedBar = itemView.findViewById(R.id.status_reblogged);
         contentCollapseButton = itemView.findViewById(R.id.button_toggle_content);
     }
 
     @Override
-    protected void setAvatar(String url, @Nullable String rebloggedUrl) {
-        super.setAvatar(url, rebloggedUrl);
-
+    protected void setAvatar(String url, @Nullable String rebloggedUrl, boolean isBot) {
+        super.setAvatar(url, rebloggedUrl, isBot);
         Context context = avatar.getContext();
-        boolean hasReblog = rebloggedUrl != null && !rebloggedUrl.isEmpty();
-        int padding = hasReblog ? Utils.dpToPx(context, 12) : 0;
 
-        avatar.setPaddingRelative(0, 0, padding, padding);
-
-        if (hasReblog) {
-            avatarReblog.setVisibility(View.VISIBLE);
+        if (!TextUtils.isEmpty(rebloggedUrl)) {
+            int padding = Utils.dpToPx(context, 12);
+            avatar.setPaddingRelative(0, 0, padding, padding);
+            avatarInset.setVisibility(View.VISIBLE);
             Picasso.with(context)
                     .load(rebloggedUrl)
                     .placeholder(R.drawable.avatar_default)
-                    .into(avatarReblog);
-        } else {
-            avatarReblog.setVisibility(View.GONE);
+                    .into(avatarInset);
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/util/ViewDataUtils.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ViewDataUtils.java
@@ -63,6 +63,8 @@ public final class ViewDataUtils {
                         SmartLengthInputFilter.LENGTH_DEFAULT
                 ))
                 .setCollapsed(true)
+                .setIsBot(visibleStatus.getAccount().getBot())
+
                 .createStatusViewData();
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.java
+++ b/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.java
@@ -87,6 +87,7 @@ public abstract class StatusViewData {
         private final Card card;
         private final boolean isCollapsible; /** Whether the status meets the requirement to be collapse */
         final boolean isCollapsed; /** Whether the status is shown partially or fully */
+        private final boolean isBot;
 
         public Concrete(String id, Spanned content, boolean reblogged, boolean favourited,
                         @Nullable String spoilerText, Status.Visibility visibility, List<Attachment> attachments,
@@ -95,7 +96,7 @@ public abstract class StatusViewData {
                         Date createdAt, int reblogsCount, int favouritesCount, @Nullable String inReplyToId,
                         @Nullable Status.Mention[] mentions, String senderId, boolean rebloggingEnabled,
                         Status.Application application, List<Emoji> statusEmojis, List<Emoji> accountEmojis, @Nullable Card card,
-                        boolean isCollapsible, boolean isCollapsed) {
+                        boolean isCollapsible, boolean isCollapsed, boolean isBot) {
             this.id = id;
             if (Build.VERSION.SDK_INT == 23) {
                 // https://github.com/tuskyapp/Tusky/issues/563
@@ -131,6 +132,7 @@ public abstract class StatusViewData {
             this.card = card;
             this.isCollapsible = isCollapsible;
             this.isCollapsed = isCollapsed;
+            this.isBot = isBot;
         }
 
         public String getId() {
@@ -178,6 +180,8 @@ public abstract class StatusViewData {
         public boolean isShowingContent() {
             return isShowingContent;
         }
+
+        public boolean isBot(){ return isBot; }
 
         @Nullable
         public String getRebloggedAvatar() {
@@ -277,6 +281,7 @@ public abstract class StatusViewData {
                     isSensitive == concrete.isSensitive &&
                     isExpanded == concrete.isExpanded &&
                     isShowingContent == concrete.isShowingContent &&
+                    isBot == concrete.isBot &&
                     reblogsCount == concrete.reblogsCount &&
                     favouritesCount == concrete.favouritesCount &&
                     rebloggingEnabled == concrete.rebloggingEnabled &&
@@ -402,6 +407,7 @@ public abstract class StatusViewData {
         private Card card;
         private boolean isCollapsible; /** Whether the status meets the requirement to be collapsed */
         private boolean isCollapsed; /** Whether the status is shown partially or fully */
+        private boolean isBot;
 
         public Builder() {
         }
@@ -435,6 +441,7 @@ public abstract class StatusViewData {
             card = viewData.getCard();
             isCollapsible = viewData.isCollapsible();
             isCollapsed = viewData.isCollapsed();
+            isBot = viewData.isBot();
         }
 
         public Builder setId(String id) {
@@ -494,6 +501,11 @@ public abstract class StatusViewData {
 
         public Builder setIsShowingSensitiveContent(boolean isShowingSensitiveContent) {
             this.isShowingContent = isShowingSensitiveContent;
+            return this;
+        }
+
+        public Builder setIsBot(boolean isBot) {
+            this.isBot = isBot;
             return this;
         }
 
@@ -600,7 +612,7 @@ public abstract class StatusViewData {
                     attachments, rebloggedByUsername, rebloggedAvatar, isSensitive, isExpanded,
                     isShowingContent, userFullName, nickname, avatar, createdAt, reblogsCount,
                     favouritesCount, inReplyToId, mentions, senderId, rebloggingEnabled, application,
-                    statusEmojis, accountEmojis, card, isCollapsible, isCollapsed);
+                    statusEmojis, accountEmojis, card, isCollapsible, isCollapsed, isBot);
         }
     }
 }

--- a/app/src/main/res/drawable/ic_bot_24dp.xml
+++ b/app/src/main/res/drawable/ic_bot_24dp.xml
@@ -1,9 +1,8 @@
+<!-- drawable/robot.xml -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
     android:height="24dp"
+    android:width="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
-  <path
-      android:fillColor="#FF000000"
-      android:pathData="M15,9L9,9v6h6L15,9zM13,13h-2v-2h2v2zM21,11L21,9h-2L19,7c0,-1.1 -0.9,-2 -2,-2h-2L15,3h-2v2h-2L11,3L9,3v2L7,5c-1.1,0 -2,0.9 -2,2v2L3,9v2h2v2L3,13v2h2v2c0,1.1 0.9,2 2,2h2v2h2v-2h2v2h2v-2h2c1.1,0 2,-0.9 2,-2v-2h2v-2h-2v-2h2zM17,17L7,17L7,7h10v10z"/>
+    <path android:fillColor="#000" android:pathData="M12,2A2,2 0 0,1 14,4C14,4.74 13.6,5.39 13,5.73V7H14A7,7 0 0,1 21,14H22A1,1 0 0,1 23,15V18A1,1 0 0,1 22,19H21V20A2,2 0 0,1 19,22H5A2,2 0 0,1 3,20V19H2A1,1 0 0,1 1,18V15A1,1 0 0,1 2,14H3A7,7 0 0,1 10,7H11V5.73C10.4,5.39 10,4.74 10,4A2,2 0 0,1 12,2M7.5,13A2.5,2.5 0 0,0 5,15.5A2.5,2.5 0 0,0 7.5,18A2.5,2.5 0 0,0 10,15.5A2.5,2.5 0 0,0 7.5,13M16.5,13A2.5,2.5 0 0,0 14,15.5A2.5,2.5 0 0,0 16.5,18A2.5,2.5 0 0,0 19,15.5A2.5,2.5 0 0,0 16.5,13Z" />
 </vector>

--- a/app/src/main/res/drawable/ic_bot_24dp.xml
+++ b/app/src/main/res/drawable/ic_bot_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M15,9L9,9v6h6L15,9zM13,13h-2v-2h2v2zM21,11L21,9h-2L19,7c0,-1.1 -0.9,-2 -2,-2h-2L15,3h-2v2h-2L11,3L9,3v2L7,5c-1.1,0 -2,0.9 -2,2v2L3,9v2h2v2L3,13v2h2v2c0,1.1 0.9,2 2,2h2v2h2v-2h2v2h2v-2h2c1.1,0 2,-0.9 2,-2v-2h2v-2h-2v-2h2zM17,17L7,17L7,7h10v10z"/>
+</vector>

--- a/app/src/main/res/layout/item_account.xml
+++ b/app/src/main/res/layout/item_account.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/account_container"
     android:layout_width="match_parent"
     android:layout_height="72dp"
@@ -12,14 +13,31 @@
         android:id="@+id/account_avatar"
         android:layout_width="48dp"
         android:layout_height="48dp"
-        android:layout_centerVertical="true"
-        android:layout_marginEnd="24dp" />
+        android:foregroundGravity="center_vertical"
+        android:layout_marginEnd="24dp"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <com.keylesspalace.tusky.view.RoundedImageView
+        android:id="@+id/account_avatar_inset"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:contentDescription="@null"
+        android:importantForAccessibility="no"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/account_avatar"
+        app:layout_constraintEnd_toEndOf="@id/account_avatar"
+        tools:src="@color/accent"
+        tools:visibility="visible" />
+
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:layout_toEndOf="@id/account_avatar"
+        app:layout_constraintStart_toEndOf="@id/account_avatar"
         android:gravity="center_vertical"
+        android:layout_marginStart="14dp"
         android:orientation="vertical">
 
         <androidx.emoji.widget.EmojiTextView
@@ -45,4 +63,4 @@
 
     </LinearLayout>
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_conversation.xml
+++ b/app/src/main/res/layout/item_conversation.xml
@@ -69,7 +69,7 @@
         tools:src="@drawable/avatar_default" />
 
     <com.keylesspalace.tusky.view.RoundedImageView
-        android:id="@+id/status_avatar_reblog"
+        android:id="@+id/status_avatar_inset"
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:contentDescription="@null"

--- a/app/src/main/res/layout/item_status.xml
+++ b/app/src/main/res/layout/item_status.xml
@@ -44,7 +44,7 @@
         tools:src="@drawable/avatar_default" />
 
     <com.keylesspalace.tusky.view.RoundedImageView
-        android:id="@+id/status_avatar_reblog"
+        android:id="@+id/status_avatar_inset"
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:contentDescription="@null"
@@ -338,14 +338,14 @@
         android:importantForAccessibility="no"
         android:padding="4dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/status_reblog"
+        app:layout_constraintEnd_toStartOf="@id/status_inset"
         app:layout_constraintHorizontal_chainStyle="spread_inside"
         app:layout_constraintStart_toStartOf="@id/status_display_name"
         app:layout_constraintTop_toBottomOf="@id/status_media_preview_container"
         app:srcCompat="@drawable/ic_reply_24dp" />
 
     <at.connyduck.sparkbutton.SparkButton
-        android:id="@+id/status_reblog"
+        android:id="@+id/status_inset"
         android:layout_width="30dp"
         android:layout_height="30dp"
         android:clipToPadding="false"
@@ -370,8 +370,8 @@
         android:importantForAccessibility="no"
         android:padding="4dp"
         app:layout_constraintEnd_toStartOf="@id/status_more"
-        app:layout_constraintStart_toEndOf="@id/status_reblog"
-        app:layout_constraintTop_toTopOf="@id/status_reblog"
+        app:layout_constraintStart_toEndOf="@id/status_inset"
+        app:layout_constraintTop_toTopOf="@id/status_inset"
         sparkbutton:activeImage="?attr/status_favourite_active_drawable"
         sparkbutton:iconSize="28dp"
         sparkbutton:inactiveImage="?attr/status_favourite_inactive_drawable"

--- a/app/src/main/res/layout/item_status_detailed.xml
+++ b/app/src/main/res/layout/item_status_detailed.xml
@@ -24,6 +24,18 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:src="@drawable/avatar_default" />
 
+    <com.keylesspalace.tusky.view.RoundedImageView
+        android:id="@+id/status_avatar_inset"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:contentDescription="@null"
+        android:importantForAccessibility="no"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/status_avatar"
+        app:layout_constraintEnd_toEndOf="@id/status_avatar"
+        tools:src="@color/accent"
+        tools:visibility="visible" />
+
     <androidx.emoji.widget.EmojiTextView
         android:id="@+id/status_display_name"
         android:layout_width="wrap_content"
@@ -408,14 +420,14 @@
         android:importantForAccessibility="no"
         android:padding="4dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/status_reblog"
+        app:layout_constraintEnd_toStartOf="@id/status_inset"
         app:layout_constraintHorizontal_chainStyle="spread_inside"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/status_buttons_divider"
         app:srcCompat="@drawable/ic_reply_24dp" />
 
     <at.connyduck.sparkbutton.SparkButton
-        android:id="@+id/status_reblog"
+        android:id="@+id/status_inset"
         android:layout_width="40dp"
         android:layout_height="40dp"
         android:clipToPadding="false"
@@ -440,8 +452,8 @@
         android:importantForAccessibility="no"
         android:padding="4dp"
         app:layout_constraintEnd_toStartOf="@id/status_more"
-        app:layout_constraintStart_toEndOf="@id/status_reblog"
-        app:layout_constraintTop_toTopOf="@id/status_reblog"
+        app:layout_constraintStart_toEndOf="@id/status_inset"
+        app:layout_constraintTop_toTopOf="@id/status_inset"
         sparkbutton:activeImage="?attr/status_favourite_active_drawable"
         sparkbutton:iconSize="28dp"
         sparkbutton:inactiveImage="?attr/status_favourite_inactive_drawable"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -463,5 +463,6 @@
 
     <string name="compose_shortcut_long_label">Compose Toot</string>
     <string name="compose_shortcut_short_label">Compose</string>
+    <string name="pref_title_bot_overlay">Show indicator for bots</string>
 
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -46,6 +46,11 @@
             android:key="absoluteTimeView"
             android:title="@string/pref_title_absolute_time" />
 
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="showBotOverlay"
+            android:title="@string/pref_title_bot_overlay" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
I saw this suggestion fly past on the federated timeline and already lost it. :grinning: 

![bot-dark-background](https://user-images.githubusercontent.com/142250/55401728-eee1d400-5551-11e9-80f0-154c7674a968.png) ![bot-light-background](https://user-images.githubusercontent.com/142250/55401729-ef7a6a80-5551-11e9-93b5-4abd68d1216a.png)

The best "bot" icon I found is the android logo, but I guess that's not ok for trademark reasons...