### PR TITLE
fix CalledFromWrongThreadException in ComposeActivity

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
@@ -314,6 +314,7 @@ public final class ComposeActivity
                             activeAccount.getFullName()));
 
             mastodonApi.getInstance()
+                    .observeOn(AndroidSchedulers.mainThread())
                     .as(autoDisposable(from(this, Lifecycle.Event.ON_DESTROY)))
                     .subscribe(this::onFetchInstanceSuccess, this::onFetchInstanceFailure);
 


### PR DESCRIPTION
cc @Tak 

<details>
<summary>Stacktrace</summary>

```
android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.
        at android.view.ViewRootImpl.checkThread(ViewRootImpl.java:7753)
        at android.view.ViewRootImpl.requestLayout(ViewRootImpl.java:1225)
        at android.view.View.requestLayout(View.java:23093)
        at android.view.View.requestLayout(View.java:23093)
        at android.view.View.requestLayout(View.java:23093)
        at android.view.View.requestLayout(View.java:23093)
        at android.view.View.requestLayout(View.java:23093)
        at android.view.View.requestLayout(View.java:23093)
        at android.view.View.requestLayout(View.java:23093)
        at android.view.View.requestLayout(View.java:23093)
        at android.widget.TextView.checkForRelayout(TextView.java:8908)
        at android.widget.TextView.setText(TextView.java:5730)
        at android.widget.TextView.setText(TextView.java:5571)
        at android.widget.TextView.setText(TextView.java:5528)
        at com.keylesspalace.tusky.ComposeActivity.updateVisibleCharactersLeft(ComposeActivity.java:925)
        at com.keylesspalace.tusky.ComposeActivity.onFetchInstanceSuccess(ComposeActivity.java:1844)
        at com.keylesspalace.tusky.ComposeActivity.lambda$24GFAKjg8msAOf-jq5uneecwmZQ(Unknown Source:0)
        at com.keylesspalace.tusky.-$$Lambda$ComposeActivity$24GFAKjg8msAOf-jq5uneecwmZQ.accept(Unknown Source:4)
        at io.reactivex.internal.observers.ConsumerSingleObserver.onSuccess(ConsumerSingleObserver.java:62)
        at com.uber.autodispose.AutoDisposingSingleObserverImpl.onSuccess(AutoDisposingSingleObserverImpl.java:85) 
        at io.reactivex.internal.operators.observable.ObservableSingleSingle$SingleElementObserver.onComplete(ObservableSingleSingle.java:109) 
        at retrofit2.adapter.rxjava2.BodyObservable$BodyObserver.onComplete(BodyObservable.java:66) 
        at retrofit2.adapter.rxjava2.CallEnqueueObservable$CallCallback.onResponse(CallEnqueueObservable.java:64) 
        at retrofit2.OkHttpCall$1.onResponse(OkHttpCall.java:129) 
        at okhttp3.RealCall$AsyncCall.run(RealCall.kt:138) 
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641) 
        at java.lang.Thread.run(Thread.java:764) 
```

</details>