### PR TITLE
fix Glide crash in MainActivity

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
@@ -120,7 +120,7 @@ public final class MainActivity extends BottomSheetActivity implements ActionBut
     private int notificationTabPosition;
     private MainPagerAdapter adapter;
 
-    private EmojiCompat.InitCallback emojiInitCallback = new EmojiCompat.InitCallback() {
+    private final EmojiCompat.InitCallback emojiInitCallback = new EmojiCompat.InitCallback() {
         @Override
         public void onInitialized() {
             updateProfiles();

--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
@@ -120,6 +120,13 @@ public final class MainActivity extends BottomSheetActivity implements ActionBut
     private int notificationTabPosition;
     private MainPagerAdapter adapter;
 
+    private EmojiCompat.InitCallback emojiInitCallback = new EmojiCompat.InitCallback() {
+        @Override
+        public void onInitialized() {
+            updateProfiles();
+        }
+    };
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -309,6 +316,12 @@ public final class MainActivity extends BottomSheetActivity implements ActionBut
         }
     }
 
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        EmojiCompat.get().unregisterInitCallback(emojiInitCallback);
+    }
+
     private void forwardShare(Intent intent) {
         Intent composeIntent = new Intent(this, ComposeActivity.class);
         composeIntent.setAction(intent.getAction());
@@ -438,12 +451,7 @@ public final class MainActivity extends BottomSheetActivity implements ActionBut
             drawer.addItem(debugItem);
         }
 
-        EmojiCompat.get().registerInitCallback(new EmojiCompat.InitCallback() {
-            @Override
-            public void onInitialized() {
-                updateProfiles();
-            }
-        });
+        EmojiCompat.get().registerInitCallback(emojiInitCallback);
     }
 
     private void setupTabs(boolean selectNotificationTab) {


### PR DESCRIPTION
Thats the last fix I would like to have in the 8.1 release. 
Basically the crash happens because the `EmojiCompat.InitCallback` did not care about the activity lifecycle. Lets unregister it in `onDestroy` to fix the problem.

<details>

<summary>Stacktrace</summary>

```
 java.lang.IllegalArgumentException: You cannot start a load for a destroyed activity
        at com.bumptech.glide.manager.RequestManagerRetriever.assertNotDestroyed(RequestManagerRetriever.java:323)
        at com.bumptech.glide.manager.RequestManagerRetriever.get(RequestManagerRetriever.java:157)
        at com.bumptech.glide.manager.RequestManagerRetriever.get(RequestManagerRetriever.java:186)
        at com.bumptech.glide.Glide.with(Glide.java:801)
        at com.keylesspalace.tusky.util.CustomEmojiHelper.emojifyText(CustomEmojiHelper.java:63)
        at com.keylesspalace.tusky.util.CustomEmojiHelper.emojifyString(CustomEmojiHelper.java:78)
        at com.keylesspalace.tusky.MainActivity.updateProfiles(MainActivity.java:596)
        at com.keylesspalace.tusky.MainActivity.access$300(MainActivity.java:88)
        at com.keylesspalace.tusky.MainActivity$3.lambda$onInitialized$0$MainActivity$3(MainActivity.java:446)
        at com.keylesspalace.tusky.-$$Lambda$MainActivity$3$52UEHKACgD3KM9Hsb4fvD0drzfc.run(Unknown Source:2)
        at android.os.Handler.handleCallback(Handler.java:790)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:164)
        at android.app.ActivityThread.main(ActivityThread.java:6523)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:857)
```

</details>