### PR TITLE
cleanup entity classes and ViewThreadFragment

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationEntity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationEntity.kt
@@ -155,7 +155,8 @@ data class ConversationStatusEntity(
                 mentions = mentions,
                 application = null,
                 pinned = false,
-                poll = poll)
+                poll = poll,
+                card = null)
     }
 }
 

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Attachment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Attachment.kt
@@ -26,13 +26,12 @@ import kotlinx.android.parcel.Parcelize
 
 @Parcelize
 data class Attachment(
-        var id: String,
-        var url: String,
+        val id: String,
+        val url: String,
         @SerializedName("preview_url") val previewUrl: String,
-        @SerializedName("text_url") val textUrl: String?,
         val meta: MetaData?,
-        var type: Type,
-        var description: String?
+        val type: Type,
+        val description: String?
 ) : Parcelable {
 
     @JsonAdapter(MediaTypeDeserializer::class)

--- a/app/src/main/java/com/keylesspalace/tusky/entity/MastoList.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/MastoList.kt
@@ -20,4 +20,7 @@ package com.keylesspalace.tusky.entity
  * Created by charlag on 1/4/18.
  */
 
-data class MastoList(val id: String, val title: String)
+data class MastoList(
+        val id: String,
+        val title: String
+)

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Status.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Status.kt
@@ -31,8 +31,8 @@ data class Status(
         val emojis: List<Emoji>,
         @SerializedName("reblogs_count") val reblogsCount: Int,
         @SerializedName("favourites_count") val favouritesCount: Int,
-        var reblogged: Boolean = false,
-        var favourited: Boolean = false,
+        var reblogged: Boolean,
+        var favourited: Boolean,
         var sensitive: Boolean,
         @SerializedName("spoiler_text") val spoilerText: String,
         val visibility: Visibility,
@@ -40,7 +40,8 @@ data class Status(
         val mentions: Array<Mention>,
         val application: Application?,
         var pinned: Boolean?,
-        val poll: Poll?
+        val poll: Poll?,
+        val card: Card?
 ) {
 
     val actionableId: String
@@ -120,45 +121,17 @@ data class Status(
     }
 
 
-    class Mention {
-        var id: String? = null
+    data class Mention (
+        val id: String,
+        val url: String,
+        @SerializedName("acct") val username: String,
+        @SerializedName("username") val localUsername: String
+    )
 
-        var url: String? = null
-
-        @SerializedName("acct")
-        var username: String? = null
-
-        @SerializedName("username")
-        var localUsername: String? = null
-
-      override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as Mention
-
-        if (id != other.id) return false
-        if (url != other.url) return false
-        if (username != other.username) return false
-        if (localUsername != other.localUsername) return false
-
-        return true
-      }
-
-      override fun hashCode(): Int {
-        var result = id?.hashCode() ?: 0
-        result = 31 * result + (url?.hashCode() ?: 0)
-        result = 31 * result + (username?.hashCode() ?: 0)
-        result = 31 * result + (localUsername?.hashCode() ?: 0)
-        return result
-      }
-
-    }
-
-    class Application {
-        var name: String? = null
-        var website: String? = null
-    }
+    data class Application (
+        val name: String,
+        val website: String
+    )
 
     companion object {
         const val MAX_MEDIA_ATTACHMENTS = 4

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -18,7 +18,6 @@ package com.keylesspalace.tusky.fragment;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
@@ -41,7 +40,6 @@ import com.keylesspalace.tusky.appstore.ReblogEvent;
 import com.keylesspalace.tusky.appstore.StatusComposedEvent;
 import com.keylesspalace.tusky.appstore.StatusDeletedEvent;
 import com.keylesspalace.tusky.di.Injectable;
-import com.keylesspalace.tusky.entity.Card;
 import com.keylesspalace.tusky.entity.Poll;
 import com.keylesspalace.tusky.entity.Status;
 import com.keylesspalace.tusky.entity.StatusContext;
@@ -92,7 +90,6 @@ public final class ViewThreadFragment extends SFragment implements
     private RecyclerView recyclerView;
     private ThreadAdapter adapter;
     private String thisThreadsStatusId;
-    private Card card;
     private boolean alwaysShowSensitiveMedia;
 
     private int statusIndex = 0;
@@ -109,7 +106,7 @@ public final class ViewThreadFragment extends SFragment implements
             });
 
     public static ViewThreadFragment newInstance(String id) {
-        Bundle arguments = new Bundle();
+        Bundle arguments = new Bundle(1);
         ViewThreadFragment fragment = new ViewThreadFragment();
         arguments.putString("id", id);
         fragment.setArguments(arguments);
@@ -147,10 +144,7 @@ public final class ViewThreadFragment extends SFragment implements
                 context, layoutManager.getOrientation());
         recyclerView.addItemDecoration(divider);
 
-        Drawable threadLineDrawable = ThemeUtils.getDrawable(context, R.attr.conversation_thread_line_drawable,
-                R.drawable.conversation_thread_line_dark);
-        recyclerView.addItemDecoration(new ConversationLineItemDecoration(context,
-                threadLineDrawable));
+        recyclerView.addItemDecoration(new ConversationLineItemDecoration(context));
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(
                 getActivity());
         alwaysShowSensitiveMedia = accountManager.getActiveAccount().getAlwaysShowSensitiveMedia();
@@ -158,6 +152,9 @@ public final class ViewThreadFragment extends SFragment implements
         adapter.setMediaPreviewEnabled(mediaPreviewEnabled);
         boolean useAbsoluteTime = preferences.getBoolean("absoluteTimeView", false);
         adapter.setUseAbsoluteTime(useAbsoluteTime);
+        boolean animateAvatars = preferences.getBoolean("animateGifAvatars", false);
+        adapter.setAnimateAvatar(animateAvatars);
+
         recyclerView.setAdapter(adapter);
 
         statuses.clear();
@@ -218,7 +215,6 @@ public final class ViewThreadFragment extends SFragment implements
     public void onRefresh() {
         sendStatusRequest(thisThreadsStatusId);
         sendThreadRequest(thisThreadsStatusId);
-        sendCardRequest(thisThreadsStatusId);
     }
 
     @Override
@@ -235,11 +231,8 @@ public final class ViewThreadFragment extends SFragment implements
                 .as(autoDisposable(from(this)))
                 .subscribe(
                         (newStatus) -> updateStatus(position, newStatus),
-                        (t) -> {
-                            Log.d(getClass().getSimpleName(),
-                                    "Failed to reblog status: " + status.getId());
-                            t.printStackTrace();
-                        }
+                        (t) -> Log.d(getClass().getSimpleName(),
+                                "Failed to reblog status: " + status.getId(), t)
                 );
     }
 
