### PR TITLE
Refresh DM column when removing toot there instead of removing conversation

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsViewModel.kt
@@ -128,15 +128,7 @@ class ConversationsViewModel @Inject constructor(
 
     fun remove(position: Int) {
         conversations.value?.getOrNull(position)?.let { conversation ->
-            /* this is not ideal since deleting last toot from an conversation
-               should not delete the conversation but show another toot of the conversation */
-            timelineCases.delete(conversation.lastStatus.id)
-                    .subscribeOn(Schedulers.io())
-                    .doOnError { t -> Log.w("ConversationViewModel", "Failed to delete conversation", t) }
-                    .subscribe()
-            database.conversationDao().delete(conversation)
-                    .subscribeOn(Schedulers.io())
-                    .subscribe()
+            refresh()
         }
     }
 


### PR DESCRIPTION
It was crashing Tusky. Since the conversation API is annoying, the only way to properly update the DM column is to refresh it.

Note that composing a new DM or responding to one doesn’t update the DM column, it probably should?