### PR TITLE
Minimal screen reader support for polls

### DIFF
--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -482,7 +482,6 @@
     <string name="pin_action">Fixar</string>
 
     <string name="description_status_reblogged">Respost</string>
-    <string name="description_status"> .<!-- Nom públic, advertència\?, contingut\?, data relativa, respost per\?, respost\?, favorits\?, nom usuari, mèdia\?; visibilitat, número de favorits\?, número de respostes\?--> %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s </string>
 
     <string name="compose_preview_image_description">Accions per a la imatge %s</string>
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -374,9 +374,6 @@
     </string>
     <string name="description_visiblity_direct">        Přímý
     </string>
-    <string name="description_status">        <!-- Zobrazované jméno, varování?, obsah?, relativní datum, znovusdíleno kým?, znovusdíleno?, oblíbeno?, uživatelské jméno, média?; viditelnost, počet oblíbení?, počet boostů?-->
-        %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s
-    </string>
     <string name="hint_list_name">Název seznamu</string>
     <string name="edit_hashtag_title">Upravit hashtag</string>
     <string name="edit_hashtag_hint">Hashtag bez #</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -366,8 +366,6 @@
     <string name="description_visiblity_private">        Sekvantoj
     </string>
     <string name="description_visiblity_direct">        Rekta    </string>
-    <string name="description_status">        <!-- Display name, cw?, content?, relative date, reposted by?, reposted?, favorited?, username, media?; visibility, fav number?, reblog number?-->
-        %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s
-    </string>
+
     <string name="hint_list_name">Nomo de la listo</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -424,7 +424,6 @@
 
     <string name="action_open_reblogger">Abrir autor del impulso</string>
     <string name="action_open_reblogged_by">Mostrar impulsos</string>
-    <string name="description_status"> <!-- Display name, cw\?, content\?, relative date, reposted by\?, reposted\?, favorited\?, username, media\?; visibility, fav number\?, reblog number\?--> %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s </string>
 
     <string name="poll_option_format"> <!-- 15% vote for this! --> &lt;b&gt;%1$d%%&lt;/b&gt; %2$s</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -372,9 +372,6 @@
     </string>
     <string name="description_visiblity_direct">        Direct
     </string>
-    <string name="description_status">        <!-- Nom public, avertissement?, contenu?, date relative, reblogué par?, reblogué?, mis en favoris?, username, media?; visibilité, nombre de fav?, nombre de reblogs?-->
-        %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s
-    </string>
     <string name="hint_list_name">Nom de la liste</string>
 <string name="edit_hashtag_title">Modifier les hashtags</string>
     <string name="edit_hashtag_hint">Hastags sans #</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -366,9 +366,6 @@
     </string>
     <string name="description_visiblity_direct">        Diretti
     </string>
-    <string name="description_status">        <!-- Nome visualizzato, cw?, contenuto?, data relativa, ripostato da?, ripostato?, apprezzato?, nome utente, media?; visibilità, numero di mi piace?, numero di riblog?-->
-        %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s
-    </string>
     <string name="hint_list_name">Nome della lista</string>
 <string name="download_media">Scarica media</string>
     <string name="downloading_media">Scaricando media</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -346,9 +346,6 @@
     </string>
     <string name="description_visiblity_direct">        Direct
     </string>
-    <string name="description_status">        <!-- Display name, cw?, content?, relative date, reposted by?, reposted?, favorited?, username, media?; visibility, fav number?, reblog number?-->
-        %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s
-    </string>
 <string name="download_media">Media downloaden</string>
     <string name="downloading_media">Media aan het downloaden</string>
 

--- a/app/src/main/res/values-no-rNB/strings.xml
+++ b/app/src/main/res/values-no-rNB/strings.xml
@@ -218,9 +218,6 @@
     <string name="pref_title_http_proxy_server">Serveradresse</string>
     <string name="pref_title_http_proxy_port">Serverport</string>
 
-
-    <string name="description_status"> <!-- Display name, cw\?, content\?, relative date, reposted by\?, reposted\?, favorited\?, username, media\?; visibility, fav number\?, reblog number\?--> %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s </string>
-
 <string name="pref_default_media_sensitivity">Marker alltid media som sensitivt</string>
     <string name="pref_publishing">Publisering (synkronisert med server)</string>
     <string name="pref_failed_to_sync">Synkronisering av innstillinger feilet</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -373,7 +373,6 @@
     <string name="description_visiblity_unlisted">Pas listat</string>
     <string name="description_visiblity_private">Seguidors</string>
     <string name="description_visiblity_direct">Dirècte</string>
-    <string name="description_status"> <!-- Nom d’afichatge, cw \?, contengut \?, data relativa, repartejat per \?, repartajat \?, aimat \?, nom d’utilizaire, mèdia \?; visibilitat, nombre de fav \?, nombre de partatge \?--> %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s </string>
 
     <string name="hint_list_name">Nom de la lista</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -386,7 +386,6 @@
     <string name="description_status_favourited">Favoritado</string>
     <string name="description_visiblity_unlisted">Não-listado</string>
     <string name="description_visiblity_direct">Direta</string>
