### PR TITLE
support custom emoji fonts in poll options

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -47,6 +47,7 @@ import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.content.res.AppCompatResources;
+import androidx.emoji.text.EmojiCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import at.connyduck.sparkbutton.SparkButton;
 import at.connyduck.sparkbutton.SparkEventListener;
@@ -878,7 +879,9 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
             for(int i = 0; i < Status.MAX_POLL_OPTIONS; i++) {
                 if(i < options.size()) {
-                    pollCheckboxOptions[i].setText(CustomEmojiHelper.emojifyString(options.get(i).getTitle(), emojis, pollCheckboxOptions[i]));
+                    CharSequence emojifiedPollOptionText = CustomEmojiHelper.emojifyString(options.get(i).getTitle(), emojis, pollCheckboxOptions[i]);
+                    emojifiedPollOptionText = EmojiCompat.get().process(emojifiedPollOptionText);
+                    pollCheckboxOptions[i].setText(emojifiedPollOptionText);
                     pollCheckboxOptions[i].setVisibility(View.VISIBLE);
                     pollCheckboxOptions[i].setChecked(false);
                 } else {
@@ -917,7 +920,9 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
             for(int i = 0; i < Status.MAX_POLL_OPTIONS; i++) {
                 if(i < options.size()) {
-                    pollRadioOptions[i].setText(CustomEmojiHelper.emojifyString(options.get(i).getTitle(), emojis, pollRadioOptions[i]));
+                    CharSequence emojifiedPollOptionText = CustomEmojiHelper.emojifyString(options.get(i).getTitle(), emojis, pollRadioOptions[i]);
+                    emojifiedPollOptionText = EmojiCompat.get().process(emojifiedPollOptionText);
+                    pollRadioOptions[i].setText(emojifiedPollOptionText);
                     pollRadioOptions[i].setVisibility(View.VISIBLE);
                 } else {
                     pollRadioOptions[i].setVisibility(View.GONE);

--- a/app/src/main/res/layout/item_conversation.xml
+++ b/app/src/main/res/layout/item_conversation.xml
@@ -341,7 +341,7 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <TextView
+    <androidx.emoji.widget.EmojiTextView
         android:id="@+id/status_poll_option_result_0"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -360,7 +360,7 @@
         app:layout_constraintTop_toBottomOf="@id/status_media_preview_container"
         tools:text="40%" />
 
-    <TextView
+    <androidx.emoji.widget.EmojiTextView
         android:id="@+id/status_poll_option_result_1"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -379,7 +379,7 @@
         app:layout_constraintTop_toBottomOf="@id/status_poll_option_result_0"
         tools:text="10%" />
 
-    <TextView
+    <androidx.emoji.widget.EmojiTextView
         android:id="@+id/status_poll_option_result_2"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -398,7 +398,7 @@
         app:layout_constraintTop_toBottomOf="@id/status_poll_option_result_1"
         tools:text="20%" />
 
-    <TextView
+    <androidx.emoji.widget.EmojiTextView
         android:id="@+id/status_poll_option_result_3"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/item_status.xml
+++ b/app/src/main/res/layout/item_status.xml
@@ -327,7 +327,7 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <TextView
+    <androidx.emoji.widget.EmojiTextView
         android:id="@+id/status_poll_option_result_0"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -346,7 +346,7 @@
         app:layout_constraintTop_toBottomOf="@id/status_media_preview_container"
         tools:text="40%" />
 
-    <TextView
+    <androidx.emoji.widget.EmojiTextView
         android:id="@+id/status_poll_option_result_1"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -365,7 +365,7 @@
         app:layout_constraintTop_toBottomOf="@id/status_poll_option_result_0"
         tools:text="10%" />
 
-    <TextView
+    <androidx.emoji.widget.EmojiTextView
         android:id="@+id/status_poll_option_result_2"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -384,7 +384,7 @@
         app:layout_constraintTop_toBottomOf="@id/status_poll_option_result_1"
         tools:text="20%" />
 
-    <TextView
+    <androidx.emoji.widget.EmojiTextView
         android:id="@+id/status_poll_option_result_3"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/item_status_detailed.xml
+++ b/app/src/main/res/layout/item_status_detailed.xml
@@ -336,7 +336,7 @@
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 
-    <TextView
+    <androidx.emoji.widget.EmojiTextView
         android:id="@+id/status_poll_option_result_0"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -355,7 +355,7 @@
         app:layout_constraintTop_toBottomOf="@id/status_media_preview_container"
         tools:text="40%" />
 
-    <TextView
+    <androidx.emoji.widget.EmojiTextView
         android:id="@+id/status_poll_option_result_1"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -374,7 +374,7 @@
         app:layout_constraintTop_toBottomOf="@id/status_poll_option_result_0"
         tools:text="10%" />
 
-    <TextView
+    <androidx.emoji.widget.EmojiTextView
         android:id="@+id/status_poll_option_result_2"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -393,7 +393,7 @@
         app:layout_constraintTop_toBottomOf="@id/status_poll_option_result_1"
         tools:text="20%" />
 
-    <TextView
+    <androidx.emoji.widget.EmojiTextView
         android:id="@+id/status_poll_option_result_3"
         android:layout_width="0dp"
         android:layout_height="wrap_content"


### PR DESCRIPTION
This is missing for the polls. I won't include it in Tusky 7 though, because I want to make sure `EmojiCompat.get()` works as expected on the nightly first.