### PR TITLE
Implement local bookmarks

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/db/TimelineDao.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/TimelineDao.kt
@@ -45,9 +45,12 @@ ELSE 1 END)
 AND (CASE WHEN :sinceId IS NOT NULL THEN
 (LENGTH(s.serverId) > LENGTH(:sinceId) OR LENGTH(s.serverId) == LENGTH(:sinceId) AND s.serverId > :sinceId)
 ELSE 1 END)
+AND (CASE WHEN :bookmarkedOnly THEN
+(s.bookmarked == '1')
+ELSE 1 END)
 ORDER BY LENGTH(s.serverId) DESC, s.serverId DESC
 LIMIT :limit""")
-    abstract fun getStatusesForAccount(account: Long, maxId: String?, sinceId: String?, limit: Int): Single<List<TimelineStatusWithAccount>>
+    abstract fun getStatusesForAccount(account: Long, maxId: String?, sinceId: String?, limit: Int, bookmarkedOnly: Boolean = false): Single<List<TimelineStatusWithAccount>>
 
 
     @Transaction
@@ -100,7 +103,7 @@ AND serverId = :statusId""")
     abstract fun delete(accountId: Long, statusId: String)
 
     @Query("""DELETE FROM TimelineStatusEntity WHERE timelineUserId = :accountId
-AND authorServerId != :accountServerId AND createdAt < :olderThan""")
+AND authorServerId != :accountServerId AND createdAt < :olderThan AND bookmarked != '1'""")
     abstract fun cleanup(accountId: Long, accountServerId: String, olderThan: Long)
 
     @Query("""UPDATE TimelineStatusEntity SET poll = :poll

--- a/app/src/main/java/com/keylesspalace/tusky/di/AppModule.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/di/AppModule.kt
@@ -29,6 +29,7 @@ import com.keylesspalace.tusky.db.AppDatabase
 import com.keylesspalace.tusky.network.MastodonApi
 import com.keylesspalace.tusky.network.TimelineCases
 import com.keylesspalace.tusky.network.TimelineCasesImpl
+import com.keylesspalace.tusky.repository.TimelineRepository
 import com.keylesspalace.tusky.util.HtmlConverter
 import com.keylesspalace.tusky.util.HtmlConverterImpl
 import dagger.Module
@@ -60,8 +61,9 @@ class AppModule {
 
     @Provides
     fun providesTimelineUseCases(api: MastodonApi,
-                                 eventHub: EventHub): TimelineCases {
-        return TimelineCasesImpl(api, eventHub)
+                                 eventHub: EventHub,
+                                 timelineRepository: TimelineRepository): TimelineCases {
+        return TimelineCasesImpl(api, eventHub, timelineRepository)
     }
 
     @Provides

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -1016,6 +1016,14 @@ public class TimelineFragment extends SFragment implements
                             (result) -> onFetchTimelineSuccess(result, fetchEnd, pos),
                             (err) -> onFetchTimelineFailure(new Exception(err), fetchEnd, pos)
                     );
+        } else if (kind == Kind.BOOKMARKS) {
+            timelineRepo.getBookmarks(maxId, sinceId, sinceIdMinusOne, LOAD_AT_ONCE)
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .as(autoDisposable(from(this, Lifecycle.Event.ON_DESTROY)))
+                    .subscribe(
+                            (result) -> onFetchTimelineSuccess(result, fetchEnd, pos),
+                            (err) -> onFetchTimelineFailure(new Exception(err), fetchEnd, pos)
+                    );
         } else {
             Callback<List<Status>> callback = new Callback<List<Status>>() {
                 @Override

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -368,6 +368,13 @@ interface MastodonApi {
             @Query("limit") limit: Int?
     ): Call<List<Status>>
 
+    @GET("api/v1/bookmarks")
+    fun bookmarksObservable(
+            @Query("max_id") maxId: String?,
+            @Query("since_id") sinceId: String?,
+            @Query("limit") limit: Int?
+    ): Single<List<Status>>
+
     @GET("api/v1/follow_requests")
     fun followRequests(
             @Query("max_id") maxId: String?

--- a/app/src/test/java/com/keylesspalace/tusky/fragment/TimelineRepositoryTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/fragment/TimelineRepositoryTest.kt
@@ -293,6 +293,24 @@ class TimelineRepositoryTest {
         assertEquals(listOf(status).map(Status::lift), result)
     }
 
+
+    @Test
+    fun getLocalBookmarked() {
+        RxJavaPlugins.setIoSchedulerHandler { Schedulers.single() }
+        val status = makeStatus("4").copy(bookmarked = true)
+        val dbResult = TimelineStatusWithAccount()
+        dbResult.status = status.toEntity(account.id, htmlConverter, gson)
+        dbResult.account = status.account.toEntity(account.id, gson)
+
+        whenever(mastodonApi.bookmarksObservable(any(), any(), anyInt()))
+                .thenReturn(Single.error(Exception()))
+        whenever(timelineDao.getStatusesForAccount(account.id, null, null, 30, true))
+                .thenReturn(Single.just(listOf(dbResult)))
+        val result = subject.getBookmarks(null, null, null, limit)
+                .blockingGet()
+        assertEquals(listOf(status).map(Status::lift), result)
+    }
+
     private fun makeStatus(id: String, account: Account = makeAccount(id)): Status {
         return Status(
                 id = id,


### PR DESCRIPTION
We already had implementation of bookmarks which relies on the server
but most servers don't support this yet so we needed a local fallback.
This commits adds such a fallback. Bookmarked statuses are saved to
the DB and never cleaned up. We fetch them likely any other statuses
from DB with additional condition.

There's only one problem one: in timeline the bookmark state is not displayed correctly when we load statuses from network. I don't think it's a big problem but I think we could do one of two things:
1. Load all/range bookmarks in repository from db and check which are bookmarked
2. Hide bookmark button (that's what vanilla web client does now btw)