### PR TITLE
Prevent NPE when displayName/userFullName is null

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -151,8 +151,14 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
     protected abstract int getMediaPreviewHeight(Context context);
 
-    protected void setDisplayName(String name, List<Emoji> customEmojis) {
-        CharSequence emojifiedName = CustomEmojiHelper.emojifyString(name, customEmojis, displayName);
+    protected void setDisplayName(Context context, String name, List<Emoji> customEmojis) {
+
+        CharSequence emojifiedName =
+                CustomEmojiHelper.emojifyString(
+                        (name == null) ? context.getString(R.string.null_display_name_placeholder) : name,
+                        customEmojis,
+                        displayName);
+
         displayName.setText(emojifiedName);
     }
 
@@ -619,7 +625,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                                    boolean animateAvatar,
                                    @Nullable Object payloads) {
         if (payloads == null) {
-            setDisplayName(status.getUserFullName(), status.getAccountEmojis());
+            setDisplayName(itemView.getContext(), status.getUserFullName(), status.getAccountEmojis());
             setUsername(status.getNickname());
             setCreatedAt(status.getCreatedAt());
             setIsReply(status.getInReplyToId() != null);

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationViewHolder.java
@@ -75,7 +75,7 @@ public class ConversationViewHolder extends StatusBaseViewHolder {
 
         setupCollapsedState(status.getCollapsible(), status.getCollapsed(), status.getExpanded(), status.getSpoilerText(), listener);
 
-        setDisplayName(account.getDisplayName(), account.getEmojis());
+        setDisplayName(itemView.getContext(), account.getDisplayName(), account.getEmojis());
         setUsername(account.getUsername());
         setCreatedAt(status.getCreatedAt());
         setIsReply(status.getInReplyToId() != null);

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Account.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Account.kt
@@ -49,7 +49,7 @@ data class Account(
 ) : Parcelable {
 
     val name: String
-        get() = if (displayName.isEmpty()) {
+        get() = if (displayName.isNullOrEmpty()) {
             localUsername
         } else displayName
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -515,4 +515,6 @@
     <string name="report_description_remote_instance">The account is from another server. Send an anonymized copy of the report there as well?</string>
 
     <string name="pref_title_show_notifications_filter">Show Notifications filter</string>
+
+    <string name="null_display_name_placeholder">unknown</string>
 </resources>


### PR DESCRIPTION
- Fixes #1398.
- Corrects edge case that takes some effort to replicate, but is replicable on multiple devices.
- Use `.isNullOrEmpty()` instead of `isEmpty()` in `Account` class.
- Replace null display name of deleted users with placeholder text, defaults to `unknown`.