### PR TITLE
fix reveal button not updating in ViewThreadActivity

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -208,6 +208,7 @@ public final class ViewThreadFragment extends SFragment implements
             statuses.setPairedItem(i, newViewData);
         }
         adapter.setStatuses(statuses.getPairedCopy());
+        updateRevealIcon();
     }
 
     private boolean allExpanded() {


### PR DESCRIPTION
Regression from https://github.com/tuskyapp/Tusky/pull/1627

(when the buttons in the timeline where `ToggleButton`s, their callback where called when changing their state from code and the reveal button would update)