### PR TITLE
Fix back button not working

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
@@ -1655,6 +1655,11 @@ public final class ComposeActivity
             }
         }
 
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            onBackPressed();
+            return true;
+        }
+
         return super.onKeyDown(keyCode, event);
     }
 


### PR DESCRIPTION
Since #1296 merged, back button is not working in `ComposeActivity`.
This PR fixes it.