### PR TITLE
Allow higher zooming levels for caption dialog images

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
@@ -50,7 +50,10 @@ fun <T> T.makeCaptionDialog(existingDescription: String?,
     dialogLayout.setPadding(padding, padding, padding, padding)
 
     dialogLayout.orientation = LinearLayout.VERTICAL
-    val imageView = PhotoView(this)
+    val imageView = PhotoView(this).apply {
+        // If it seems a lot, try opening an image of A4 format or similar
+        maximumScale = 6.0f
+    }
 
     val displayMetrics = DisplayMetrics()
     windowManager.defaultDisplay.getMetrics(displayMetrics)


### PR DESCRIPTION
In #1643 we allowed zooming images. Unfortunately for the relatively small dialog default zoom levels are not very efficient. As @ismirth suggested in https://github.com/tuskyapp/Tusky/issues/1316#issuecomment-576444918 it might be not enough (I just tested it with one image and I increased zoom level multiple times).