### PR TITLE
fix another issue with avatar background recycling

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -193,6 +193,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             avatarInset.setImageResource(R.drawable.ic_bot_24dp);
             avatarInset.setBackgroundColor(0x50ffffff);
         } else {
+            avatarInset.setBackground(null);
             avatarInset.setVisibility(View.GONE);
         }
     }


### PR DESCRIPTION
similar to #1199, but not as obvious (the background of the bot overlay is shown behind the small avatar)
![device-2019-04-21-162323](https://user-images.githubusercontent.com/10157047/56471451-0cb89f80-6453-11e9-8291-fb4093d4ef4f.png)

cc @Tak 