### PR TITLE
fix avatars with non-square aspect ratio display

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/ImageLoadingHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ImageLoadingHelper.kt
@@ -5,12 +5,12 @@ package com.keylesspalace.tusky.util
 import android.widget.ImageView
 import androidx.annotation.Px
 import com.bumptech.glide.Glide
-import com.bumptech.glide.load.resource.bitmap.FitCenter
+import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.keylesspalace.tusky.R
 
 
-private val fitCenterTransformation = FitCenter()
+private val centerCropTransformation = CenterCrop()
 
 fun loadAvatar(url: String?, imageView: ImageView, @Px radius: Int, animate: Boolean) {
 
@@ -23,7 +23,7 @@ fun loadAvatar(url: String?, imageView: ImageView, @Px radius: Int, animate: Boo
             Glide.with(imageView)
                     .load(url)
                     .transform(
-                            fitCenterTransformation,
+                            centerCropTransformation,
                             RoundedCorners(radius)
                     )
                     .placeholder(R.drawable.avatar_default)
@@ -34,7 +34,7 @@ fun loadAvatar(url: String?, imageView: ImageView, @Px radius: Int, animate: Boo
                     .asBitmap()
                     .load(url)
                     .transform(
-                            fitCenterTransformation,
+                            centerCropTransformation,
                             RoundedCorners(radius)
                     )
                     .placeholder(R.drawable.avatar_default)


### PR DESCRIPTION
Apparently there can be non-square avatars and Tusky displays them like so:

![device-2019-10-09-194841](https://user-images.githubusercontent.com/10157047/66507143-f076f080-eace-11e9-85ad-b9da2a7f8147.png)
