### PR TITLE
change dialog background color

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -91,6 +91,7 @@
     <style name="TuskyDialog" parent="@style/ThemeOverlay.MaterialComponents.Dialog.Alert">
         <item name="android:letterSpacing">0</item>
         <item name="dialogCornerRadius">8dp</item>
+        <item name="android:background">@color/colorBackground</item>
     </style>
 
     <style name="TuskyDialogFragmentStyle" parent="@style/ThemeOverlay.MaterialComponents.Dialog">


### PR DESCRIPTION
The color got lost somewhere in the refactoring. Its now the same as in Tusky 9 again.