### PR TITLE
Remove boosted status when the original author was blocked or muted

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -870,7 +870,8 @@ public class TimelineFragment extends SFragment implements
         Iterator<Either<Placeholder, Status>> iterator = statuses.iterator();
         while (iterator.hasNext()) {
             Status status = iterator.next().asRightOrNull();
-            if (status != null && status.getAccount().getId().equals(accountId)) {
+            if (status != null &&
+                    (status.getAccount().getId().equals(accountId) || status.getActionableStatus().getAccount().getId().equals(accountId))) {
                 iterator.remove();
             }
         }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -421,7 +421,7 @@ public final class ViewThreadFragment extends SFragment implements
         Iterator<Status> iterator = statuses.iterator();
         while (iterator.hasNext()) {
             Status s = iterator.next();
-            if (s.getAccount().getId().equals(accountId)) {
+            if (s.getAccount().getId().equals(accountId) || s.getActionableStatus().getAccount().getId().equals(accountId)) {
                 iterator.remove();
             }
         }


### PR DESCRIPTION
Currently, we only remove boosted statuses when the user that boosted the status gets blocked/muted. This PR makes sure statuses will also get removed when the original author gets muted or blocked.