### PR TITLE
Fix screen reader not announcing post content in some cases

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -682,7 +682,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         String description = context.getString(R.string.description_status,
                 status.getUserFullName(),
                 getContentWarningDescription(context, status),
-                (!status.isSensitive() || status.isExpanded() ? status.getContent() : ""),
+                (TextUtils.isEmpty(status.getSpoilerText()) || !status.isSensitive() || status.isExpanded() ? status.getContent() : ""),
                 getCreatedAtDescription(status.getCreatedAt()),
                 getReblogDescription(context, status),
                 status.getNickname(),


### PR DESCRIPTION
Some posts (especially cross-posted ones) are marked as sensitive but have no CW. User cannot expand them and hear the full content.