### PR TITLE
ScheduledTootActivity: fix toolbar back button #1586

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ScheduledTootActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ScheduledTootActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.view.MenuItem
 import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -78,6 +79,16 @@ class ScheduledTootActivity : BaseActivity(), ScheduledTootAdapter.ScheduledToot
                         refreshStatuses()
                     }
                 }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            android.R.id.home -> {
+                onBackPressed()
+                return true
+            }
+        }
+        return super.onOptionsItemSelected(item)
     }
 
     fun loadStatuses() {


### PR DESCRIPTION
Added forgotten onOptionsItemSelected, so toolbar back button does work again.

However, I would rather suggest move onOptionsItemSelected to BaseActivity.java and remove copypasted code from every activity that has toolbar with back button but it's not intuitive and theoretically may break unexpectedly.