### PR TITLE
fix notification refresh

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -1024,6 +1024,14 @@ public class NotificationsFragment extends SFragment implements
             }
         }
         Log.e(TAG, "Fetch failure: " + exception.getMessage());
+
+        if (fetchEnd == FetchEnd.TOP) {
+            topLoading = false;
+        }
+        if (fetchEnd == FetchEnd.BOTTOM) {
+            bottomLoading = false;
+        }
+
         progressBar.setVisibility(View.GONE);
     }
 


### PR DESCRIPTION
Pull to refresh on the notifications tab while offline. The second pull will load forever because `if(fetchEnd == FetchEnd.TOP && topLoading) { return; }` and `topLoading` is not reset in the error callback.

Closes #1637 