### PR TITLE
make avatar images in drawer rounded squares

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/view/BezelImageView.java
+++ b/app/src/main/java/com/keylesspalace/tusky/view/BezelImageView.java
@@ -1,0 +1,63 @@
+/* Copyright 2019 Tusky contributors
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>. */
+
+package com.keylesspalace.tusky.view;
+
+import android.content.Context;
+import android.graphics.Outline;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewOutlineProvider;
+
+
+/**
+ * override BezelImageView from MaterialDrawer library to provide custom outline
+ */
+
+public class BezelImageView extends com.mikepenz.materialdrawer.view.BezelImageView {
+    public BezelImageView(Context context) {
+        this(context, null);
+    }
+
+    public BezelImageView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public BezelImageView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+
+    @Override
+    protected void onSizeChanged(int w, int h, int old_w, int old_h) {
+        setOutlineProvider(new CustomOutline(w, h));
+    }
+
+    private static class CustomOutline extends ViewOutlineProvider {
+
+        int width;
+        int height;
+
+        CustomOutline(int width, int height) {
+            this.width = width;
+            this.height = height;
+        }
+
+        @Override
+        public void getOutline(View view, Outline outline) {
+            outline.setRoundRect(0, 0, width, height, width < height ? width / 8f : height / 8f);
+        }
+    }
+}

--- a/app/src/main/res/drawable/materialdrawer_shape_large.xml
+++ b/app/src/main/res/drawable/materialdrawer_shape_large.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle" >
+    <solid android:color="#000"/>
+    <corners android:radius="7dp"/>
+</shape>

--- a/app/src/main/res/drawable/materialdrawer_shape_small.xml
+++ b/app/src/main/res/drawable/materialdrawer_shape_small.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle" >
+    <solid android:color="#000"/>
+    <corners android:radius="5dp"/>
+</shape>

