### PR TITLE
Fix build warnings

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/FiltersActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/FiltersActivity.kt
@@ -2,7 +2,6 @@ package com.keylesspalace.tusky
 
 import android.os.Bundle
 import android.view.MenuItem
-import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.Toast
@@ -61,7 +60,7 @@ class FiltersActivity: BaseActivity() {
 
     private fun deleteFilter(itemIndex: Int) {
         val filter = filters[itemIndex]
-        if (filter.context.count() == 1) {
+        if (filter.context.size == 1) {
             // This is the only context for this filter; delete it
             api.deleteFilter(filters[itemIndex].id).enqueue(object: Callback<ResponseBody> {
                 override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
@@ -157,7 +156,7 @@ class FiltersActivity: BaseActivity() {
                     filterProgressBar.hide()
                     filterMessageView.show()
                     filterMessageView.setup(R.drawable.elephant_error,
-                            R.string.error_generic, this@FiltersActivity::reload)
+                            R.string.error_generic) { loadFilters() }
                 }
             }
 
@@ -166,17 +165,13 @@ class FiltersActivity: BaseActivity() {
                 filterMessageView.show()
                 if (t is IOException) {
                     filterMessageView.setup(R.drawable.elephant_offline,
-                            R.string.error_network, this@FiltersActivity::reload)
+                            R.string.error_network) { loadFilters() }
                 } else {
                     filterMessageView.setup(R.drawable.elephant_error,
-                            R.string.error_generic, this@FiltersActivity::reload)
+                            R.string.error_generic) { loadFilters() }
                 }
             }
         })
-    }
-
-    private fun reload(v: View) {
-        loadFilters()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -783,7 +783,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         if (poll == null) {
             return "";
         } else {
-            CharSequence[] args = new CharSequence[5];
+            Object[] args = new CharSequence[5];
             List<PollOption> options = poll.getOptions();
             for (int i = 0; i < args.length; i++) {
                 if (i < options.size()) {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -438,6 +438,5 @@
 <string name="compose_preview_image_description">إجراءات على الصورة %s</string>
 
     <string name="caption_notoemoji">حزمة الإيموجي الحالية لـ غوغل</string>
-    <string name="description_poll">استطلاع رأي بالخيارات: %s, %s, %s, %s; %s</string>
 
     </resources>

--- a/app/src/main/res/values-bn-rIN/strings.xml
+++ b/app/src/main/res/values-bn-rIN/strings.xml
@@ -417,7 +417,7 @@
     <string name="description_visiblity_unlisted">অতালিকাভুক্ত</string>
     <string name="description_visiblity_private">অনুগামিবৃন্দ</string>
     <string name="description_visiblity_direct">সরাসরি</string>
-    <string name="description_poll">পছন্দগুলি সহ নর্বাচন: %s, %s, %s, %s; %s</string>
+    <string name="description_poll">পছন্দগুলি সহ নর্বাচন: %1$s, %2$s, %3$s, %4$s; %5$s</string>
 
     <string name="hint_list_name">নামের তালিকা</string>
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -431,6 +431,6 @@
 
 <string name="pref_title_animate_gif_avatars">Animovat avatary GIF</string>
 
-    <string name="description_poll">Anketa s volbami: %s, %s, %s, %s; %s</string>
+    <string name="description_poll">Anketa s volbami: %1$s, %2$s, %3$s, %4$s; %5$s</string>
 
     </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -425,6 +425,6 @@
     <string name="poll_option_format"> <!-- 15% vote for this! --> &lt;b&gt;%1$d%%&lt;/b&gt; %2$s</string>
 
     <string name="poll_ended_voted">Un sondage auquel vous avez participé vient de se terminer</string>
-    <string name="description_poll">Sondage avec des choix : %s, %s, %s, %s; %s</string>
+    <string name="description_poll">Sondage avec des choix : %1$s, %2$s, %3$s, %4$s; %5$s</string>
 
     </resources>

--- a/app/src/main/res/values-no-rNB/strings.xml
+++ b/app/src/main/res/values-no-rNB/strings.xml
@@ -462,7 +462,7 @@
 
     <string name="pref_title_animate_gif_avatars">Animer GIF-avatarer</string>
 
-    <string name="description_poll">Avstemming med valg: %s, %s, %s, %s; %s</string>
+    <string name="description_poll">Avstemming med valg: %1$s, %2$s, %3$s, %4$s; %5$s</string>
 
     <string name="caption_notoemoji">Googles nåværende emoji-samling</string>
     <string name="button_continue">Fortsett</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -433,7 +433,7 @@
     <string name="pref_title_animate_gif_avatars">Activar l’animacion dels avatars</string>
 
     <string name="caption_notoemoji">Jòc d’emoji actuals de Google</string>
-    <string name="description_poll">Sondatge amb opcion : %s, %s, %s, %s; %s</string>
+    <string name="description_poll">Sondatge amb opcion : %1$s, %2$s, %3$s, %4$s; %5$s</string>
 
     <string name="button_continue">Contunhar</string>
     <string name="button_back">Tornar</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -427,6 +427,6 @@
 
 <string name="pref_title_animate_gif_avatars">Reproduzir GIFs</string>
 
-    <string name="description_poll">Enquete com as opções: %s, %s, %s, %s; %s</string>
+    <string name="description_poll">Enquete com as opções: %1$s, %2$s, %3$s, %4$s; %5$s</string>
 
     </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -476,7 +476,7 @@
 
 <string name="pref_title_animate_gif_avatars">Animirane podobe GIF</string>
 
-    <string name="description_poll">Anketa z izbiro: %s, %s, %s, %s; %s</string>
+    <string name="description_poll">Anketa z izbiro: %1$s, %2$s, %3$s, %4$s; %5$s</string>
 
     <string name="caption_notoemoji">Googlovi trenutni emotikoni</string>
     <string name="button_continue">Nadaljuj</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -423,6 +423,6 @@
 
     <string name="pref_title_animate_gif_avatars">Animera profil gifar</string>
 
-    <string name="description_poll">Undersökning med valen: %s, %s, %s, %s; %s</string>
+    <string name="description_poll">Undersökning med valen: %1$s, %2$s, %3$s, %4$s; %5$s</string>
 
     </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -448,7 +448,7 @@
         Direct
     </string>
     <string name="description_poll">
-        Poll with choices: %s, %s, %s, %s; %s
+        Poll with choices: %1$s, %2$s, %3$s, %4$s; %5$s
     </string>
 
     <string name="hint_list_name">List name</string>


### PR DESCRIPTION
These warnings were occuring on every build, this PR fixes them


`w: /Users/connyduck/Documents/AndroidApps/Tusky/app/src/main/java/com/keylesspalace/tusky/FiltersActivity.kt: (178, 24): Parameter 'v' is never used`

`warn: multiple substitutions specified in non-positional format; did you mean to add the formatted="false" attribute?`

```
/Users/connyduck/Documents/AndroidApps/Tusky/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java:800: warning: non-varargs call of varargs method with inexact argument type for last parameter;
            return context.getString(R.string.description_poll, args);
                                                                ^
  cast to Object for a varargs call
  cast to Object[] for a non-varargs call and to suppress this warning
```
