### PR TITLE
fix main tabs on tablet

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,14 +21,12 @@
             android:background="?android:colorBackground"
             android:contentDescription="@string/action_open_drawer"
             android:elevation="@dimen/actionbar_elevation"
-            app:layout_anchor="@id/pager"
-            app:layout_anchorGravity="top|left"
             app:srcCompat="@drawable/ic_menu_24dp" />
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tab_layout"
             style="@style/TuskyTabAppearance"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="?attr/actionBarSize"
             android:layout_alignParentTop="true"
             android:layout_alignParentEnd="true"
@@ -37,6 +35,7 @@
             android:elevation="@dimen/actionbar_elevation"
             app:tabGravity="fill"
             app:tabIconTint="@color/tab_icon_color"
+            app:tabMaxWidth="0dp"
             app:tabMode="fixed"
             app:tabPaddingEnd="1dp"
             app:tabPaddingStart="1dp"


### PR DESCRIPTION
before

![device-2019-06-15-101900](https://user-images.githubusercontent.com/10157047/59549000-20feb180-8f57-11e9-836f-3a0acf6766a2.png)

after

![device-2019-06-15-101715](https://user-images.githubusercontent.com/10157047/59549002-3542ae80-8f57-11e9-8aaa-0efdece7dddf.png)

(the `tabMaxWidth="0dp"` is doing the trick, the other changes are just cleanup)

