### PR TITLE
Implement identity proof api

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
@@ -52,6 +52,8 @@ import com.keylesspalace.tusky.components.compose.ComposeActivity
 import com.keylesspalace.tusky.components.report.ReportActivity
 import com.keylesspalace.tusky.di.ViewModelFactory
 import com.keylesspalace.tusky.entity.Account
+import com.keylesspalace.tusky.entity.Field
+import com.keylesspalace.tusky.entity.IdentityProof
 import com.keylesspalace.tusky.entity.Relationship
 import com.keylesspalace.tusky.interfaces.ActionButtonActivity
 import com.keylesspalace.tusky.interfaces.LinkListener
@@ -350,6 +352,11 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
             }
 
         })
+        viewModel.accountFieldData.observe(this, Observer<List<Either<IdentityProof, Field>>> {
+            accountFieldAdapter.fields = it
+            accountFieldAdapter.notifyDataSetChanged()
+
+        })
     }
 
     /**
@@ -378,7 +385,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
         val emojifiedNote = CustomEmojiHelper.emojifyText(account.note, account.emojis, accountNoteTextView)
         LinkHelper.setClickableText(accountNoteTextView, emojifiedNote, null, this)
 
-        accountFieldAdapter.fields = account.fields ?: emptyList()
+       // accountFieldAdapter.fields = account.fields ?: emptyList()
         accountFieldAdapter.emojis = account.emojis ?: emptyList()
         accountFieldAdapter.notifyDataSetChanged()
 

--- a/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
@@ -19,8 +19,7 @@ import android.animation.ArgbEvaluator
 import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
-import android.graphics.Color
-import android.graphics.PorterDuff
+import android.graphics.*
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -120,7 +119,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
         viewModel = ViewModelProviders.of(this, viewModelFactory)[AccountViewModel::class.java]
 
         // Obtain information to fill out the profile.
-        viewModel.setAccountInfo(intent.getStringExtra(KEY_ACCOUNT_ID))
+        viewModel.setAccountInfo(intent.getStringExtra(KEY_ACCOUNT_ID)!!)
 
         val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(this)
         animateAvatar = sharedPrefs.getBoolean("animateGifAvatars", false)
@@ -479,7 +478,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
             // this is necessary because API 19 can't handle vector compound drawables
             val movedIcon = ContextCompat.getDrawable(this, R.drawable.ic_briefcase)?.mutate()
             val textColor = ThemeUtils.getColor(this, android.R.attr.textColorTertiary)
-            movedIcon?.setColorFilter(textColor, PorterDuff.Mode.SRC_IN)
+            movedIcon?.colorFilter = PorterDuffColorFilter(textColor, PorterDuff.Mode.SRC_IN)
 
             accountMovedText.setCompoundDrawablesRelativeWithIntrinsicBounds(movedIcon, null, null, null)
         }

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
@@ -115,10 +115,7 @@ class StatusDetailedViewHolder extends StatusBaseViewHolder {
             timestampInfo.append("  •  ");
 
             if (app.getWebsite() != null) {
-                URLSpan span = new CustomURLSpan(app.getWebsite());
-
-                SpannableStringBuilder text = new SpannableStringBuilder(app.getName());
-                text.setSpan(span, 0, app.getName().length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+                CharSequence text = LinkHelper.createClickableText(app.getName(), app.getWebsite());
                 timestampInfo.append(text);
                 timestampInfo.setMovementMethod(LinkMovementMethod.getInstance());
             } else {

--- a/app/src/main/java/com/keylesspalace/tusky/entity/IdentityProof.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/IdentityProof.kt
@@ -1,0 +1,9 @@
+package com.keylesspalace.tusky.entity
+
+import com.google.gson.annotations.SerializedName
+
+data class IdentityProof(
+        val provider: String,
+        @SerializedName("provider_username") val username: String,
+        @SerializedName("profile_url") val profileUrl: String
+)

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -318,6 +318,11 @@ interface MastodonApi {
             @Query("id[]") accountIds: List<String>
     ): Call<List<Relationship>>
 
+    @GET("api/v1/accounts/{id}/identity_proofs")
+    fun identityProofs(
+            @Path("id") accountId: String
+    ): Call<List<IdentityProof>>
+
     @GET("api/v1/blocks")
     fun blocks(
             @Query("max_id") maxId: String?

--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.java
@@ -179,6 +179,14 @@ public class LinkHelper {
         view.setMovementMethod(LinkMovementMethod.getInstance());
     }
 
+    public static CharSequence createClickableText(String text, String link) {
+        URLSpan span = new CustomURLSpan(link);
+
+        SpannableStringBuilder clickableText = new SpannableStringBuilder(text);
+        clickableText.setSpan(span, 0, text.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
+        return text;
+    }
+
     /**
      * Opens a link, depending on the settings, either in the browser or in a custom tab
      *

--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.java
@@ -184,7 +184,7 @@ public class LinkHelper {
 
         SpannableStringBuilder clickableText = new SpannableStringBuilder(text);
         clickableText.setSpan(span, 0, text.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
-        return text;
+        return clickableText;
     }
 
     /**

--- a/app/src/main/java/com/keylesspalace/tusky/viewmodel/AccountViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/viewmodel/AccountViewModel.kt
@@ -83,6 +83,7 @@ class AccountViewModel @Inject constructor(
                 }
 
                 override fun onFailure(call: Call<Account>, t: Throwable) {
+                    Log.w(TAG, "failed obtaining account", t)
                     accountData.postValue(Error())
                     isDataLoading = false
                     isRefreshing.postValue(false)
@@ -113,6 +114,7 @@ class AccountViewModel @Inject constructor(
                 }
 
                 override fun onFailure(call: Call<List<Relationship>>, t: Throwable) {
+                    Log.w(TAG, "failed obtaining relationships", t)
                     relationshipData.postValue(Error())
                 }
             })
@@ -137,7 +139,7 @@ class AccountViewModel @Inject constructor(
                 }
 
                 override fun onFailure(call: Call<List<IdentityProof>>, t: Throwable) {
-                    relationshipData.postValue(Error())
+                    Log.w(TAG, "failed obtaining identity proofs", t)
                 }
             })
 


### PR DESCRIPTION
I don't know if `MediatorLiveData` is the way to go here... It causes more adapter updates than necessary, but works fine.
Other possibility would be to move this to Rx and zip the two network requests, have only one `LiveData` with a `Pair<Account, List<IdentityProofs>`.

Also, instead of `Either<IdentityProof, Field>` I could map the IdentityProofs to Fields 🤔 

Thoughts?