--- a/app/src/main/res/layout/material_drawer_header.xml
+++ b/app/src/main/res/layout/material_drawer_header.xml
@@ -1,0 +1,134 @@
+<!-- this replaces the default material_drawer_header.xml from the MaterialDrawer library -->
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/material_drawer_account_header"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/material_drawer_account_header_height"
+    android:clickable="true">
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/material_drawer_account_header_background"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/material_drawer_account_header_height"
+        android:scaleType="centerCrop"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/material_drawer_statusbar_guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_begin="0dp" />
+
+    <com.keylesspalace.tusky.view.BezelImageView
+        android:id="@+id/material_drawer_account_header_current"
+        android:layout_width="@dimen/material_drawer_account_header_selected"
+        android:layout_height="@dimen/material_drawer_account_header_selected"
+        android:layout_marginStart="@dimen/material_drawer_vertical_padding"
+        android:layout_marginLeft="@dimen/material_drawer_vertical_padding"
+        android:layout_marginTop="@dimen/material_drawer_account_header_horizontal_top"
+        android:clickable="true"
+        android:elevation="8dp"
+        android:focusable="true"
+        android:src="@drawable/avatar_default"
+        app:biv_maskDrawable="@drawable/materialdrawer_shape_large"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/material_drawer_statusbar_guideline" />
+
+    <com.keylesspalace.tusky.view.BezelImageView
+        android:id="@+id/material_drawer_account_header_small_first"
+        android:layout_width="@dimen/material_drawer_account_header_secondary"
+        android:layout_height="@dimen/material_drawer_account_header_secondary"
+        android:layout_marginTop="@dimen/material_drawer_account_header_horizontal_top"
+        android:layout_marginEnd="@dimen/material_drawer_vertical_padding"
+        android:layout_marginRight="@dimen/material_drawer_vertical_padding"
+        android:clickable="true"
+        android:elevation="8dp"
+        android:focusable="true"
+        android:src="@drawable/avatar_default"
+        app:biv_maskDrawable="@drawable/materialdrawer_shape_small"
+        app:layout_constraintEnd_toStartOf="@id/material_drawer_account_header_small_second"
+        app:layout_constraintTop_toBottomOf="@+id/material_drawer_statusbar_guideline" />
+
+    <com.keylesspalace.tusky.view.BezelImageView
+        android:id="@+id/material_drawer_account_header_small_second"
+        android:layout_width="@dimen/material_drawer_account_header_secondary"
+        android:layout_height="@dimen/material_drawer_account_header_secondary"
+        android:layout_marginTop="@dimen/material_drawer_account_header_horizontal_top"
+        android:layout_marginEnd="@dimen/material_drawer_vertical_padding"
+        android:layout_marginRight="@dimen/material_drawer_vertical_padding"
+        android:clickable="true"
+        android:elevation="8dp"
+        android:focusable="true"
+        android:src="@drawable/avatar_default"
+        app:biv_maskDrawable="@drawable/materialdrawer_shape_small"
+        app:layout_constraintEnd_toStartOf="@id/material_drawer_account_header_small_third"
+        app:layout_constraintTop_toBottomOf="@+id/material_drawer_statusbar_guideline" />
+
+    <com.keylesspalace.tusky.view.BezelImageView
+        android:id="@+id/material_drawer_account_header_small_third"
+        android:layout_width="@dimen/material_drawer_account_header_secondary"
+        android:layout_height="@dimen/material_drawer_account_header_secondary"
+        android:layout_marginTop="@dimen/material_drawer_account_header_horizontal_top"
+        android:layout_marginEnd="@dimen/material_drawer_vertical_padding"
+        android:layout_marginRight="@dimen/material_drawer_vertical_padding"
+        android:clickable="true"
+        android:elevation="8dp"
+        android:focusable="true"
+        android:src="@drawable/avatar_default"
+        app:biv_maskDrawable="@drawable/materialdrawer_shape_small"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/material_drawer_statusbar_guideline" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/material_drawer_text_guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_end="@dimen/material_drawer_account_header_dropdown_guideline" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/material_drawer_account_header_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/material_drawer_vertical_padding"
+        android:layout_marginLeft="@dimen/material_drawer_vertical_padding"
+        android:fontFamily="sans-serif-medium"
+        android:lines="1"
+        android:maxLines="1"
+        android:textSize="@dimen/material_drawer_account_header_title"
+        app:layout_constraintBottom_toTopOf="@id/material_drawer_account_header_email"
+        app:layout_constraintEnd_toStartOf="@id/material_drawer_account_header_text_switcher"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/material_drawer_text_guideline"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/material_drawer_account_header_email"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/material_drawer_vertical_padding"
+        android:layout_marginLeft="@dimen/material_drawer_vertical_padding"
+        android:layout_marginBottom="@dimen/material_drawer_padding"
+        android:fontFamily="sans-serif"
+        android:lines="1"
+        android:maxLines="1"
+        android:textSize="@dimen/material_drawer_account_header_subtext"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/material_drawer_account_header_text_switcher"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/material_drawer_account_header_name" />
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/material_drawer_account_header_text_switcher"
+        android:layout_width="@dimen/material_drawer_account_header_dropdown"
+        android:layout_height="@dimen/material_drawer_account_header_dropdown"
+        android:layout_marginEnd="@dimen/material_drawer_vertical_padding"
+        android:layout_marginRight="@dimen/material_drawer_vertical_padding"
+        android:layout_marginBottom="@dimen/material_drawer_account_header_dropdown_margin_bottom"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -206,4 +206,10 @@
 
     <style name="TuskyBlackTheme" parent="TuskyBlackThemeBase" />
 
+    <!-- customize the shape of the avatars in account selection list -->
+    <style name="BezelImageView">
+        <item name="biv_maskDrawable">@drawable/materialdrawer_shape_small</item>
+        <item name="biv_drawCircularShadow">false</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
So we finally have our trademark rounded squares with radius 1/8 of size everywhere.

This is a little bit hacky, but definitely easier than forking the MaterialDrawer library.
I added some comments, so I hope it is clear how it works.

![Screenshot_20190715-113625](https://user-images.githubusercontent.com/10157047/61207281-fdb15880-a6f4-11e9-9b02-8f478107cf03.png)

