### PR TITLE
Fix crash when status date is null

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -252,18 +252,25 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
     }
 
-    protected void setCreatedAt(@NonNull Date createdAt) {
+    protected void setCreatedAt(Date createdAt) {
         if (useAbsoluteTime) {
             timestampInfo.setText(getAbsoluteTime(createdAt));
         } else {
-            long then = createdAt.getTime();
-            long now = System.currentTimeMillis();
-            String readout = TimestampUtils.getRelativeTimeSpanString(timestampInfo.getContext(), then, now);
-            timestampInfo.setText(readout);
+            if(createdAt == null) {
+                timestampInfo.setText("?m");
+            } else {
+                long then = createdAt.getTime();
+                long now = System.currentTimeMillis();
+                String readout = TimestampUtils.getRelativeTimeSpanString(timestampInfo.getContext(), then, now);
+                timestampInfo.setText(readout);
+            }
         }
     }
 
-    private String getAbsoluteTime(@NonNull Date createdAt) {
+    private String getAbsoluteTime(Date createdAt) {
+        if(createdAt == null) {
+            return "??:??:??";
+        }
         if (DateUtils.isToday(createdAt.getTime())) {
             return shortSdf.format(createdAt);
         } else {
@@ -271,18 +278,22 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         }
     }
 
-    private CharSequence getCreatedAtDescription(@NonNull Date createdAt) {
+    private CharSequence getCreatedAtDescription(Date createdAt) {
         if (useAbsoluteTime) {
             return getAbsoluteTime(createdAt);
         } else {
             /* This one is for screen-readers. Frequently, they would mispronounce timestamps like "17m"
              * as 17 meters instead of minutes. */
 
-            long then = createdAt.getTime();
-            long now = System.currentTimeMillis();
-            return DateUtils.getRelativeTimeSpanString(then, now,
-                    DateUtils.SECOND_IN_MILLIS,
-                    DateUtils.FORMAT_ABBREV_RELATIVE);
+            if(createdAt == null) {
+                return "? minutes";
+            } else {
+                long then = createdAt.getTime();
+                long now = System.currentTimeMillis();
+                return DateUtils.getRelativeTimeSpanString(then, now,
+                        DateUtils.SECOND_IN_MILLIS,
+                        DateUtils.FORMAT_ABBREV_RELATIVE);
+            }
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
@@ -67,9 +67,13 @@ class StatusDetailedViewHolder extends StatusBaseViewHolder {
     }
 
     @Override
-    protected void setCreatedAt(@NonNull Date createdAt) {
-        DateFormat dateFormat = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.SHORT);
-        timestampInfo.setText(dateFormat.format(createdAt));
+    protected void setCreatedAt(Date createdAt) {
+        if(createdAt == null) {
+            timestampInfo.setText("");
+        } else {
+            DateFormat dateFormat = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.SHORT);
+            timestampInfo.setText(dateFormat.format(createdAt));
+        }
     }
 
     private void setReblogAndFavCount(int reblogCount, int favCount, StatusActionListener listener) {
@@ -220,6 +224,10 @@ class StatusDetailedViewHolder extends StatusBaseViewHolder {
     }
 
     private void setStatusVisibility(Status.Visibility visibility) {
+
+        if(visibility == null) {
+            return;
+        }
 
         int visibilityIcon;
         switch (visibility) {


### PR DESCRIPTION
I have no idea where null `createdAt` is coming from, but I see it in the crashlogs of the beta. So lets revert the change.

