### PR TITLE
Make avatars lighter, not darker in light theme, fix #1258

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -17,7 +17,10 @@ package com.keylesspalace.tusky.adapter;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.graphics.ColorFilter;
+import android.graphics.LightingColorFilter;
 import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.text.InputFilter;
@@ -49,6 +52,7 @@ import com.keylesspalace.tusky.util.ImageLoadingHelper;
 import com.keylesspalace.tusky.util.LinkHelper;
 import com.keylesspalace.tusky.util.SmartLengthInputFilter;
 import com.keylesspalace.tusky.util.StatusDisplayOptions;
+import com.keylesspalace.tusky.util.ThemeUtils;
 import com.keylesspalace.tusky.util.TimestampUtils;
 import com.keylesspalace.tusky.viewdata.NotificationViewData;
 import com.keylesspalace.tusky.viewdata.StatusViewData;
@@ -367,9 +371,18 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
             contentCollapseButton = itemView.findViewById(R.id.button_toggle_notification_content);
             this.statusDisplayOptions = statusDisplayOptions;
 
-            int darkerFilter = Color.rgb(123, 123, 123);
-            statusAvatar.setColorFilter(darkerFilter, PorterDuff.Mode.MULTIPLY);
-            notificationAvatar.setColorFilter(darkerFilter, PorterDuff.Mode.MULTIPLY);
+            ColorFilter colorFilter;
+            // Wow this is horrible
+            if (ThemeUtils.getColorId(itemView.getContext(), R.attr.window_background)
+                    == R.color.window_background_light) {
+                colorFilter = new LightingColorFilter(Color.WHITE, Color.rgb(100, 100, 100));
+            } else {
+                colorFilter = new PorterDuffColorFilter(Color.rgb(123, 123, 123),
+                        PorterDuff.Mode.MULTIPLY);
+            }
+
+            statusAvatar.setColorFilter(colorFilter);
+            notificationAvatar.setColorFilter(colorFilter);
 
             itemView.setOnClickListener(this);
             message.setOnClickListener(this);


### PR DESCRIPTION
We will probably throw it away but I experimented with making avatars brighter, not darker on light theme. Didn't go that well.
Multiple can only make something darker (because white is like 1 and other colors are fractions of it) so we have to add in some smart way. Also we have to take care of rounded corners, we cannot subtract anything from them.
Here is a useful link with exmaples:
https://medium.com/better-programming/practical-image-porterduff-mode-usage-in-android-3b4b5d2e8f5f
Here are docs or PorterDuff modes:
https://developer.android.com/reference/android/graphics/PorterDuff.Mode.html#DARKEN
I think Screen mode would be perfect but it screws up corners so I'm not sure what to do about it.

Maybe we could even apply filter to the bitmap itself and not to the image.

![Screenshot_20200118-001915](https://user-images.githubusercontent.com/3099142/72652810-949eec00-3988-11ea-8e46-787a20834179.png)
