### PR TITLE
remove redundant request when timeline is empty

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -68,7 +68,6 @@ import com.keylesspalace.tusky.view.EndlessOnScrollListener;
 import com.keylesspalace.tusky.viewdata.StatusViewData;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -286,12 +285,12 @@ public class TimelineFragment extends SFragment implements
     }
 
     private void updateCurrent() {
-        String topId;
         if (this.statuses.isEmpty()) {
-            topId = null;
-        } else {
-            topId = CollectionsKt.first(this.statuses, Either::isRight).asRight().getId();
+            return;
         }
+
+        String topId = CollectionsKt.first(this.statuses, Either::isRight).asRight().getId();
+
         this.timelineRepo.getStatuses(topId, null, null, LOAD_AT_ONCE,
                 TimelineRequestMode.NETWORK)
                 .observeOn(AndroidSchedulers.mainThread())
@@ -303,7 +302,7 @@ public class TimelineFragment extends SFragment implements
                             if (!statuses.isEmpty()) {
                                 filterStatuses(statuses);
 
-                                if (!this.statuses.isEmpty() && topId != null) {
+                                if (!this.statuses.isEmpty()) {
                                     // clear old cached statuses
                                     Iterator<Either<Placeholder, Status>> iterator = this.statuses.iterator();
                                     while (iterator.hasNext()) {


### PR DESCRIPTION
When `TimelineFragment` is created, it makes two requests to the server: One to refresh cached statuses, one to load new ones. When the timeline is empty (e.g. when first logging in and nothing is cached) the request to refresh cached statuses is redundant, so lets remove it.