### PR TITLE
fix null search when refreshing hashtags

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
@@ -79,9 +79,7 @@ class SearchActivity : BottomSheetActivity(), SearchView.OnQueryTextListener, Ha
                 .actionView as SearchView
         setupSearchView(searchView)
 
-        if (viewModel.currentQuery != null) {
-            searchView.setQuery(viewModel.currentQuery, false)
-        }
+        searchView.setQuery(viewModel.currentQuery, false)
 
         return true
     }
@@ -115,7 +113,7 @@ class SearchActivity : BottomSheetActivity(), SearchView.OnQueryTextListener, Ha
 
     private fun handleIntent(intent: Intent) {
         if (Intent.ACTION_SEARCH == intent.action) {
-            viewModel.currentQuery = intent.getStringExtra(SearchManager.QUERY)
+            viewModel.currentQuery = intent.getStringExtra(SearchManager.QUERY) ?: ""
             viewModel.search(viewModel.currentQuery)
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
@@ -26,7 +26,7 @@ class SearchViewModel @Inject constructor(
         private val timelineCases: TimelineCases,
         private val accountManager: AccountManager) : ViewModel() {
 
-    var currentQuery: String? = null
+    var currentQuery: String = ""
 
     var activeAccount: AccountEntity?
         get() = accountManager.activeAccount
@@ -62,7 +62,7 @@ class SearchViewModel @Inject constructor(
     val networkStateHashTagRefresh: LiveData<NetworkState> = Transformations.switchMap(repoResultHashTag) { it.refreshState }
 
     private val loadedStatuses = ArrayList<Pair<Status, StatusViewData.Concrete>>()
-    fun search(query: String?) {
+    fun search(query: String) {
         loadedStatuses.clear()
         repoResultStatus.value = statusesRepository.getSearchData(SearchType.Status, query, disposables, initialItems = loadedStatuses) {
             (it?.statuses?.map { status -> Pair(status, ViewDataUtils.statusToViewData(status, alwaysShowSensitiveMedia, alwaysOpenSpoiler)!!) }
@@ -74,7 +74,7 @@ class SearchViewModel @Inject constructor(
         repoResultAccount.value = accountsRepository.getSearchData(SearchType.Account, query, disposables) {
             it?.accounts ?: emptyList()
         }
-        val hashtagQuery = if (query != null && query.startsWith("#")) query else "#$query"
+        val hashtagQuery = if (query.startsWith("#")) query else "#$query"
         repoResultHashTag.value =
                 hashtagsRepository.getSearchData(SearchType.Hashtag, hashtagQuery, disposables) {
                     it?.hashtags ?: emptyList()

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/adapter/SearchAccountsAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/adapter/SearchAccountsAdapter.kt
@@ -22,12 +22,8 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.adapter.AccountViewHolder
-import com.keylesspalace.tusky.adapter.StatusViewHolder
 import com.keylesspalace.tusky.entity.Account
-import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.interfaces.LinkListener
-import com.keylesspalace.tusky.interfaces.StatusActionListener
-import com.keylesspalace.tusky.viewdata.StatusViewData
 
 class SearchAccountsAdapter(private val linkListener: LinkListener)
     : PagedListAdapter<Account, RecyclerView.ViewHolder>(STATUS_COMPARATOR) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchFragment.kt
@@ -28,7 +28,7 @@ import javax.inject.Inject
 
 abstract class SearchFragment<T> : Fragment(),
         LinkListener, Injectable, SwipeRefreshLayout.OnRefreshListener {
-    private var isSwipeToRefreshEnabled: Boolean = true
+
     private var snackbarErrorRetry: Snackbar? = null
     @Inject
     lateinit var viewModelFactory: ViewModelFactory


### PR DESCRIPTION
Steps to reproduce: Open search, go to hashtags. Don't search anything, refresh. Hashtags for searchterm "null" will be displayed.

![Screenshot_1574005800](https://user-images.githubusercontent.com/10157047/69010099-258f2200-095c-11ea-9fa2-868d060057a8.png)
