### PR TITLE
fix issue with foreground service on Oreo+

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
@@ -956,7 +956,11 @@ public final class ComposeActivity
                 getIntent().getStringExtra(SAVED_JSON_URLS_EXTRA),
                 accountManager.getActiveAccount(), savedTootUid);
 
-        startService(sendIntent);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(sendIntent);
+        } else {
+            startService(sendIntent);
+        }
 
         finishWithoutSlideOutAnimation();
 


### PR DESCRIPTION
According to Google Play logs Tusky sometimes crashes with a `IllegalStateException` when sending a toot, this should fix it.

https://stackoverflow.com/questions/46445265/android-8-0-java-lang-illegalstateexception-not-allowed-to-start-service-inten