### PR TITLE
fix crash caused by broken mention

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.java
@@ -48,7 +48,9 @@ public class LinkHelper {
             return "";
         }
         String host = uri.getHost();
-        if (host.startsWith("www.")) {
+        if(host == null) {
+            return "";
+        } else if (host.startsWith("www.")) {
             return host.substring(4);
         } else {
             return host;


### PR DESCRIPTION
Looks like Plume(?) created statuses with broken mentions that make Tusky crash. This fixes the problem.

Here is the part of the json of the offending status, as returned by my instance chaos.social, note how the `href` part makes no sense at all

```
"content":"\u003cp\u003e\u003ca href=\"/@/0x1C3B00DA/\" rel=\"nofollow noopener\" target=\"_blank\"\u003e@0x1C3B00DA\u003c/a\u003e Blockquotes are supported, it just that they don't have a specific style (only a little margin on the left side), and your Pleroma account is available at https://baptiste.gelez.xyz/\u003ca href=\"/@//\" rel=\"nofollow noopener\" target=\"_blank\"\u003e@\u003c/a\u003e/0x1C3B00DA\u003ca href=\"/@/edolas.world/\" rel=\"nofollow noopener\" target=\"_blank\"\u003e@edolas.world\u003c/a\u003e/ the link in the article is broken because the final dot of your sentence got included…\u003c/p\u003e\n"
```

closes #1359 