### PR TITLE
fix IndexOutOfBoundException caused by ListStatusAccessibilityDelegate

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -191,7 +191,7 @@ public class NotificationsFragment extends SFragment implements
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.setAccessibilityDelegateCompat(
                 new ListStatusAccessibilityDelegate(recyclerView, this, (pos) -> {
-                    NotificationViewData notification = notifications.getPairedItem(pos);
+                    NotificationViewData notification = notifications.getPairedItemOrNull(pos);
                     // We support replies only for now
                     if (notification instanceof NotificationViewData.Concrete) {
                         return ((NotificationViewData.Concrete) notification).getStatusViewData();

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -397,7 +397,7 @@ public class TimelineFragment extends SFragment implements
 
     private void setupRecyclerView() {
         recyclerView.setAccessibilityDelegateCompat(
-                new ListStatusAccessibilityDelegate(recyclerView, this, statuses::getPairedItem));
+                new ListStatusAccessibilityDelegate(recyclerView, this, statuses::getPairedItemOrNull));
         Context context = recyclerView.getContext();
         recyclerView.setHasFixedSize(true);
         layoutManager = new LinearLayoutManager(context);

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -141,7 +141,7 @@ public final class ViewThreadFragment extends SFragment implements
         LinearLayoutManager layoutManager = new LinearLayoutManager(context);
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.setAccessibilityDelegateCompat(
-                new ListStatusAccessibilityDelegate(recyclerView, this, statuses::getPairedItem));
+                new ListStatusAccessibilityDelegate(recyclerView, this, statuses::getPairedItemOrNull));
         DividerItemDecoration divider = new DividerItemDecoration(
                 context, layoutManager.getOrientation());
         recyclerView.addItemDecoration(divider);

--- a/app/src/main/java/com/keylesspalace/tusky/util/PairedList.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/PairedList.java
@@ -1,5 +1,6 @@
 package com.keylesspalace.tusky.util;
 
+import androidx.annotation.Nullable;
 import androidx.arch.core.util.Function;
 
 import java.util.AbstractList;
@@ -42,6 +43,15 @@ public final class PairedList<T, V> extends AbstractList<T> {
 
     public V getPairedItem(int index) {
         return synced.get(index);
+    }
+
+    @Nullable
+    public V getPairedItemOrNull(int index) {
+        if (index >= 0 && index < synced.size()) {
+            return synced.get(index);
+        } else {
+            return null;
+        }
     }
 
     public void setPairedItem(int index, V element) {


### PR DESCRIPTION
seeing these crashes a lot in the Play Console. No idea how to reproduce yet.

https://gist.github.com/connyduck/d82782aa502bbd997782ad3db4c9d3b0
https://gist.github.com/connyduck/eb4359c867760fe0244530027e6204f0

But seems the `ListStatusAccessibilityDelegate` actually expects nullable `StatusViewData`, so lets just give it what it wants.