@@ -252,10 +245,8 @@ public final class ViewThreadFragment extends SFragment implements
                 .as(autoDisposable(from(this)))
                 .subscribe(
                         (newStatus) -> updateStatus(position, newStatus),
-                        (t) -> {
-                            Log.d(getClass().getSimpleName(), "Failed to favourite status: " + status.getId());
-                            t.printStackTrace();
-                        }
+                        (t) -> Log.d(getClass().getSimpleName(),
+                                "Failed to favourite status: " + status.getId(), t)
                 );
     }
 
@@ -487,26 +478,6 @@ public final class ViewThreadFragment extends SFragment implements
         callList.add(call);
     }
 
-    private void sendCardRequest(final String id) {
-        Call<Card> call = mastodonApi.statusCard(id);
-        call.enqueue(new Callback<Card>() {
-            @Override
-            public void onResponse(@NonNull Call<Card> call, @NonNull Response<Card> response) {
-                if (response.isSuccessful()) {
-                    showCard(response.body());
-                } else {
-                    onThreadRequestFailure(id);
-                }
-            }
-
-            @Override
-            public void onFailure(@NonNull Call<Card> call, @NonNull Throwable t) {
-                Log.e(TAG, "Error fetching status card");
-            }
-        });
-        callList.add(call);
-    }
-
     private void onThreadRequestFailure(final String id) {
         View view = getView();
         swipeRefreshLayout.setRefreshing(false);
@@ -515,7 +486,6 @@ public final class ViewThreadFragment extends SFragment implements
                     .setAction(R.string.action_retry, v -> {
                         sendThreadRequest(id);
                         sendStatusRequest(id);
-                        sendCardRequest(id);
                     })
                     .show();
         } else {
@@ -534,14 +504,7 @@ public final class ViewThreadFragment extends SFragment implements
         int i = statusIndex;
         statuses.add(i, status);
         adapter.setDetailedStatusPosition(i);
-        StatusViewData.Concrete viewData = statuses.getPairedItem(i);
-        if (viewData.getCard() == null && card != null) {
-            viewData = new StatusViewData.Builder(viewData)
-                    .setCard(card)
-                    .createStatusViewData();
-        }
-        statuses.setPairedItem(i, viewData);
-        adapter.addItem(i, viewData);
+        adapter.addItem(i, statuses.getPairedItem(i));
         updateRevealIcon();
         return i;
     }
@@ -578,13 +541,7 @@ public final class ViewThreadFragment extends SFragment implements
             // everything except one), re-insert the remaining status here.
             statuses.add(statusIndex, mainStatus);
             StatusViewData.Concrete viewData = statuses.getPairedItem(statusIndex);
-            if (viewData.getCard() == null && card != null) {
-                viewData = new StatusViewData.Builder(viewData)
-                        .setCard(card)
-                        .createStatusViewData();
-                statuses.setPairedItem(statusIndex, viewData);
 
-            }
             adapter.addItem(statusIndex, viewData);
         }
 
@@ -605,28 +562,10 @@ public final class ViewThreadFragment extends SFragment implements
         updateRevealIcon();
     }
 
