### PR TITLE
fix overlapping icons in ComposeActivity

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -113,6 +113,8 @@ class ComposeActivity : BaseActivity(),
     private var composeOptions: ComposeOptions? = null
     private lateinit var viewModel: ComposeViewModel
 
+    private var mediaCount = 0
+
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val preferences = PreferenceManager.getDefaultSharedPreferences(this)
@@ -304,9 +306,12 @@ class ComposeActivity : BaseActivity(),
                 setStatusVisibility(visibility)
             }
             viewModel.media.observe { media ->
-                composeMediaPreviewBar.visible(media.isNotEmpty())
                 mediaAdapter.submitList(media)
-                updateSensitiveMediaToggle(viewModel.markMediaAsSensitive.value != false, viewModel.showContentWarning.value != false)
+                if(media.size != mediaCount) {
+                    mediaCount = media.size
+                    composeMediaPreviewBar.visible(media.isNotEmpty())
+                    updateSensitiveMediaToggle(viewModel.markMediaAsSensitive.value != false, viewModel.showContentWarning.value != false)
+                }
             }
             viewModel.poll.observe { poll ->
                 pollPreview.visible(poll != null)
@@ -493,8 +498,6 @@ class ComposeActivity : BaseActivity(),
     }
 
     private fun updateSensitiveMediaToggle(markMediaSensitive: Boolean, contentWarningShown: Boolean) {
-        TransitionManager.beginDelayedTransition(composeHideMediaButton.parent as ViewGroup)
-
         if (viewModel.media.value.isNullOrEmpty()) {
             composeHideMediaButton.hide()
         } else {

--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -243,6 +243,7 @@
         android:layout_gravity="bottom"
         android:background="?android:colorBackground"
         android:elevation="12dp"
+        android:animateLayoutChanges="true"
         android:gravity="center_vertical"
         android:paddingStart="8dp"
         android:paddingTop="4dp"
@@ -274,13 +275,12 @@
         <ImageButton
             android:id="@+id/composeHideMediaButton"
             style="?attr/image_button_style"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
             android:layout_marginEnd="4dp"
             android:contentDescription="@string/action_hide_media"
             android:padding="4dp"
             android:tooltipText="@string/action_hide_media"
-            android:visibility="gone"
             tools:src="@drawable/ic_eye_24dp" />
 
         <ImageButton


### PR DESCRIPTION
closes #1639 

The problem is that `updateSensitiveMediaToggle()` is called way to often and that messes with the `TransitionManager`. Fixed by reducing the number of calls to `updateSensitiveMediaToggle()` and using other transition mechanism.