### PR TITLE
Add options to confirm reblog/unreblog actions, close #460

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -155,7 +155,7 @@ dependencies {
     implementation "com.google.dagger:dagger-android-support:$daggerVersion"
     kapt "com.google.dagger:dagger-android-processor:$daggerVersion"
 
-    implementation "com.github.connyduck:sparkbutton:3.0.0"
+    implementation "com.github.connyduck:sparkbutton:4.0.0"
 
     implementation "com.github.chrisbanes:PhotoView:2.3.0"
 

--- a/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.kt
@@ -129,7 +129,7 @@ class PreferencesActivity : BaseActivity(), SharedPreferences.OnSharedPreference
 
             }
             "statusTextSize", "absoluteTimeView", "showBotOverlay", "animateGifAvatars",
-            "useBlurhash", "showCardsInTimelines" -> {
+            "useBlurhash", "showCardsInTimelines", "confirmReblogs" -> {
                 restartActivitiesOnExit = true
             }
             "language" -> {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -232,7 +232,8 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
                 statusDisplayOptions.useAbsoluteTime(),
                 statusDisplayOptions.showBotOverlay(),
                 statusDisplayOptions.useBlurhash(),
-                CardViewMode.NONE
+                CardViewMode.NONE,
+                statusDisplayOptions.confirmReblogs()
         );
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/TimelineAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/TimelineAdapter.java
@@ -64,7 +64,8 @@ public final class TimelineAdapter extends RecyclerView.Adapter {
                 statusDisplayOptions.useAbsoluteTime(),
                 statusDisplayOptions.showBotOverlay(),
                 statusDisplayOptions.useBlurhash(),
-                statusDisplayOptions.cardViewMode()
+                statusDisplayOptions.cardViewMode(),
+                statusDisplayOptions.confirmReblogs()
         );
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationViewHolder.java
@@ -104,7 +104,8 @@ public class ConversationViewHolder extends StatusBaseViewHolder {
             hideSensitiveMediaWarning();
         }
 
-        setupButtons(listener, account.getId());
+        setupButtons(listener, account.getId(), status.getContent().toString(),
+                statusDisplayOptions);
 
         setSpoilerAndContent(status.getExpanded(), status.getContent(), status.getSpoilerText(),
                 status.getMentions(), status.getEmojis(),

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
@@ -66,7 +66,8 @@ class ConversationsFragment : SFragment(), StatusActionListener, Injectable, Res
                 useAbsoluteTime = preferences.getBoolean("absoluteTimeView", false),
                 showBotOverlay = preferences.getBoolean("showBotOverlay", true),
                 useBlurhash = preferences.getBoolean("useBlurhash", true),
-                cardViewMode = CardViewMode.NONE
+                cardViewMode = CardViewMode.NONE,
+                confirmReblogs = preferences.getBoolean("confirmReblogs", true)
         )
 
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportStatusesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportStatusesFragment.kt
@@ -117,7 +117,8 @@ class ReportStatusesFragment : Fragment(), Injectable, AdapterHandler {
                 useAbsoluteTime = preferences.getBoolean("absoluteTimeView", false),
                 showBotOverlay = false,
                 useBlurhash = preferences.getBoolean("useBlurhash", true),
-                cardViewMode = CardViewMode.NONE
+                cardViewMode = CardViewMode.NONE,
+                confirmReblogs = preferences.getBoolean("confirmReblogs", true)
         )
 
         adapter = StatusesAdapter(statusDisplayOptions,

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchStatusesFragment.kt
@@ -71,7 +71,7 @@ class SearchStatusesFragment : SearchFragment<Pair<Status, StatusViewData.Concre
         get() = viewModel.statuses
 
     private val searchAdapter
-            get() = super.adapter as SearchStatusesAdapter
+        get() = super.adapter as SearchStatusesAdapter
 
     override fun createAdapter(): PagedListAdapter<Pair<Status, StatusViewData.Concrete>, *> {
         val preferences = PreferenceManager.getDefaultSharedPreferences(searchRecyclerView.context)
@@ -81,7 +81,8 @@ class SearchStatusesFragment : SearchFragment<Pair<Status, StatusViewData.Concre
                 useAbsoluteTime = preferences.getBoolean("absoluteTimeView", false),
                 showBotOverlay = preferences.getBoolean("showBotOverlay", true),
                 useBlurhash = preferences.getBoolean("useBlurhash", true),
-                cardViewMode = CardViewMode.NONE
+                cardViewMode = CardViewMode.NONE,
+                confirmReblogs = preferences.getBoolean("confirmReblogs", true)
         )
 
         searchRecyclerView.addItemDecoration(DividerItemDecoration(searchRecyclerView.context, DividerItemDecoration.VERTICAL))

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -246,7 +246,8 @@ public class NotificationsFragment extends SFragment implements
                 preferences.getBoolean("absoluteTimeView", false),
                 preferences.getBoolean("showBotOverlay", true),
                 preferences.getBoolean("useBlurhash", true),
-                CardViewMode.NONE
+                CardViewMode.NONE,
+                preferences.getBoolean("confirmReblogs", true)
         );
 
         adapter = new NotificationsAdapter(accountManager.getActiveAccount().getAccountId(),

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -230,7 +230,8 @@ public class TimelineFragment extends SFragment implements
                 preferences.getBoolean("useBlurhash", true),
                 preferences.getBoolean("showCardsInTimelines", false) ?
                         CardViewMode.INDENTED :
-                        CardViewMode.NONE
+                        CardViewMode.NONE,
+                preferences.getBoolean("confirmReblogs", true)
         );
         adapter = new TimelineAdapter(dataSource, statusDisplayOptions, this);
 
@@ -580,6 +581,10 @@ public class TimelineFragment extends SFragment implements
     @Override
     public void onReblog(final boolean reblog, final int position) {
         final Status status = statuses.get(position).asRight();
+        doReblog(reblog, position, status);
+    }
+
+    private void doReblog(boolean reblog, int position, Status status) {
         timelineCases.reblog(status, reblog)
                 .observeOn(AndroidSchedulers.mainThread())
                 .as(autoDisposable(from(this, Lifecycle.Event.ON_DESTROY)))

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -135,7 +135,8 @@ public final class ViewThreadFragment extends SFragment implements
                 preferences.getBoolean("useBlurhash", true),
                 preferences.getBoolean("showCardsInTimelines", false) ?
                         CardViewMode.INDENTED :
-                        CardViewMode.NONE
+                        CardViewMode.NONE,
+                preferences.getBoolean("confirmReblogs", true)
         );
         adapter = new ThreadAdapter(statusDisplayOptions, this);
     }

