### PR TITLE
Use cached preview as thumbnail in ViewImageFragment, fix #1267

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
@@ -29,21 +29,23 @@ import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.os.Environment
-import androidx.core.content.FileProvider
-import androidx.viewpager.widget.ViewPager
+import android.transition.Transition
+import android.transition.TransitionListenerAdapter
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.webkit.MimeTypeMap
 import android.widget.Toast
+import androidx.core.content.FileProvider
 import androidx.lifecycle.Lifecycle
+import androidx.viewpager.widget.PagerAdapter
+import androidx.viewpager.widget.ViewPager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.FutureTarget
 import com.keylesspalace.tusky.BuildConfig.APPLICATION_ID
 import com.keylesspalace.tusky.entity.Attachment
 import com.keylesspalace.tusky.fragment.ViewImageFragment
-
 import com.keylesspalace.tusky.pager.AvatarImagePagerAdapter
 import com.keylesspalace.tusky.pager.ImagePagerAdapter
 import com.keylesspalace.tusky.util.getTemporaryMediaFilename
@@ -53,14 +55,12 @@ import com.uber.autodispose.autoDisposable
 import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
-
 import kotlinx.android.synthetic.main.activity_view_media.*
-
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
-import java.util.ArrayList
+import java.util.*
 
 class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener {
     companion object {
@@ -125,7 +125,7 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
             AvatarImagePagerAdapter(supportFragmentManager, avatarUrl)
         }
 
-        viewPager.adapter = adapter
+        viewPager.adapter = adapter as PagerAdapter
         viewPager.currentItem = initialPosition
         viewPager.addOnPageChangeListener(object : ViewPager.SimpleOnPageChangeListener() {
             override fun onPageSelected(position: Int) {
@@ -154,6 +154,12 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
 
         window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LOW_PROFILE
         window.statusBarColor = Color.BLACK
+        window.sharedElementEnterTransition.addListener(object : TransitionListenerAdapter() {
+            override fun onTransitionEnd(transition: Transition?) {
+                (adapter as SharedElementTransitionListener).onTransitionEnd()
+                window.sharedElementEnterTransition.removeListener(this)
+            }
+        })
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -326,4 +332,8 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
 
         shareFile(file, mimeType)
     }
+}
+
+interface SharedElementTransitionListener {
+    fun onTransitionEnd()
 }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewImageFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewImageFragment.kt
@@ -30,12 +30,13 @@ import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
-
 import com.github.chrisbanes.photoview.PhotoViewAttacher
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.entity.Attachment
 import com.keylesspalace.tusky.util.hide
 import com.keylesspalace.tusky.util.visible
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.subjects.BehaviorSubject
 import kotlinx.android.synthetic.main.activity_view_media.*
 import kotlinx.android.synthetic.main.fragment_view_image.*
 
@@ -49,14 +50,15 @@ class ViewImageFragment : ViewMediaFragment() {
     private lateinit var attacher: PhotoViewAttacher
     private lateinit var photoActionsListener: PhotoActionsListener
     private lateinit var toolbar: View
-    override lateinit var descriptionView: TextView
+    private var transition = BehaviorSubject.create<Unit>()
 
+    override lateinit var descriptionView: TextView
     override fun onAttach(context: Context) {
         super.onAttach(context)
         photoActionsListener = context as PhotoActionsListener
     }
 
-    override fun setupMediaView(url: String) {
+    override fun setupMediaView(url: String, previewUrl: String?) {
         descriptionView = mediaDescription
         photoView.transitionName = url
         attacher = PhotoViewAttacher(photoView)
@@ -77,7 +79,7 @@ class ViewImageFragment : ViewMediaFragment() {
             result
         }
 
-        loadImageFromNetwork(url, photoView)
+        loadImageFromNetwork(url, previewUrl, photoView)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -103,7 +105,7 @@ class ViewImageFragment : ViewMediaFragment() {
             }
         }
 
-        finalizeViewSetup(url, description)
+        finalizeViewSetup(url, attachment?.previewUrl, description)
     }
 
     private fun onMediaTap() {
@@ -131,49 +133,75 @@ class ViewImageFragment : ViewMediaFragment() {
         super.onDestroyView()
     }
 
-    private fun loadImageFromNetwork(url: String, photoView: ImageView) =
-            //Request image from the any cache
-            Glide.with(this)
-                    .load(url)
-                    .dontAnimate()
-                    .onlyRetrieveFromCache(true)
-                    .error(
-                            //Request image from the network on fail load image from cache
-                            Glide.with(this)
-                                    .load(url)
-                                    .centerInside()
-                                    .addListener(ImageRequestListener(false))
-                    )
-                    .centerInside()
-                    .addListener(ImageRequestListener(true))
-                    .into(photoView)
-
+    private fun loadImageFromNetwork(url: String, previewUrl: String?, photoView: ImageView) {
+        val glide = Glide.with(this)
+        // Request image from the any cache
+        glide
+                .load(url)
+                .dontAnimate()
+                .onlyRetrieveFromCache(true)
+                .let {
+                    if (previewUrl != null)
+                        it.thumbnail(glide
+                                .load(previewUrl)
+                                .dontAnimate()
+                                .onlyRetrieveFromCache(true)
+                                .centerInside()
+                                .addListener(ImageRequestListener(true, isThumnailRequest = true)))
+                    else it
+                }
+                //Request image from the network on fail load image from cache
+                .error(glide.load(url)
+                        .centerInside()
+                        .addListener(ImageRequestListener(false, isThumnailRequest = false))
+                )
+                .centerInside()
+                .addListener(ImageRequestListener(true, isThumnailRequest = false))
+                .into(photoView)
+    }
 
     /**
      * @param isCacheRequest - is this listener for request image from cache or from the network
      */
-    private inner class ImageRequestListener(private val isCacheRequest: Boolean) : RequestListener<Drawable> {
-        override fun onLoadFailed(e: GlideException?, model: Any?, target: Target<Drawable>?, isFirstResource: Boolean): Boolean {
-            if (isCacheRequest) //Complete the transition on failed image from cache
-                completeTransition()
-            else
-                progressBar?.hide() //Hide progress bar only on fail request from internet
+    private inner class ImageRequestListener(
+            private val isCacheRequest: Boolean,
+            private val isThumnailRequest: Boolean) : RequestListener<Drawable> {
+
+        override fun onLoadFailed(e: GlideException?, model: Any?, target: Target<Drawable>?,
+                                  isFirstResource: Boolean): Boolean {
+            // If cache for full image failed, complete transition
+            if (isCacheRequest && !isThumnailRequest) photoActionsListener.onBringUp()
+            // Hide progress bar only on fail request from internet
+            if (!isCacheRequest) progressBar?.hide()
             return false
         }
 
-        override fun onResourceReady(resource: Drawable?, model: Any?, target: Target<Drawable>?, dataSource: DataSource?, isFirstResource: Boolean): Boolean {
-            progressBar?.hide() //Always hide the progress bar on success
+        override fun onResourceReady(resource: Drawable?, model: Any?, target: Target<Drawable>?,
+                                     dataSource: DataSource?, isFirstResource: Boolean): Boolean {
+            progressBar?.hide() // Always hide the progress bar on success
             resource?.let {
-                target?.onResourceReady(resource, null)
-                if (isCacheRequest) completeTransition() //Complete transition on cache request only, because transition already completed on Network request
+                if (isThumnailRequest) {
+                    photoView.post {
+                        target?.onResourceReady(resource, null)
+                        photoActionsListener.onBringUp()
+                    }
+                } else {
+                    transition
+                            .take(1)
+                            .observeOn(AndroidSchedulers.mainThread())
+                            .subscribe {
+                                target?.onResourceReady(resource, null)
+                                photoActionsListener.onBringUp()
+                            }
+                }
                 return true
             }
             return false
         }
+
     }
 
-    private fun completeTransition() {
-        attacher.update()
-        photoActionsListener.onBringUp()
+    override fun onTransitionEnd() {
+        this.transition.onNext(Unit)
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewMediaFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewMediaFragment.kt
@@ -18,15 +18,16 @@ package com.keylesspalace.tusky.fragment
 import android.os.Bundle
 import android.text.TextUtils
 import android.widget.TextView
+import com.keylesspalace.tusky.SharedElementTransitionListener
 
 import com.keylesspalace.tusky.ViewMediaActivity
 import com.keylesspalace.tusky.entity.Attachment
 import com.keylesspalace.tusky.util.visible
 
-abstract class ViewMediaFragment : BaseFragment() {
+abstract class ViewMediaFragment : BaseFragment(), SharedElementTransitionListener {
     private var toolbarVisibiltyDisposable: Function0<Boolean>? = null
 
-    abstract fun setupMediaView(url: String)
+    abstract fun setupMediaView(url: String, previewUrl: String?)
     abstract fun onToolbarVisibilityChange(visible: Boolean)
     abstract val descriptionView : TextView
 
@@ -66,9 +67,9 @@ abstract class ViewMediaFragment : BaseFragment() {
         }
     }
 
-    protected fun finalizeViewSetup(url: String, description: String?) {
+    protected fun finalizeViewSetup(url: String, previewUrl: String?, description: String?) {
         val mediaActivity = activity as ViewMediaActivity
-        setupMediaView(url)
+        setupMediaView(url, previewUrl)
 
         descriptionView.text = description ?: ""
         showingDescription = !TextUtils.isEmpty(description)

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewMediaFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewMediaFragment.kt
@@ -29,15 +29,18 @@ abstract class ViewMediaFragment : BaseFragment(), SharedElementTransitionListen
 
     abstract fun setupMediaView(url: String, previewUrl: String?)
     abstract fun onToolbarVisibilityChange(visible: Boolean)
-    abstract val descriptionView : TextView
+    abstract val descriptionView: TextView
 
     protected var showingDescription = false
     protected var isDescriptionVisible = false
 
     companion object {
-        @JvmStatic protected val ARG_START_POSTPONED_TRANSITION = "startPostponedTransition"
-        @JvmStatic protected val ARG_ATTACHMENT = "attach"
-        @JvmStatic protected val ARG_AVATAR_URL = "avatarUrl"
+        @JvmStatic
+        protected val ARG_START_POSTPONED_TRANSITION = "startPostponedTransition"
+        @JvmStatic
+        protected val ARG_ATTACHMENT = "attach"
+        @JvmStatic
+        protected val ARG_AVATAR_URL = "avatarUrl"
 
         @JvmStatic
         fun newInstance(attachment: Attachment, shouldStartPostponedTransition: Boolean): ViewMediaFragment {
@@ -75,13 +78,12 @@ abstract class ViewMediaFragment : BaseFragment(), SharedElementTransitionListen
         showingDescription = !TextUtils.isEmpty(description)
         isDescriptionVisible = showingDescription
 
-        descriptionView.visible(showingDescription && mediaActivity.isToolbarVisible())
+        descriptionView.visible(showingDescription && mediaActivity.isToolbarVisible)
 
-        toolbarVisibiltyDisposable = (activity as ViewMediaActivity).addToolbarVisibilityListener(object: ViewMediaActivity.ToolbarVisibilityListener {
-            override fun onToolbarVisiblityChanged(isVisible: Boolean) {
-                onToolbarVisibilityChange(isVisible)
-            }
-        })
+        toolbarVisibiltyDisposable = (activity as ViewMediaActivity)
+                .addToolbarVisibilityListener { isVisible ->
+                    onToolbarVisibilityChange(isVisible)
+                }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
@@ -26,7 +26,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.MediaController
 import android.widget.TextView
-
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.ViewMediaActivity
 import com.keylesspalace.tusky.entity.Attachment
@@ -68,7 +67,7 @@ class ViewVideoFragment : ViewMediaFragment() {
     }
 
     @SuppressLint("ClickableViewAccessibility")
-    override fun setupMediaView(url: String) {
+    override fun setupMediaView(url: String, previewUrl: String?) {
         descriptionView = mediaDescription
         val videoView = videoPlayer
         videoView.transitionName = url
@@ -114,7 +113,7 @@ class ViewVideoFragment : ViewMediaFragment() {
             throw IllegalArgumentException("attachment has to be set")
         }
         url = attachment.url
-        finalizeViewSetup(url, attachment.description)
+        finalizeViewSetup(url, attachment.previewUrl, attachment.description)
     }
 
     override fun onToolbarVisibilityChange(visible: Boolean) {
@@ -138,5 +137,8 @@ class ViewVideoFragment : ViewMediaFragment() {
         } else {
             handler.removeCallbacks(hideToolbar)
         }
+    }
+
+    override fun onTransitionEnd() {
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
@@ -55,7 +55,7 @@ class ViewVideoFragment : ViewMediaFragment() {
         }
 
         if (isVisibleToUser) {
-            if (mediaActivity.isToolbarVisible()) {
+            if (mediaActivity.isToolbarVisible) {
                 handler.postDelayed(hideToolbar, TOOLBAR_HIDE_DELAY_MS)
             }
             videoPlayer.start()

--- a/app/src/main/java/com/keylesspalace/tusky/pager/AvatarImagePagerAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/pager/AvatarImagePagerAdapter.kt
@@ -3,12 +3,10 @@ package com.keylesspalace.tusky.pager
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
-
+import com.keylesspalace.tusky.SharedElementTransitionListener
 import com.keylesspalace.tusky.fragment.ViewMediaFragment
-import java.lang.IllegalStateException
 
-class AvatarImagePagerAdapter(fragmentManager: FragmentManager, private val avatarUrl: String) : FragmentPagerAdapter(fragmentManager) {
-
+class AvatarImagePagerAdapter(fragmentManager: FragmentManager, private val avatarUrl: String) : FragmentPagerAdapter(fragmentManager), SharedElementTransitionListener {
     override fun getItem(position: Int): Fragment {
         return if (position == 0) {
             ViewMediaFragment.newAvatarInstance(avatarUrl)
@@ -19,4 +17,6 @@ class AvatarImagePagerAdapter(fragmentManager: FragmentManager, private val avat
 
     override fun getCount() = 1
 
+    override fun onTransitionEnd() {
+    }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/pager/ImagePagerAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/pager/ImagePagerAdapter.kt
@@ -17,9 +17,9 @@ class ImagePagerAdapter(
 
     private var primaryItem: ViewMediaFragment? = null
 
-    override fun setPrimaryItem(container: ViewGroup, position: Int, `object`: Any) {
-        super.setPrimaryItem(container, position, `object`)
-        this.primaryItem = `object` as ViewMediaFragment
+    override fun setPrimaryItem(container: ViewGroup, position: Int, item: Any) {
+        super.setPrimaryItem(container, position, item)
+        this.primaryItem = item as ViewMediaFragment
     }
 
     override fun getItem(position: Int): Fragment {
@@ -41,5 +41,4 @@ class ImagePagerAdapter(
     override fun onTransitionEnd() {
         primaryItem?.onTransitionEnd()
     }
-
 }

--- a/app/src/main/java/com/keylesspalace/tusky/pager/ImagePagerAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/pager/ImagePagerAdapter.kt
@@ -1,20 +1,26 @@
 package com.keylesspalace.tusky.pager
 
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentStatePagerAdapter
-
+import com.keylesspalace.tusky.SharedElementTransitionListener
 import com.keylesspalace.tusky.entity.Attachment
 import com.keylesspalace.tusky.fragment.ViewMediaFragment
-import java.lang.IllegalStateException
-
-import java.util.Locale
+import java.util.*
 
 class ImagePagerAdapter(
         fragmentManager: FragmentManager,
         private val attachments: List<Attachment>,
         private val initialPosition: Int
-) : FragmentStatePagerAdapter(fragmentManager) {
+) : FragmentStatePagerAdapter(fragmentManager), SharedElementTransitionListener {
+
+    private var primaryItem: ViewMediaFragment? = null
+
+    override fun setPrimaryItem(container: ViewGroup, position: Int, `object`: Any) {
+        super.setPrimaryItem(container, position, `object`)
+        this.primaryItem = `object` as ViewMediaFragment
+    }
 
     override fun getItem(position: Int): Fragment {
         return if (position >= 0 && position < attachments.size) {
@@ -31,4 +37,9 @@ class ImagePagerAdapter(
     override fun getPageTitle(position: Int): CharSequence {
         return String.format(Locale.getDefault(), "%d/%d", position + 1, attachments.size)
     }
+
+    override fun onTransitionEnd() {
+        primaryItem?.onTransitionEnd()
+    }
+
 }

--- a/app/src/main/java/com/keylesspalace/tusky/repository/TimelineRepository.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/repository/TimelineRepository.kt
@@ -5,7 +5,6 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.keylesspalace.tusky.db.*
 import com.keylesspalace.tusky.entity.*
-import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.network.MastodonApi
 import com.keylesspalace.tusky.repository.TimelineRequestMode.DISK
 import com.keylesspalace.tusky.repository.TimelineRequestMode.NETWORK


### PR DESCRIPTION
It's not really finished yet but I want to ask for feedback.
Basically when the full image is not in cache, it tried out preview from cache and then loads the complete image.
There are couple of things:
1. Maybe progress bar on top would work better then. We could even show progress but we need to play a little with OkHttp: https://learnpainless.com/android/show-progress-while-loading-images-with-glide
2. I've tried to do the same with video but... let's say it wasn't really successful