### PR TITLE
fix Glide crash in MainActivity

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.java
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.java
@@ -176,7 +176,7 @@ public interface MastodonApi {
     Single<Status> unpinStatus(@Path("id") String statusId);
 
     @GET("api/v1/accounts/verify_credentials")
-    Call<Account> accountVerifyCredentials();
+    Single<Account> accountVerifyCredentials();
 
     @FormUrlEncoded
     @PATCH("api/v1/accounts/update_credentials")

--- a/app/src/main/java/com/keylesspalace/tusky/viewmodel/EditProfileViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/viewmodel/EditProfileViewModel.kt
@@ -31,6 +31,8 @@ import com.keylesspalace.tusky.entity.StringField
 import com.keylesspalace.tusky.network.MastodonApi
 import com.keylesspalace.tusky.util.*
 import io.reactivex.Single
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.rxkotlin.addTo
 import io.reactivex.schedulers.Schedulers
 import okhttp3.MediaType
 import okhttp3.MultipartBody
@@ -63,32 +65,24 @@ class EditProfileViewModel  @Inject constructor(
 
     private var oldProfileData: Account? = null
 
-    private val callList: MutableList<Call<*>> = mutableListOf()
+    private val disposeables = CompositeDisposable()
 
     fun obtainProfile() {
         if(profileData.value == null || profileData.value is Error) {
 
             profileData.postValue(Loading())
 
-            val call = mastodonApi.accountVerifyCredentials()
-            call.enqueue(object : Callback<Account> {
-                override fun onResponse(call: Call<Account>,
-                                        response: Response<Account>) {
-                    if (response.isSuccessful) {
-                        val profile = response.body()
-                        oldProfileData = profile
-                        profileData.postValue(Success(profile))
-                    } else {
-                        profileData.postValue(Error())
-                    }
-                }
+            mastodonApi.accountVerifyCredentials()
+                    .subscribe(
+                            {profile ->
+                                oldProfileData = profile
+                                profileData.postValue(Success(profile))
+                            },
+                            {
+                                profileData.postValue(Error())
+                            })
+                    .addTo(disposeables)
 
-                override fun onFailure(call: Call<Account>, t: Throwable) {
-                    profileData.postValue(Error())
-                }
-            })
-
-            callList.add(call)
         }
     }
 
@@ -138,6 +132,7 @@ class EditProfileViewModel  @Inject constructor(
                 }, {
                     imageLiveData.postValue(Error())
                 })
+                .addTo(disposeables)
     }
 
     fun save(newDisplayName: String, newNote: String, newLocked: Boolean, newFields: List<StringField>, context: Context) {
@@ -267,9 +262,7 @@ class EditProfileViewModel  @Inject constructor(
     }
 
     override fun onCleared() {
-        callList.forEach {
-            it.cancel()
-        }
+        disposeables.dispose()
     }
 
 


### PR DESCRIPTION
Steps to reproduce: Switch between accounts quickly on a slow internet connection -> crash
Apparently glide does not like to be called on a destroyed activity, whereas Picasso did not care. Lets dispose the network calls correctly so this does no longer happen.