### PR TITLE
fix upgrade of material lib

### DIFF
--- a/app/src/main/res/drawable/background_main_toolbar.xml
+++ b/app/src/main/res/drawable/background_main_toolbar.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?android:colorBackground" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -33,7 +33,7 @@
             android:layout_alignParentTop="true"
             android:layout_alignParentEnd="true"
             android:layout_toEndOf="@id/drawer_toggle"
-            android:background="?android:colorBackground"
+            android:background="@drawable/background_main_toolbar"
             android:elevation="@dimen/actionbar_elevation"
             app:tabGravity="fill"
             app:tabIconTint="@color/tab_icon_color"

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -9,6 +9,8 @@
         <item name="colorSecondary">@color/tusky_blue</item>
         <item name="colorOnSecondary">@color/white</item>
 
+        <item name="colorSurface">@color/color_primary_dark_dark</item>
+
         <item name="colorPrimaryDark">@color/color_primary_dark_dark</item>
 
         <item name="android:colorBackground">@color/color_primary_dark_dark</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -60,6 +60,8 @@
         <item name="colorSecondary">@color/tusky_blue</item>
         <item name="colorOnSecondary">@color/white</item>
 
+        <item name="colorSurface">@color/color_background_light</item>
+
         <item name="colorPrimaryDark">@color/color_primary_dark_light</item>
 
         <item name="android:colorBackground">@color/color_background_light</item>


### PR DESCRIPTION
In #1263 I removed the `colorSurface` because it made the main toolbar look ugly. Turns out it is needed for the color of drop downs. 

here is the code change that causes the problem: https://github.com/material-components/material-components-android/commit/6d4ffa29e3b9476352273b42dbdd16077eb88dc9

So my workaround is using a shape drawable instead of a color drawable. Once the materialcomponents are stable I will do a proper refactoring.