-    <string name="description_status"> <!-- Display name, cw\?, content\?, relative date, reposted by\?, reposted\?, favorited\?, username, media\?; visibility, fav number\?, reblog number\?--> %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s </string>
 
     <string name="hint_list_name">Nome da lista</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -465,10 +465,6 @@
     <string name="description_visiblity_direct">
         Для упомянутых
     </string>
-    <string name="description_status">
-        <!-- Display name, cw?, content?, relative date, reposted by?, reposted?, favorited?, username, media?; visibility, fav number?, reblog number?-->
-        %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s
-    </string>
 
     <string name="hint_list_name">Название списка</string>
 

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -394,7 +394,6 @@
     <string name="description_visiblity_unlisted">Ni prikazano</string>
     <string name="description_visiblity_private">Sledilci</string>
     <string name="description_visiblity_direct">Neposredno</string>
-    <string name="description_status"> <!-- Display name, cw\?, content\?, relative date, reposted by\?, reposted\?, favorited\?, username, media\?; visibility, fav number\?, reblog number\?-->%1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s </string>
 
     <string name="hint_list_name">Ime seznama</string>
 

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -366,9 +366,6 @@
     </string>
     <string name="description_visiblity_direct">        Direkt
     </string>
-    <string name="description_status">        <!-- Display name, cw?, content?, relative date, reposted by?, reposted?, favorited?, username, media?; visibility, fav number?, reblog number?-->
-        %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s
-    </string>
     <string name="hint_list_name">Listnamn</string>
 <string name="download_media">Ladda ned media</string>
     <string name="downloading_media">Laddar ned media</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -447,10 +447,6 @@
     <string name="description_visiblity_direct">
         私信
     </string>
-    <string name="description_status">
-        <!-- Display name, cw?, content?, relative date, reposted by?, reposted?, favorited?, username, media?; visibility, fav number?, reblog number?-->
-        %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s
-    </string>
 
     <string name="hint_list_name">列表名</string>
 

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -447,10 +447,6 @@
     <string name="description_visiblity_direct">
         私信
     </string>
-    <string name="description_status">
-        <!-- Display name, cw?, content?, relative date, reposted by?, reposted?, favorited?, username, media?; visibility, fav number?, reblog number?-->
-        %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s
-    </string>
     
     <string name="hint_list_name">列表名</string>
     

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -447,10 +447,6 @@
     <string name="description_visiblity_direct">
         私信
     </string>
-    <string name="description_status">
-        <!-- Display name, cw?, content?, relative date, reposted by?, reposted?, favorited?, username, media?; visibility, fav number?, reblog number?-->
-        %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s
-    </string>
     
     <string name="hint_list_name">列表名</string>
     

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -447,10 +447,6 @@
     <string name="description_visiblity_direct">
         私信
     </string>
-    <string name="description_status">
-        <!-- Display name, cw?, content?, relative date, reposted by?, reposted?, favorited?, username, media?; visibility, fav number?, reblog number?-->
-        %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s
-    </string>
 
     <string name="hint_list_name">列表名</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -447,10 +447,6 @@
     <string name="description_visiblity_direct">
         私信
     </string>
-    <string name="description_status">
-        <!-- Display name, cw?, content?, relative date, reposted by?, reposted?, favorited?, username, media?; visibility, fav number?, reblog number?-->
-        %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s
-    </string>
     
     <string name="hint_list_name">列表名</string>
     

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -99,4 +99,10 @@
         <item>ja</item>
     </string-array>
 
+
+    <string name="description_status" translatable="false">
+        <!-- Display name, cw?, content?, poll? relative date, reposted by?, reposted?, favorited?, username, media?; visibility, fav number?, reblog number?-->
+        %1$s; %2$s; %3$s, %13$s %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s
+    </string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -450,9 +450,8 @@
     <string name="description_visiblity_direct">
         Direct
     </string>
-    <string name="description_status">
-        <!-- Display name, cw?, content?, relative date, reposted by?, reposted?, favorited?, username, media?; visibility, fav number?, reblog number?-->
-        %1$s; %2$s; %3$s, %4$s, %5$s; %6$s, %7$s, %8$s, %9$s; %10$s, %11$s, %12$s
+    <string name="description_poll">
+        Poll with choices: %s, %s, %s, %s; %s
     </string>
 
     <string name="hint_list_name">List name</string>


### PR DESCRIPTION
This is a minimal fix for #1287. Notifications are still not announced correctly and I didn't add any special actions for polls so one may have to scroll through them manually. I think they're rare enough that it's not a big problem yet.
I checked `description_status` in all languages and it's either left as-is (even in Asian languages) or not translated at all. So I've made it non-translatable.