--- a/app/src/main/java/com/keylesspalace/tusky/util/StatusDisplayOptions.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/StatusDisplayOptions.kt
@@ -12,5 +12,7 @@ data class StatusDisplayOptions(
         @get:JvmName("useBlurhash")
         val useBlurhash: Boolean,
         @get:JvmName("cardViewMode")
-        val cardViewMode: CardViewMode
+        val cardViewMode: CardViewMode,
+        @get:JvmName("confirmReblogs")
+        val confirmReblogs: Boolean
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -549,5 +549,6 @@
     <string name="no_scheduled_status">You don\'t have any scheduled statuses.</string>
     <string name="warning_scheduling_interval">Mastodon has a minimum scheduling interval of 5 minutes.</string>
     <string name="pref_title_show_cards_in_timelines">Show link previews in timelines</string>
+    <string name="pref_title_confirm_reblogs">Show confirmation dialog before boosting</string>
 
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -78,6 +78,12 @@
             android:title="@string/pref_title_show_cards_in_timelines"
             app:singleLineTitle="false" />
 
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="confirmReblogs"
+            android:title="@string/pref_title_confirm_reblogs"
+            app:singleLineTitle="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_title_browser_settings">


### PR DESCRIPTION
Add an option to confirm reblogs.
Initially I wanted to put it much further the pipeline but to get animations work right I had to work around `SparkButton` a little bit. The advantage is that it's implemented in just one place now.

It tries to mimick Masto UI but not very closely.

![image](https://user-images.githubusercontent.com/3099142/72672087-66d3a900-3a55-11ea-9fe1-e4db6a7901da.png)
