### PR TITLE
Fix setting text to CW button in fav/reblog notification. Fix #1641

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -479,6 +479,11 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
                 boolean hasSpoiler = !TextUtils.isEmpty(statusViewData.getSpoilerText());
                 contentWarningDescriptionTextView.setVisibility(hasSpoiler ? View.VISIBLE : View.GONE);
                 contentWarningButton.setVisibility(hasSpoiler ? View.VISIBLE : View.GONE);
+                if (statusViewData.isExpanded()) {
+                    contentWarningButton.setText(R.string.status_content_warning_show_less);
+                } else {
+                    contentWarningButton.setText(R.string.status_content_warning_show_more);
+                }
 
                 contentWarningButton.setOnClickListener(view -> {
                     if (getAdapterPosition() != RecyclerView.NO_POSITION) {


### PR DESCRIPTION
This is a regression from e5b78f65cf61f3ded18f2ded93cd57b8c0af42c9