### PR TITLE
Make image in BackgroundMessageView adapt to the height, fix #1618

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -167,6 +167,7 @@ public class NotificationsFragment extends SFragment implements
     private boolean alwaysShowSensitiveMedia;
     private boolean alwaysOpenSpoiler;
     private boolean showNotificationsFilter;
+    private boolean showingError;
 
     // Each element is either a Notification for loading data or a Placeholder
     private final PairedList<Either<Placeholder, Notification>, NotificationViewData> notifications
@@ -280,7 +281,7 @@ public class NotificationsFragment extends SFragment implements
     private void updateFilterVisibility() {
         CoordinatorLayout.LayoutParams params =
                 (CoordinatorLayout.LayoutParams) swipeRefreshLayout.getLayoutParams();
-        if (showNotificationsFilter) {
+        if (showNotificationsFilter && !showingError && !notifications.isEmpty()) {
             appBarOptions.setExpanded(true, false);
             appBarOptions.setVisibility(View.VISIBLE);
             //Set content behaviour to hide filter on scroll
@@ -392,6 +393,7 @@ public class NotificationsFragment extends SFragment implements
     @Override
     public void onRefresh() {
         this.statusView.setVisibility(View.GONE);
+        this.showingError = false;
         Either<Placeholder, Notification> first = CollectionsKt.firstOrNull(this.notifications);
         String topId;
         if (first != null && first.isRight()) {
@@ -669,6 +671,7 @@ public class NotificationsFragment extends SFragment implements
         //Show friend elephant
         this.statusView.setVisibility(View.VISIBLE);
         this.statusView.setup(R.drawable.elephant_friend_empty, R.string.message_empty, null);
+        updateFilterVisibility();
 
         //Update adapter
         updateAdapter();
@@ -994,6 +997,7 @@ public class NotificationsFragment extends SFragment implements
         } else {
             swipeRefreshLayout.setEnabled(true);
         }
+        updateFilterVisibility();
         swipeRefreshLayout.setRefreshing(false);
         progressBar.setVisibility(View.GONE);
     }
@@ -1009,6 +1013,7 @@ public class NotificationsFragment extends SFragment implements
         } else if (this.notifications.isEmpty()) {
             this.statusView.setVisibility(View.VISIBLE);
             swipeRefreshLayout.setEnabled(false);
+            this.showingError = true;
             if (exception instanceof IOException) {
                 this.statusView.setup(R.drawable.elephant_offline, R.string.error_network, __ -> {
                     this.progressBar.setVisibility(View.VISIBLE);
@@ -1022,6 +1027,7 @@ public class NotificationsFragment extends SFragment implements
                     return Unit.INSTANCE;
                 });
             }
+            updateFilterVisibility();
         }
         Log.e(TAG, "Fetch failure: " + exception.getMessage());
 

--- a/app/src/main/java/com/keylesspalace/tusky/view/BackgroundMessageView.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/view/BackgroundMessageView.kt
@@ -39,7 +39,7 @@ class BackgroundMessageView @JvmOverloads constructor(
     fun setup(@DrawableRes imageRes: Int, @StringRes messageRes: Int,
               clickListener: ((v: View) -> Unit)? = null) {
         messageTextView.setText(messageRes)
-        messageTextView.setCompoundDrawablesWithIntrinsicBounds(0, imageRes, 0, 0)
+        imageView.setImageResource(imageRes)
         button.setOnClickListener(clickListener)
         button.visible(clickListener != null)
     }

--- a/app/src/main/res/layout/activity_lists.xml
+++ b/app/src/main/res/layout/activity_lists.xml
@@ -39,7 +39,9 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/appbar"
+            tools:visibility="visible"
+            app:layout_constrainedHeight="true" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_timeline.xml
+++ b/app/src/main/res/layout/fragment_timeline.xml
@@ -36,7 +36,8 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:visibility="visible" />
+        tools:visibility="visible"
+        app:layout_constrainedHeight="true" />
 
     <androidx.core.widget.ContentLoadingProgressBar
         android:id="@+id/topProgressBar"

--- a/app/src/main/res/layout/fragment_timeline_notifications.xml
+++ b/app/src/main/res/layout/fragment_timeline_notifications.xml
@@ -52,7 +52,7 @@
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipeRefreshLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/view_background_message.xml
+++ b/app/src/main/res/layout/view_background_message.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:gravity="center_horizontal"
+    tools:orientation="vertical"
+    tools:parentTag="android.widget.LinearLayout">
+
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="4dp"
+        android:layout_weight="1"
+        android:contentDescription="@null"
+        android:scaleType="centerInside"
+        tools:src="@drawable/elephant_offline" />
 
     <TextView
         android:id="@+id/messageTextView"
@@ -13,7 +26,6 @@
         android:paddingRight="16dp"
         android:textAlignment="center"
         android:textSize="?attr/status_text_medium"
-        tools:drawableTop="@drawable/elephant_offline"
         tools:text="@string/error_network" />
 
     <Button
@@ -22,5 +34,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
+        android:layout_marginBottom="4dp"
         android:text="@string/action_retry" />
 </merge>


### PR DESCRIPTION
I tried to fix it but not like proposed in #1618 because it would require additional layouts so I tried to just fit the Image.
The only problem is notifications screen where we have this damn bar. We need to offset top correctly and we need to fix the bar height for that but idk how it would work with text scaling.
![Screenshot_20200118-220346](https://user-images.githubusercontent.com/3099142/72671199-089fc980-3a47-11ea-875d-b61e7f781cce.png)
