### PR TITLE
fix LoginActivity created twice on unauthenticated appstart

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/SplashActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/SplashActivity.kt
@@ -17,10 +17,17 @@ package com.keylesspalace.tusky
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.keylesspalace.tusky.db.AccountManager
+import com.keylesspalace.tusky.di.Injectable
 
 import com.keylesspalace.tusky.util.NotificationHelper
+import javax.inject.Inject
 
-class SplashActivity : BaseActivity() {
+class SplashActivity : AppCompatActivity(), Injectable {
+
+    @Inject
+    lateinit var accountManager: AccountManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,7 +46,5 @@ class SplashActivity : BaseActivity() {
         startActivity(intent)
         finish()
     }
-
-    override fun requiresLogin() = false
 
 }

--- a/app/src/main/java/com/keylesspalace/tusky/SplashActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/SplashActivity.kt
@@ -39,4 +39,7 @@ class SplashActivity : BaseActivity() {
         startActivity(intent)
         finish()
     }
+
+    override fun requiresLogin() = false
+
 }

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -2,6 +2,7 @@
 
     <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowBackground">@drawable/background_splash</item>
+        <item name="colorPrimary">@color/color_primary_dark_dark</item>
         <item name="colorPrimaryDark">@color/color_primary_dark_dark</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowLightNavigationBar">false</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -36,6 +36,7 @@
 
     <style name="SplashTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
         <item name="android:windowBackground">@drawable/background_splash</item>
+        <item name="colorPrimary">@color/color_primary_dark_dark</item>
         <item name="colorPrimaryDark">@color/color_primary_dark_dark</item>
         <item name="android:windowNoTitle">true</item>
     </style>


### PR DESCRIPTION
The LoginActivity was started twice when opening the app while not being logged in because both the BaseActivity and the SplashActivity were redirecting. I only noticed because I pressed back to close the app and there was another login.