### PR TITLE
fix mute action not being correctly displayed

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
@@ -362,6 +362,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
         updateMovedAccount()
         updateRemoteAccount()
         updateAccountStats()
+        invalidateOptionsMenu()
 
         accountMuteButton.setOnClickListener {
             viewModel.changeMuteState()


### PR DESCRIPTION

![Screenshot_20190707-211501](https://user-images.githubusercontent.com/10157047/60917678-caed0780-a291-11e9-8ba4-05ea73d92a72.png)

Basically this happened when the relationship call returned before the account call and the menu was updated without having the account data. Fixed by also updating the menu when the account info arrives.

cc @Tak 