### PR TITLE
Display Elephant with better message in Drafts screen when there are none

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/SavedTootActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/SavedTootActivity.java
@@ -20,7 +20,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.TextView;
+import android.widget.LinearLayout;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
@@ -41,6 +41,7 @@ import com.keylesspalace.tusky.db.TootDao;
 import com.keylesspalace.tusky.db.TootEntity;
 import com.keylesspalace.tusky.di.Injectable;
 import com.keylesspalace.tusky.util.SaveTootHelper;
+import com.keylesspalace.tusky.view.BackgroundMessageView;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Type;
@@ -60,7 +61,7 @@ public final class SavedTootActivity extends BaseActivity implements SavedTootAd
 
     // ui
     private SavedTootAdapter adapter;
-    private TextView noContent;
+    private BackgroundMessageView errorMessageView;
 
     private List<TootEntity> toots = new ArrayList<>();
     @Nullable
@@ -95,7 +96,7 @@ public final class SavedTootActivity extends BaseActivity implements SavedTootAd
         }
 
         RecyclerView recyclerView = findViewById(R.id.recyclerView);
-        noContent = findViewById(R.id.no_content);
+        errorMessageView = findViewById(R.id.errorMessageView);
         recyclerView.setHasFixedSize(true);
         LinearLayoutManager layoutManager = new LinearLayoutManager(this);
         recyclerView.setLayoutManager(layoutManager);
@@ -136,9 +137,10 @@ public final class SavedTootActivity extends BaseActivity implements SavedTootAd
 
     private void setNoContent(int size) {
         if (size == 0) {
-            noContent.setVisibility(View.VISIBLE);
+            errorMessageView.setup(R.drawable.elephant_friend_empty, R.string.no_saved_status, null);
+            errorMessageView.setVisibility(View.VISIBLE);
         } else {
-            noContent.setVisibility(View.INVISIBLE);
+            errorMessageView.setVisibility(View.GONE);
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/SavedTootActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/SavedTootActivity.java
@@ -20,7 +20,6 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.LinearLayout;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;

--- a/app/src/main/res/layout/activity_saved_toot.xml
+++ b/app/src/main/res/layout/activity_saved_toot.xml
@@ -14,18 +14,20 @@
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <TextView
-            android:id="@+id/no_content"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:text="@string/no_content"
-            android:visibility="invisible" />
-
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recyclerView"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
+
+        <com.keylesspalace.tusky.view.BackgroundMessageView
+            android:id="@+id/errorMessageView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:src="@android:color/transparent"
+            android:visibility="gone"
+            tools:src="@drawable/elephant_error"
+            tools:visibility="visible" />
 
     </RelativeLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -306,8 +306,6 @@
 
     <string name="state_follow_requested">Follow requested</string>
 
-    <string name="no_content">no content</string>
-
     <!--These are for timestamps on statuses. For example: "16s" or "2d"-->
     <string name="abbreviated_in_years">in %dy</string>
     <string name="abbreviated_in_days">in %dd</string>
@@ -546,6 +544,7 @@
     <string name="edit_poll">Edit</string>
     <string name="post_lookup_error_format">Error looking up post %s</string>
 
+    <string name="no_saved_status">You don\'t have any drafts.</string>
     <string name="no_scheduled_status">You don\'t have any scheduled statuses.</string>
 
 </resources>


### PR DESCRIPTION
Before:

![Screenshot_20200104-230347_Tusky](https://user-images.githubusercontent.com/2446451/71772163-9d360200-2f46-11ea-8979-9351eacb7d4b.png)

After:

![Screenshot_20200104-230327_Tusky](https://user-images.githubusercontent.com/2446451/71772162-9c9d6b80-2f46-11ea-9351-7bd949766ff1.png)

Inspired by Scheduled toot activity:

![Screenshot_20200104-230319_Tusky](https://user-images.githubusercontent.com/2446451/71772161-9c9d6b80-2f46-11ea-949b-08ccc00bc357.png)