-    private void showCard(Card card) {
-        this.card = card;
-        if (statusIndex >= 0 && statusIndex < statuses.size()) {
-            StatusViewData.Concrete newViewData =
-                    new StatusViewData.Builder(statuses.getPairedItem(statusIndex))
-                            .setCard(card)
-                            .createStatusViewData();
-
-            statuses.setPairedItem(statusIndex, newViewData);
-            adapter.setItem(statusIndex, newViewData, true);
-        }
-    }
-
-    public void clear() {
-        statuses.clear();
-        adapter.clear();
-    }
-
     private void handleFavEvent(FavoriteEvent event) {
         Pair<Integer, Status> posAndStatus = findStatusAndPos(event.getStatusId());
         if (posAndStatus == null) return;
-        //noinspection ConstantConditions
+
         boolean favourite = event.getFavourite();
         posAndStatus.second.setFavourited(favourite);
 
@@ -648,7 +587,7 @@ public final class ViewThreadFragment extends SFragment implements
     private void handleReblogEvent(ReblogEvent event) {
         Pair<Integer, Status> posAndStatus = findStatusAndPos(event.getStatusId());
         if (posAndStatus == null) return;
-        //noinspection ConstantConditions
+
         boolean reblog = event.getReblog();
         posAndStatus.second.setReblogged(reblog);
 

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.java
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.java
@@ -312,11 +312,6 @@ public interface MastodonApi {
             @Field("grant_type") String grantType
     );
 
-    @GET("/api/v1/statuses/{id}/card")
-    Call<Card> statusCard(
-            @Path("id") String statusId
-    );
-
     @GET("/api/v1/lists")
     Single<List<MastoList>> getLists();
 

--- a/app/src/main/java/com/keylesspalace/tusky/repository/TimelineRepository.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/repository/TimelineRepository.kt
@@ -229,7 +229,8 @@ class TimelineRepositoryImpl(
                     mentions = mentions,
                     application = application,
                     pinned = false,
-                    poll = poll
+                    poll = poll,
+                    card = null
             )
         }
         val status = if (reblog != null) {
@@ -254,7 +255,8 @@ class TimelineRepositoryImpl(
                     mentions = arrayOf(),
                     application = null,
                     pinned = false,
-                    poll = null
+                    poll = null,
+                    card = null
             )
         } else {
             Status(
@@ -278,7 +280,8 @@ class TimelineRepositoryImpl(
                     mentions = mentions,
                     application = application,
                     pinned = false,
-                    poll = poll
+                    poll = poll,
+                    card = null
             )
         }
         return Either.Right(status)

--- a/app/src/main/java/com/keylesspalace/tusky/util/ViewDataUtils.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ViewDataUtils.java
@@ -64,6 +64,7 @@ public final class ViewDataUtils {
                 ))
                 .setCollapsed(true)
                 .setPoll(visibleStatus.getPoll())
+                .setCard(visibleStatus.getCard())
                 .setIsBot(visibleStatus.getAccount().getBot())
                 .createStatusViewData();
     }

--- a/app/src/main/java/com/keylesspalace/tusky/view/ConversationLineItemDecoration.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/view/ConversationLineItemDecoration.kt
@@ -23,8 +23,12 @@ import android.view.View
 
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.adapter.ThreadAdapter
+import com.keylesspalace.tusky.util.ThemeUtils
 
-class ConversationLineItemDecoration(private val context: Context, private val divider: Drawable) : RecyclerView.ItemDecoration() {
+class ConversationLineItemDecoration(private val context: Context) : RecyclerView.ItemDecoration() {
+
+    private val divider: Drawable  = ThemeUtils.getDrawable(context, R.attr.conversation_thread_line_drawable,
+            R.drawable.conversation_thread_line_dark)
 
     override fun onDraw(canvas: Canvas, parent: RecyclerView, state: RecyclerView.State) {
         val dividerStart = parent.paddingStart + context.resources.getDimensionPixelSize(R.dimen.status_line_margin_start)

--- a/app/src/test/java/com/keylesspalace/tusky/BottomSheetActivityTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/BottomSheetActivityTest.kt
@@ -85,7 +85,8 @@ class BottomSheetActivityTest {
             arrayOf(),
             null,
             pinned = false,
-            poll = null
+            poll = null,
+            card = null
     )
     private val statusCallback = FakeSearchResults(status)
 

--- a/app/src/test/java/com/keylesspalace/tusky/fragment/TimelineRepositoryTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/fragment/TimelineRepositoryTest.kt
@@ -315,7 +315,8 @@ class TimelineRepositoryTest {
                 pinned = false,
                 reblog = null,
                 url = "http://example.com/statuses/$id",
-                poll = null
+                poll = null,
+                card = null
         )
     }
 


### PR DESCRIPTION
At first, I just wanted to cleanup the entitiy classes

- `var` -> `val` where possible
- use data classes
- remove unused attributes
- fix nullability

But then I found that since Mastodon 2.6 every status has the Card already embedded so there is no need for that extra request in `ViewThreadFragment`.

Also fixes the problem that avatars where never animated in `ViewThreadFragment`