### PR TITLE
fix FragmentAdapter returning null fragments when activity was recreated

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/pager/AccountPagerAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/pager/AccountPagerAdapter.kt
@@ -21,33 +21,23 @@ import com.keylesspalace.tusky.fragment.AccountMediaFragment
 import com.keylesspalace.tusky.fragment.TimelineFragment
 import com.keylesspalace.tusky.interfaces.RefreshableFragment
 
-import androidx.viewpager2.adapter.FragmentStateAdapter
-import java.lang.ref.WeakReference
+import com.keylesspalace.tusky.util.CustomFragmentStateAdapter
 
 class AccountPagerAdapter(
         activity: FragmentActivity,
         private val accountId: String
-) : FragmentStateAdapter(activity) {
-
-    private val fragments = MutableList<WeakReference<Fragment>?>(TAB_COUNT) { null }
+) : CustomFragmentStateAdapter(activity) {
 
     override fun getItemCount() = TAB_COUNT
 
     override fun createFragment(position: Int): Fragment {
-        val fragment: Fragment = when (position) {
+        return when (position) {
             0 -> TimelineFragment.newInstance(TimelineFragment.Kind.USER, accountId, false)
             1 -> TimelineFragment.newInstance(TimelineFragment.Kind.USER_WITH_REPLIES, accountId, false)
             2 -> TimelineFragment.newInstance(TimelineFragment.Kind.USER_PINNED, accountId, false)
             3 -> AccountMediaFragment.newInstance(accountId, false)
             else -> throw AssertionError("Page $position is out of AccountPagerAdapter bounds")
         }
-
-        fragments[position] = WeakReference(fragment)
-        return fragment
-    }
-
-    fun getFragment(position: Int): Fragment? {
-        return fragments[position]?.get()
     }
 
     fun refreshContent() {

--- a/app/src/main/java/com/keylesspalace/tusky/pager/MainPagerAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/pager/MainPagerAdapter.kt
@@ -17,10 +17,8 @@ package com.keylesspalace.tusky.pager
 
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
-import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.keylesspalace.tusky.TabData
 import com.keylesspalace.tusky.util.CustomFragmentStateAdapter
-import java.lang.ref.WeakReference
 
 class MainPagerAdapter(val tabs: List<TabData>, activity: FragmentActivity) : CustomFragmentStateAdapter(activity) {
 

--- a/app/src/main/java/com/keylesspalace/tusky/util/CustomFragmentStateAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/CustomFragmentStateAdapter.kt
@@ -19,7 +19,9 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
 
-abstract class CustomFragmentStateAdapter(val activity: FragmentActivity): FragmentStateAdapter(activity) {
+abstract class CustomFragmentStateAdapter(
+        private val activity: FragmentActivity
+): FragmentStateAdapter(activity) {
 
     fun getFragment(position: Int): Fragment?
             = activity.supportFragmentManager.findFragmentByTag("f"  + getItemId(position))

--- a/app/src/main/java/com/keylesspalace/tusky/util/CustomFragmentStateAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/CustomFragmentStateAdapter.kt
@@ -1,4 +1,4 @@
-/* Copyright 2017 Andrew Dawson
+/* Copyright 2019 Tusky Contributors
  *
  * This file is a part of Tusky.
  *
@@ -13,22 +13,14 @@
  * You should have received a copy of the GNU General Public License along with Tusky; if not,
  * see <http://www.gnu.org/licenses>. */
 
-package com.keylesspalace.tusky.pager
+package com.keylesspalace.tusky.util
 
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
-import com.keylesspalace.tusky.TabData
-import com.keylesspalace.tusky.util.CustomFragmentStateAdapter
-import java.lang.ref.WeakReference
 
-class MainPagerAdapter(val tabs: List<TabData>, activity: FragmentActivity) : CustomFragmentStateAdapter(activity) {
+abstract class CustomFragmentStateAdapter(val activity: FragmentActivity): FragmentStateAdapter(activity) {
 
-    override fun createFragment(position: Int): Fragment {
-        val tab = tabs[position]
-        return tab.fragment(tab.arguments)
-    }
-
-    override fun getItemCount() = tabs.size
-
+    fun getFragment(position: Int): Fragment?
+            = activity.supportFragmentManager.findFragmentByTag("f"  + getItemId(position))
 }


### PR DESCRIPTION
Steps to reproduce: Enable "Don't keep activities" in the developer settings and bring the main activity in the background and foreground again (or recreate it in an other way). Jumping to the top by clicking the selected tab will no longer work.

