### PR TITLE
Fix image viewer & transitions

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/pager/ImagePagerAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/pager/ImagePagerAdapter.kt
@@ -16,6 +16,7 @@ class ImagePagerAdapter(
 ) : FragmentStatePagerAdapter(fragmentManager), SharedElementTransitionListener {
 
     private var primaryItem: ViewMediaFragment? = null
+    private var didTransition = false
 
     override fun setPrimaryItem(container: ViewGroup, position: Int, item: Any) {
         super.setPrimaryItem(container, position, item)
@@ -24,7 +25,14 @@ class ImagePagerAdapter(
 
     override fun getItem(position: Int): Fragment {
         return if (position >= 0 && position < attachments.size) {
-            ViewMediaFragment.newInstance(attachments[position], position == initialPosition)
+            // Fragment should not wait for or start transition if it already happened but we
+            // instantiate the same fragment again, e.g. open the first photo, scroll to the
+            // forth photo and then back to the first. The first fragment will trz to start the
+            // transition and wait until it's over and it will never take place.
+            ViewMediaFragment.newInstance(
+                    attachment = attachments[position],
+                    shouldStartPostponedTransition = !didTransition && position == initialPosition
+            )
         } else {
             throw IllegalStateException()
         }
@@ -39,6 +47,7 @@ class ImagePagerAdapter(
     }
 
     override fun onTransitionEnd() {
+        this.didTransition = true
         primaryItem?.onTransitionEnd()
     }
 }


### PR DESCRIPTION
Follow up for #1344 
After few hours of fiddling with it, it seems to finally work now. Images transition, don't jump around when touched, avatars open and so on.
At least one of the problems was that we've been waiting for the transition when we shouldn't (for 3rd and 4th images when you open the 1st one e.g.). Another problem is that we really, really need `attacher.update()` for some reason. Third problem is that after loading Glide resets the image and it could happen when we already set thumbnail...
So, a lot of races. Hopefully it's more reliable now.
I've also noticed that exit transitions don't work for images other than the one you've opened. We could look into that in the future.