### PR TITLE
fix content warning edittext not losing focus when its hidden

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
@@ -1718,6 +1718,7 @@ public final class ComposeActivity
             color = ContextCompat.getColor(this, R.color.tusky_blue);
         } else {
             contentWarningBar.setVisibility(View.GONE);
+            textEditor.requestFocus();
             color = ThemeUtils.getColor(this, android.R.attr.textColorTertiary);
         }
         contentWarningButton.getDrawable().setColorFilter(color, PorterDuff.Mode.SRC_IN);


### PR DESCRIPTION
https://social.diskseven.com/@Jo/102847053684897266
This only happens on a few of my devices, no idea what exactly is going on here, but this one line fixes the issue.