### PR TITLE
Added check if text in compose toot field has only whitespaces

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
@@ -1016,7 +1016,7 @@ public final class ComposeActivity
             spoilerText = contentWarningEditor.getText().toString();
         }
         int characterCount = calculateTextLength();
-        if (characterCount <= 0 && mediaQueued.size() == 0) {
+        if ((characterCount <= 0 || contentText.trim().length() <= 0) && mediaQueued.size() == 0) {
             textEditor.setError(getString(R.string.error_empty));
             enableButtons();
         } else if (characterCount <= maximumTootCharacters) {


### PR DESCRIPTION
I'd like to fix #1192 myself. 
I'm not sure though whether my approach is the best one. 

There's a dedicated `calculateTextLength()` function, maybe I should change it to:
```java
    int calculateTextLength() {
        String composeText = textEditor.getText().toString();  // NEW
        if (composeText.trim().length() <= 0)                  // NEW
            return 0;                                          // NEW
        
        int offset = 0;
        URLSpan[] urlSpans = textEditor.getUrls();
        if (urlSpans != null) {
            for (URLSpan span : urlSpans) {
                offset += Math.max(0, span.getURL().length() - MAXIMUM_URL_LENGTH);
            }
        }
        int length = textEditor.length() - offset;
        if (statusHideText) {
            length += contentWarningEditor.length();
        }
        return length;
    }
```