### PR TITLE
fix requestLayout() improperly called warning in AccountActivity

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
@@ -236,10 +236,17 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
 
         // Add a listener to change the toolbar icon color when it enters/exits its collapsed state.
         accountAppBarLayout.addOnOffsetChangedListener(object : AppBarLayout.OnOffsetChangedListener {
+            var priorOffset = 0
+
             @AttrRes
             var priorAttribute = R.attr.account_toolbar_icon_tint_uncollapsed
 
             override fun onOffsetChanged(appBarLayout: AppBarLayout, verticalOffset: Int) {
+
+                if(verticalOffset == priorOffset) {
+                    return
+                }
+                priorOffset = verticalOffset
 
                 @AttrRes val attribute = if (titleVisibleHeight + verticalOffset < 0) {
                     supportActionBar?.setDisplayShowTitleEnabled(true)


### PR DESCRIPTION
Noticed this warning in logcat:
`requestLayout() improperly called by com.google.android.material.appbar.CollapsingToolbarLayout{15ddc71f V.ED.... ......ID 0,0-540,568 #7f0900e4 app:id/collapsingToolbar} during layout: running second layout pass`

this fixes it