### PR TITLE
fix timestamp not updating in notifications

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -202,7 +202,7 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
                                 concreteNotificaton.getId());
                     } else {
                         if (payloadForHolder instanceof List)
-                            for (Object item : payloads) {
+                            for (Object item : (List)payloadForHolder) {
                                 if (StatusBaseViewHolder.Key.KEY_CREATED.equals(item)) {
                                     holder.setCreatedAt(statusViewData.getCreatedAt());
                                 }


### PR DESCRIPTION
So when pulling-to-refresh not all timestamps are updated in the NotificationsAdapter because of a small bug that causes the change payload being ignored. 