### PR TITLE
fix R8 rules to avoid crash when downloading Emoji Font

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -94,9 +94,10 @@
 
 -dontwarn com.google.errorprone.annotations.*
 
-# work around a bug in proguard
-# see https://sourceforge.net/p/proguard/bugs/729/
--keepnames public interface com.uber.autodispose.lifecycle.CorrespondingEventsFunction { *; }
+# without this emoji font downloading fails with AbstractMethodError
+-keep class * extends android.os.AsyncTask {
+    public *;
+}
 
 # Glide
 -keep public class * implements com.bumptech.glide.module.GlideModule


### PR DESCRIPTION
Seems R8 is optimizing away too much and the AsyncTask was missing methods. This also explains why it worked in a debug build.
cc @C1710 
