### PR TITLE
Tusky is no longer a fully compliant Mastodon client

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![](/fastlane/metadata/android/en-US/images/icon.png)
 
-Tusky is a beautiful Android client for [Mastodon](https://github.com/tootsuite/mastodon). Mastodon is a GNU social-compatible federated social network. That means not one entity controls the whole network, rather, like e-mail, volunteers and organisations operate their own independent servers, users from which can all interact with each other seamlessly.
+Tusky is a beautiful Android client for some [Mastodon](https://github.com/tootsuite/mastodon) instances. Mastodon is a GNU social-compatible federated social network. That means not one entity controls the whole network, rather, like e-mail, volunteers and organisations operate their own independent servers, users from which can all interact with each other seamlessly. While Tusky is not fully compliant, it supports most Mastodon features on most Mastodon instances.
 
 [<img src="/assets/fdroid_badge.png" alt="Get it on F-Droid" height="80" />](https://f-droid.org/repository/browse/?fdid=com.keylesspalace.tusky)
 [<img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" alt="Get it on Google Play" height="80" />](https://play.google.com/store/apps/details?id=com.keylesspalace.tusky&utm_source=github&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1)


### PR DESCRIPTION
Given the fact that Tusky now blocks Gab (#1303), it is not a fully compliant client according to https://docs.joinmastodon.org/api/guidelines/.  

In particular:
![image](https://user-images.githubusercontent.com/11603778/59644883-f40bf380-913c-11e9-8913-120ae66bd258.png)
Since a user can no longer log in to any Mastodon server, it is no longer a fully compliant client, so the README should reflect that.