### PR TITLE
Retain content warning when replying to a CWed post

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -166,8 +166,7 @@ class ComposeActivity : BaseActivity(),
         setupContentWarningField(composeOptions?.contentWarning)
         setupPollView()
         applyShareIntent(intent, savedInstanceState)
-
-        composeEditField.requestFocus()
+        viewModel.setupComplete.value = true
     }
 
     private fun applyShareIntent(intent: Intent?, savedInstanceState: Bundle?) {
@@ -330,6 +329,10 @@ class ComposeActivity : BaseActivity(),
             }.subscribe()
             viewModel.uploadError.observe {
                 displayTransientError(R.string.error_media_upload_sending)
+            }
+            viewModel.setupComplete.observe {
+                // Focus may have changed during view model setup, ensure initial focus is on the edit field
+                composeEditField.requestFocus()
             }
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -82,6 +82,7 @@ class ComposeViewModel
 
     val statusVisibility = mutableLiveData(Status.Visibility.UNKNOWN)
     val showContentWarning = mutableLiveData(false)
+    val setupComplete = mutableLiveData(false)
     val poll: MutableLiveData<NewPoll?> = mutableLiveData(null)
     val scheduledAt: MutableLiveData<String?> = mutableLiveData(null)
 
@@ -367,6 +368,7 @@ class ComposeViewModel
         if (contentWarning != null) {
             startingContentWarning = contentWarning
         }
+        showContentWarning.value = !contentWarning.isNullOrBlank()
 
         // recreate media list
         // when coming from SavedTootActivity


### PR DESCRIPTION
This seems to have regressed with the `ComposeActivity` refactor - if you reply to a post with a content warning, the CW is carried over to the reply, but the content warning toggle in the newly-created compose activity isn't activated.

The proposed fix sets `showContentWarning` in the view model when it's set up with a nonnull CW.
The `setupComplete` roundtrip is there because the event for showing the content warning is dispatched _after_ the activity creation finishes, so without it, the focus is incorrectly set to the CW field.