### PR TITLE
Add option to show link previews in timelines

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.kt
@@ -129,7 +129,7 @@ class PreferencesActivity : BaseActivity(), SharedPreferences.OnSharedPreference
 
             }
             "statusTextSize", "absoluteTimeView", "showBotOverlay", "animateGifAvatars",
-            "useBlurhash" -> {
+            "useBlurhash", "showCardsInTimelines" -> {
                 restartActivitiesOnExit = true
             }
             "language" -> {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -44,6 +44,7 @@ import com.keylesspalace.tusky.entity.Emoji;
 import com.keylesspalace.tusky.entity.Notification;
 import com.keylesspalace.tusky.interfaces.LinkListener;
 import com.keylesspalace.tusky.interfaces.StatusActionListener;
+import com.keylesspalace.tusky.util.CardViewMode;
 import com.keylesspalace.tusky.util.CustomEmojiHelper;
 import com.keylesspalace.tusky.util.ImageLoadingHelper;
 import com.keylesspalace.tusky.util.LinkHelper;
@@ -231,7 +232,7 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
                 statusDisplayOptions.useAbsoluteTime(),
                 statusDisplayOptions.showBotOverlay(),
                 statusDisplayOptions.useBlurhash(),
-                false
+                CardViewMode.NONE
         );
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -230,7 +230,8 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
                 mediaPreviewEnabled,
                 statusDisplayOptions.useAbsoluteTime(),
                 statusDisplayOptions.showBotOverlay(),
-                statusDisplayOptions.useBlurhash()
+                statusDisplayOptions.useBlurhash(),
+                false
         );
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -938,9 +938,6 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         if (cardViewMode != CardViewMode.NONE && status.getAttachments().size() == 0 && status.getCard() != null && !TextUtils.isEmpty(status.getCard().getUrl())) {
             final Card card = status.getCard();
             cardView.setVisibility(View.VISIBLE);
-            cardView.getLayoutParams().width = cardViewMode == CardViewMode.FULL_WIDTH ?
-                    ViewGroup.LayoutParams.MATCH_PARENT :
-                    ViewGroup.LayoutParams.WRAP_CONTENT;
             cardTitle.setText(card.getTitle());
             if (TextUtils.isEmpty(card.getDescription()) && TextUtils.isEmpty(card.getAuthorName())) {
                 cardDescription.setVisibility(View.GONE);

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -35,6 +35,7 @@ import com.keylesspalace.tusky.entity.Card;
 import com.keylesspalace.tusky.entity.Emoji;
 import com.keylesspalace.tusky.entity.Status;
 import com.keylesspalace.tusky.interfaces.StatusActionListener;
+import com.keylesspalace.tusky.util.CardViewMode;
 import com.keylesspalace.tusky.util.CustomEmojiHelper;
 import com.keylesspalace.tusky.util.HtmlUtils;
 import com.keylesspalace.tusky.util.ImageLoadingHelper;
@@ -702,7 +703,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             }
 
             if (cardView != null) {
-                setupCard(status, statusDisplayOptions.showCards());
+                setupCard(status, statusDisplayOptions.cardViewMode());
             }
 
             setupButtons(listener, status.getSenderId());
@@ -933,10 +934,13 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         return pollDescription.getContext().getString(R.string.poll_info_format, votesText, pollDurationInfo);
     }
 
-    protected void setupCard(StatusViewData.Concrete status, boolean showCards) {
-        if (showCards && status.getAttachments().size() == 0 && status.getCard() != null && !TextUtils.isEmpty(status.getCard().getUrl())) {
+    protected void setupCard(StatusViewData.Concrete status, CardViewMode cardViewMode) {
+        if (cardViewMode != CardViewMode.NONE && status.getAttachments().size() == 0 && status.getCard() != null && !TextUtils.isEmpty(status.getCard().getUrl())) {
             final Card card = status.getCard();
             cardView.setVisibility(View.VISIBLE);
+            cardView.getLayoutParams().width = cardViewMode == CardViewMode.FULL_WIDTH ?
+                    ViewGroup.LayoutParams.MATCH_PARENT :
+                    ViewGroup.LayoutParams.WRAP_CONTENT;
             cardTitle.setText(card.getTitle());
             if (TextUtils.isEmpty(card.getDescription()) && TextUtils.isEmpty(card.getAuthorName())) {
                 cardDescription.setVisibility(View.GONE);

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -8,9 +8,11 @@ import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -22,11 +24,14 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.resource.bitmap.CenterCrop;
+import com.bumptech.glide.load.resource.bitmap.GranularRoundedCorners;
 import com.google.android.material.button.MaterialButton;
 import com.keylesspalace.tusky.R;
 import com.keylesspalace.tusky.entity.Attachment;
 import com.keylesspalace.tusky.entity.Attachment.Focus;
 import com.keylesspalace.tusky.entity.Attachment.MetaData;
+import com.keylesspalace.tusky.entity.Card;
 import com.keylesspalace.tusky.entity.Emoji;
 import com.keylesspalace.tusky.entity.Status;
 import com.keylesspalace.tusky.interfaces.StatusActionListener;
@@ -86,6 +91,12 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
     private TextView pollDescription;
     private Button pollButton;
 
+    private LinearLayout cardView;
+    private LinearLayout cardInfo;
+    private ImageView cardImage;
+    private TextView cardTitle;
+    private TextView cardDescription;
+    private TextView cardUrl;
     private PollAdapter pollAdapter;
 
     private SimpleDateFormat shortSdf;
@@ -142,6 +153,13 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         pollOptions = itemView.findViewById(R.id.status_poll_options);
         pollDescription = itemView.findViewById(R.id.status_poll_description);
         pollButton = itemView.findViewById(R.id.status_poll_button);
+
+        cardView = itemView.findViewById(R.id.status_card_view);
+        cardInfo = itemView.findViewById(R.id.card_info);
+        cardImage = itemView.findViewById(R.id.card_image);
+        cardTitle = itemView.findViewById(R.id.card_title);
+        cardDescription = itemView.findViewById(R.id.card_description);
+        cardUrl = itemView.findViewById(R.id.card_link);
 
         pollAdapter = new PollAdapter();
         pollOptions.setAdapter(pollAdapter);
@@ -683,6 +701,10 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                 hideSensitiveMediaWarning();
             }
 
+            if (cardView != null) {
+                setupCard(status, statusDisplayOptions.showCards());
+            }
+
             setupButtons(listener, status.getSenderId());
             setRebloggingEnabled(status.getRebloggingEnabled(), status.getVisibility());
 
@@ -909,6 +931,80 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         }
 
         return pollDescription.getContext().getString(R.string.poll_info_format, votesText, pollDurationInfo);
+    }
+
+    protected void setupCard(StatusViewData.Concrete status, boolean showCards) {
+        if (showCards && status.getAttachments().size() == 0 && status.getCard() != null && !TextUtils.isEmpty(status.getCard().getUrl())) {
+            final Card card = status.getCard();
+            cardView.setVisibility(View.VISIBLE);
+            cardTitle.setText(card.getTitle());
+            if (TextUtils.isEmpty(card.getDescription()) && TextUtils.isEmpty(card.getAuthorName())) {
+                cardDescription.setVisibility(View.GONE);
+            } else {
+                cardDescription.setVisibility(View.VISIBLE);
+                if (TextUtils.isEmpty(card.getDescription())) {
+                    cardDescription.setText(card.getAuthorName());
+                } else {
+                    cardDescription.setText(card.getDescription());
+                }
+            }
+
+            cardUrl.setText(card.getUrl());
+
+            if (!TextUtils.isEmpty(card.getImage())) {
+
+                int topLeftRadius = 0;
+                int topRightRadius = 0;
+                int bottomRightRadius = 0;
+                int bottomLeftRadius = 0;
+
+                int radius = cardImage.getContext().getResources()
+                        .getDimensionPixelSize(R.dimen.card_radius);
+
+                if (card.getWidth() > card.getHeight()) {
+                    cardView.setOrientation(LinearLayout.VERTICAL);
+
+                    cardImage.getLayoutParams().height = cardImage.getContext().getResources()
+                            .getDimensionPixelSize(R.dimen.card_image_vertical_height);
+                    cardImage.getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
+                    cardInfo.getLayoutParams().height = ViewGroup.LayoutParams.MATCH_PARENT;
+                    cardInfo.getLayoutParams().width = ViewGroup.LayoutParams.WRAP_CONTENT;
+                    topLeftRadius = radius;
+                    topRightRadius = radius;
+                } else {
+                    cardView.setOrientation(LinearLayout.HORIZONTAL);
+                    cardImage.getLayoutParams().height = ViewGroup.LayoutParams.MATCH_PARENT;
+                    cardImage.getLayoutParams().width = cardImage.getContext().getResources()
+                            .getDimensionPixelSize(R.dimen.card_image_horizontal_width);
+                    cardInfo.getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
+                    cardInfo.getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
+                    topLeftRadius = radius;
+                    bottomLeftRadius = radius;
+                }
+
+
+                Glide.with(cardImage)
+                        .load(card.getImage())
+                        .transform(
+                                new CenterCrop(),
+                                new GranularRoundedCorners(topLeftRadius, topRightRadius, bottomRightRadius, bottomLeftRadius)
+                        )
+                        .into(cardImage);
+            } else {
+                cardView.setOrientation(LinearLayout.HORIZONTAL);
+                cardImage.getLayoutParams().height = ViewGroup.LayoutParams.MATCH_PARENT;
+                cardImage.getLayoutParams().width = cardImage.getContext().getResources()
+                        .getDimensionPixelSize(R.dimen.card_image_horizontal_width);
+                cardInfo.getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
+                cardInfo.getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
+                cardImage.setImageResource(R.drawable.card_image_placeholder);
+            }
+
+            cardView.setOnClickListener(v -> LinkHelper.openLink(card.getUrl(), v.getContext()));
+            cardView.setClipToOutline(true);
+        } else {
+            cardView.setVisibility(View.GONE);
+        }
     }
 
     private static String formatDuration(double durationInSeconds) {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.keylesspalace.tusky.R;
 import com.keylesspalace.tusky.entity.Status;
 import com.keylesspalace.tusky.interfaces.StatusActionListener;
+import com.keylesspalace.tusky.util.CardViewMode;
 import com.keylesspalace.tusky.util.LinkHelper;
 import com.keylesspalace.tusky.util.StatusDisplayOptions;
 import com.keylesspalace.tusky.viewdata.StatusViewData;
@@ -105,6 +106,7 @@ class StatusDetailedViewHolder extends StatusBaseViewHolder {
                                    StatusDisplayOptions statusDisplayOptions,
                                    @Nullable Object payloads) {
         super.setupWithStatus(status, listener, statusDisplayOptions, payloads);
+        setupCard(status, CardViewMode.FULL_WIDTH); // Always show card for detailed status
         if (payloads == null) {
             setReblogAndFavCount(status.getReblogsCount(), status.getFavouritesCount(), listener);
 

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
@@ -4,23 +4,15 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
-import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.view.View;
-import android.view.ViewGroup;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.resource.bitmap.CenterCrop;
-import com.bumptech.glide.load.resource.bitmap.GranularRoundedCorners;
 import com.keylesspalace.tusky.R;
-import com.keylesspalace.tusky.entity.Card;
 import com.keylesspalace.tusky.entity.Status;
 import com.keylesspalace.tusky.interfaces.StatusActionListener;
 import com.keylesspalace.tusky.util.LinkHelper;
@@ -33,27 +25,13 @@ import java.util.Date;
 class StatusDetailedViewHolder extends StatusBaseViewHolder {
     private TextView reblogs;
     private TextView favourites;
-    private LinearLayout cardView;
-    private LinearLayout cardInfo;
-    private ImageView cardImage;
-    private TextView cardTitle;
-    private TextView cardDescription;
-    private TextView cardUrl;
     private View infoDivider;
 
     StatusDetailedViewHolder(View view) {
         super(view);
         reblogs = view.findViewById(R.id.status_reblogs);
         favourites = view.findViewById(R.id.status_favourites);
-        cardView = view.findViewById(R.id.card_view);
-        cardInfo = view.findViewById(R.id.card_info);
-        cardImage = view.findViewById(R.id.card_image);
-        cardTitle = view.findViewById(R.id.card_title);
-        cardDescription = view.findViewById(R.id.card_description);
-        cardUrl = view.findViewById(R.id.card_link);
         infoDivider = view.findViewById(R.id.status_info_divider);
-
-        cardView.setClipToOutline(true);
     }
 
     @Override
@@ -145,82 +123,6 @@ class StatusDetailedViewHolder extends StatusBaseViewHolder {
 
             content.setOnLongClickListener(longClickListener);
             contentWarningDescription.setOnLongClickListener(longClickListener);
-
-            if (status.getAttachments().size() == 0 && status.getCard() != null && !TextUtils.isEmpty(status.getCard().getUrl())) {
-                final Card card = status.getCard();
-                cardView.setVisibility(View.VISIBLE);
-                cardTitle.setText(card.getTitle());
-                if (TextUtils.isEmpty(card.getDescription()) && TextUtils.isEmpty(card.getAuthorName())) {
-                    cardDescription.setVisibility(View.GONE);
-                } else {
-                    cardDescription.setVisibility(View.VISIBLE);
-                    if (TextUtils.isEmpty(card.getDescription())) {
-                        cardDescription.setText(card.getAuthorName());
-                    } else {
-                        cardDescription.setText(card.getDescription());
-                    }
-                }
-
-                cardUrl.setText(card.getUrl());
-
-                if (!TextUtils.isEmpty(card.getImage())) {
-
-                    int topLeftRadius = 0;
-                    int topRightRadius = 0;
-                    int bottomRightRadius = 0;
-                    int bottomLeftRadius = 0;
-
-                    int radius = cardImage.getContext().getResources()
-                            .getDimensionPixelSize(R.dimen.card_radius);
-
-                    if (card.getWidth() > card.getHeight()) {
-                        cardView.setOrientation(LinearLayout.VERTICAL);
-
-                        cardImage.getLayoutParams().height = cardImage.getContext().getResources()
-                                .getDimensionPixelSize(R.dimen.card_image_vertical_height);
-                        cardImage.getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
-                        cardInfo.getLayoutParams().height = ViewGroup.LayoutParams.MATCH_PARENT;
-                        cardInfo.getLayoutParams().width = ViewGroup.LayoutParams.WRAP_CONTENT;
-                        topLeftRadius = radius;
-                        topRightRadius = radius;
-                    } else {
-                        cardView.setOrientation(LinearLayout.HORIZONTAL);
-                        cardImage.getLayoutParams().height = ViewGroup.LayoutParams.MATCH_PARENT;
-                        cardImage.getLayoutParams().width = cardImage.getContext().getResources()
-                                .getDimensionPixelSize(R.dimen.card_image_horizontal_width);
-                        cardInfo.getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
-                        cardInfo.getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
-                        topLeftRadius = radius;
-                        bottomLeftRadius = radius;
-                    }
-
-
-                    Glide.with(cardImage)
-                            .load(card.getImage())
-                            .transform(
-                                    new CenterCrop(),
-                                    new GranularRoundedCorners(topLeftRadius, topRightRadius, bottomRightRadius, bottomLeftRadius)
-                            )
-                            .into(cardImage);
-
-                } else {
-                    cardView.setOrientation(LinearLayout.HORIZONTAL);
-                    cardImage.getLayoutParams().height = ViewGroup.LayoutParams.MATCH_PARENT;
-                    cardImage.getLayoutParams().width = cardImage.getContext().getResources()
-                            .getDimensionPixelSize(R.dimen.card_image_horizontal_width);
-                    cardInfo.getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
-                    cardInfo.getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
-
-                    cardImage.setImageResource(R.drawable.card_image_placeholder);
-
-                }
-
-                cardView.setOnClickListener(v -> LinkHelper.openLink(card.getUrl(), v.getContext()));
-
-            } else {
-                cardView.setVisibility(View.GONE);
-            }
-
             setStatusVisibility(status.getVisibility());
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/TimelineAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/TimelineAdapter.java
@@ -64,7 +64,7 @@ public final class TimelineAdapter extends RecyclerView.Adapter {
                 statusDisplayOptions.useAbsoluteTime(),
                 statusDisplayOptions.showBotOverlay(),
                 statusDisplayOptions.useBlurhash(),
-                statusDisplayOptions.showCards()
+                statusDisplayOptions.cardViewMode()
         );
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/TimelineAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/TimelineAdapter.java
@@ -63,7 +63,8 @@ public final class TimelineAdapter extends RecyclerView.Adapter {
                 mediaPreviewEnabled,
                 statusDisplayOptions.useAbsoluteTime(),
                 statusDisplayOptions.showBotOverlay(),
-                statusDisplayOptions.useBlurhash()
+                statusDisplayOptions.useBlurhash(),
+                statusDisplayOptions.showCards()
         );
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
@@ -36,10 +36,7 @@ import com.keylesspalace.tusky.di.ViewModelFactory
 import com.keylesspalace.tusky.fragment.SFragment
 import com.keylesspalace.tusky.interfaces.ReselectableFragment
 import com.keylesspalace.tusky.interfaces.StatusActionListener
-import com.keylesspalace.tusky.util.NetworkState
-import com.keylesspalace.tusky.util.StatusDisplayOptions
-import com.keylesspalace.tusky.util.ThemeUtils
-import com.keylesspalace.tusky.util.hide
+import com.keylesspalace.tusky.util.*
 import kotlinx.android.synthetic.main.fragment_timeline.*
 import javax.inject.Inject
 
@@ -69,7 +66,7 @@ class ConversationsFragment : SFragment(), StatusActionListener, Injectable, Res
                 useAbsoluteTime = preferences.getBoolean("absoluteTimeView", false),
                 showBotOverlay = preferences.getBoolean("showBotOverlay", true),
                 useBlurhash = preferences.getBoolean("useBlurhash", true),
-                showCards = false
+                cardViewMode = CardViewMode.NONE
         )
 
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
@@ -68,7 +68,8 @@ class ConversationsFragment : SFragment(), StatusActionListener, Injectable, Res
                 mediaPreviewEnabled = accountManager.activeAccount?.mediaPreviewEnabled ?: true,
                 useAbsoluteTime = preferences.getBoolean("absoluteTimeView", false),
                 showBotOverlay = preferences.getBoolean("showBotOverlay", true),
-                useBlurhash = preferences.getBoolean("useBlurhash", true)
+                useBlurhash = preferences.getBoolean("useBlurhash", true),
+                showCards = false
         )
 
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportStatusesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportStatusesFragment.kt
@@ -43,10 +43,7 @@ import com.keylesspalace.tusky.di.Injectable
 import com.keylesspalace.tusky.di.ViewModelFactory
 import com.keylesspalace.tusky.entity.Attachment
 import com.keylesspalace.tusky.entity.Status
-import com.keylesspalace.tusky.util.StatusDisplayOptions
-import com.keylesspalace.tusky.util.ThemeUtils
-import com.keylesspalace.tusky.util.hide
-import com.keylesspalace.tusky.util.show
+import com.keylesspalace.tusky.util.*
 import com.keylesspalace.tusky.viewdata.AttachmentViewData
 import kotlinx.android.synthetic.main.fragment_report_statuses.*
 import javax.inject.Inject
@@ -120,7 +117,7 @@ class ReportStatusesFragment : Fragment(), Injectable, AdapterHandler {
                 useAbsoluteTime = preferences.getBoolean("absoluteTimeView", false),
                 showBotOverlay = false,
                 useBlurhash = preferences.getBoolean("useBlurhash", true),
-                showCards = false
+                cardViewMode = CardViewMode.NONE
         )
 
         adapter = StatusesAdapter(statusDisplayOptions,

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportStatusesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportStatusesFragment.kt
@@ -119,7 +119,8 @@ class ReportStatusesFragment : Fragment(), Injectable, AdapterHandler {
                 mediaPreviewEnabled = accountManager.activeAccount?.mediaPreviewEnabled ?: true,
                 useAbsoluteTime = preferences.getBoolean("absoluteTimeView", false),
                 showBotOverlay = false,
-                useBlurhash = preferences.getBoolean("useBlurhash", true)
+                useBlurhash = preferences.getBoolean("useBlurhash", true),
+                showCards = false
         )
 
         adapter = StatusesAdapter(statusDisplayOptions,

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchStatusesFragment.kt
@@ -79,7 +79,8 @@ class SearchStatusesFragment : SearchFragment<Pair<Status, StatusViewData.Concre
                 mediaPreviewEnabled = viewModel.mediaPreviewEnabled,
                 useAbsoluteTime = preferences.getBoolean("absoluteTimeView", false),
                 showBotOverlay = preferences.getBoolean("showBotOverlay", true),
-                useBlurhash = preferences.getBoolean("useBlurhash", true)
+                useBlurhash = preferences.getBoolean("useBlurhash", true),
+                showCards = false
         )
 
         searchRecyclerView.addItemDecoration(DividerItemDecoration(searchRecyclerView.context, DividerItemDecoration.VERTICAL))

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchStatusesFragment.kt
@@ -51,6 +51,7 @@ import com.keylesspalace.tusky.entity.Attachment
 import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.interfaces.AccountSelectionListener
 import com.keylesspalace.tusky.interfaces.StatusActionListener
+import com.keylesspalace.tusky.util.CardViewMode
 import com.keylesspalace.tusky.util.NetworkState
 import com.keylesspalace.tusky.util.StatusDisplayOptions
 import com.keylesspalace.tusky.viewdata.AttachmentViewData
@@ -80,7 +81,7 @@ class SearchStatusesFragment : SearchFragment<Pair<Status, StatusViewData.Concre
                 useAbsoluteTime = preferences.getBoolean("absoluteTimeView", false),
                 showBotOverlay = preferences.getBoolean("showBotOverlay", true),
                 useBlurhash = preferences.getBoolean("useBlurhash", true),
-                showCards = false
+                cardViewMode = CardViewMode.NONE
         )
 
         searchRecyclerView.addItemDecoration(DividerItemDecoration(searchRecyclerView.context, DividerItemDecoration.VERTICAL))

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -244,7 +244,8 @@ public class NotificationsFragment extends SFragment implements
                 accountManager.getActiveAccount().getMediaPreviewEnabled(),
                 preferences.getBoolean("absoluteTimeView", false),
                 preferences.getBoolean("showBotOverlay", true),
-                preferences.getBoolean("useBlurhash", true)
+                preferences.getBoolean("useBlurhash", true),
+                false
         );
 
         adapter = new NotificationsAdapter(accountManager.getActiveAccount().getAccountId(),

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -69,6 +69,7 @@ import com.keylesspalace.tusky.entity.Status;
 import com.keylesspalace.tusky.interfaces.ActionButtonActivity;
 import com.keylesspalace.tusky.interfaces.ReselectableFragment;
 import com.keylesspalace.tusky.interfaces.StatusActionListener;
+import com.keylesspalace.tusky.util.CardViewMode;
 import com.keylesspalace.tusky.util.Either;
 import com.keylesspalace.tusky.util.HttpHeaderLink;
 import com.keylesspalace.tusky.util.ListStatusAccessibilityDelegate;
@@ -245,7 +246,7 @@ public class NotificationsFragment extends SFragment implements
                 preferences.getBoolean("absoluteTimeView", false),
                 preferences.getBoolean("showBotOverlay", true),
                 preferences.getBoolean("useBlurhash", true),
-                false
+                CardViewMode.NONE
         );
 
         adapter = new NotificationsAdapter(accountManager.getActiveAccount().getAccountId(),

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -72,6 +72,7 @@ import com.keylesspalace.tusky.network.MastodonApi;
 import com.keylesspalace.tusky.repository.Placeholder;
 import com.keylesspalace.tusky.repository.TimelineRepository;
 import com.keylesspalace.tusky.repository.TimelineRequestMode;
+import com.keylesspalace.tusky.util.CardViewMode;
 import com.keylesspalace.tusky.util.Either;
 import com.keylesspalace.tusky.util.LinkHelper;
 import com.keylesspalace.tusky.util.ListStatusAccessibilityDelegate;
@@ -227,7 +228,9 @@ public class TimelineFragment extends SFragment implements
                 preferences.getBoolean("absoluteTimeView", false),
                 preferences.getBoolean("showBotOverlay", true),
                 preferences.getBoolean("useBlurhash", true),
-                preferences.getBoolean("showCardsInTimelines", false)
+                preferences.getBoolean("showCardsInTimelines", false) ?
+                        CardViewMode.FULL_WIDTH :
+                        CardViewMode.NONE
         );
         adapter = new TimelineAdapter(dataSource, statusDisplayOptions, this);
 

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -229,7 +229,7 @@ public class TimelineFragment extends SFragment implements
                 preferences.getBoolean("showBotOverlay", true),
                 preferences.getBoolean("useBlurhash", true),
                 preferences.getBoolean("showCardsInTimelines", false) ?
-                        CardViewMode.FULL_WIDTH :
+                        CardViewMode.INDENTED :
                         CardViewMode.NONE
         );
         adapter = new TimelineAdapter(dataSource, statusDisplayOptions, this);

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -226,7 +226,8 @@ public class TimelineFragment extends SFragment implements
                 accountManager.getActiveAccount().getMediaPreviewEnabled(),
                 preferences.getBoolean("absoluteTimeView", false),
                 preferences.getBoolean("showBotOverlay", true),
-                preferences.getBoolean("useBlurhash", true)
+                preferences.getBoolean("useBlurhash", true),
+                preferences.getBoolean("showCardsInTimelines", false)
         );
         adapter = new TimelineAdapter(dataSource, statusDisplayOptions, this);
 

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -131,7 +131,8 @@ public final class ViewThreadFragment extends SFragment implements
                 accountManager.getActiveAccount().getMediaPreviewEnabled(),
                 preferences.getBoolean("absoluteTimeView", false),
                 preferences.getBoolean("showBotOverlay", true),
-                preferences.getBoolean("useBlurhash", true)
+                preferences.getBoolean("useBlurhash", true),
+                true
         );
         adapter = new ThreadAdapter(statusDisplayOptions, this);
     }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -58,6 +58,7 @@ import com.keylesspalace.tusky.entity.Status;
 import com.keylesspalace.tusky.entity.StatusContext;
 import com.keylesspalace.tusky.interfaces.StatusActionListener;
 import com.keylesspalace.tusky.network.MastodonApi;
+import com.keylesspalace.tusky.util.CardViewMode;
 import com.keylesspalace.tusky.util.ListStatusAccessibilityDelegate;
 import com.keylesspalace.tusky.util.PairedList;
 import com.keylesspalace.tusky.util.StatusDisplayOptions;
@@ -132,7 +133,9 @@ public final class ViewThreadFragment extends SFragment implements
                 preferences.getBoolean("absoluteTimeView", false),
                 preferences.getBoolean("showBotOverlay", true),
                 preferences.getBoolean("useBlurhash", true),
-                true
+                preferences.getBoolean("showCardsInTimelines", false) ?
+                        CardViewMode.INDENTED :
+                        CardViewMode.NONE
         );
         adapter = new ThreadAdapter(statusDisplayOptions, this);
     }

--- a/app/src/main/java/com/keylesspalace/tusky/util/CardViewMode.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/CardViewMode.kt
@@ -1,0 +1,7 @@
+package com.keylesspalace.tusky.util
+
+enum class CardViewMode {
+    NONE,
+    FULL_WIDTH,
+    INDENTED
+}

--- a/app/src/main/java/com/keylesspalace/tusky/util/StatusDisplayOptions.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/StatusDisplayOptions.kt
@@ -11,6 +11,6 @@ data class StatusDisplayOptions(
         val showBotOverlay: Boolean,
         @get:JvmName("useBlurhash")
         val useBlurhash: Boolean,
-        @get:JvmName("showCards")
-        val showCards: Boolean
+        @get:JvmName("cardViewMode")
+        val cardViewMode: CardViewMode
 )

--- a/app/src/main/java/com/keylesspalace/tusky/util/StatusDisplayOptions.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/StatusDisplayOptions.kt
@@ -10,5 +10,7 @@ data class StatusDisplayOptions(
         @get:JvmName("showBotOverlay")
         val showBotOverlay: Boolean,
         @get:JvmName("useBlurhash")
-        val useBlurhash: Boolean
+        val useBlurhash: Boolean,
+        @get:JvmName("showCards")
+        val showCards: Boolean
 )

--- a/app/src/main/res/layout/item_status.xml
+++ b/app/src/main/res/layout/item_status.xml
@@ -157,6 +157,71 @@
         app:layout_constraintTop_toBottomOf="@id/status_content_warning_button"
         tools:text="This is a status" />
 
+    <LinearLayout
+        android:id="@+id/status_card_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/card_frame"
+        android:clipChildren="true"
+        android:foreground="?attr/selectableItemBackground"
+        android:minHeight="80dp"
+        android:orientation="vertical"
+        app:layout_constraintTop_toBottomOf="@+id/status_content"
+        tools:visibility="gone">
+
+        <ImageView
+            android:id="@+id/card_image"
+            android:layout_width="match_parent"
+            android:layout_height="300dp"
+            android:layout_margin="1dp"
+            android:background="?attr/colorBackgroundAccent"
+            android:importantForAccessibility="no"
+            android:scaleType="center" />
+
+        <LinearLayout
+            android:id="@+id/card_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingLeft="6dp"
+            android:paddingTop="6dp"
+            android:paddingRight="6dp"
+            android:paddingBottom="6dp">
+
+            <androidx.emoji.widget.EmojiTextView
+                android:id="@+id/card_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:ellipsize="end"
+                android:fontFamily="sans-serif-medium"
+                android:lines="1"
+                android:textColor="?android:textColorSecondary"
+                android:textSize="?attr/status_text_medium" />
+
+            <androidx.emoji.widget.EmojiTextView
+                android:id="@+id/card_description"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:ellipsize="end"
+                android:lineSpacingMultiplier="1.1"
+                android:maxLines="2"
+                android:textColor="?android:textColorSecondary"
+                android:textSize="?attr/status_text_medium" />
+
+            <TextView
+                android:id="@+id/card_link"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:lines="1"
+                android:textColor="?android:textColorTertiary"
+                android:textSize="?attr/status_text_medium" />
+        </LinearLayout>
+    </LinearLayout>
+
     <Button
         android:id="@+id/button_toggle_content"
         style="@style/TuskyButton.Outlined"
@@ -175,7 +240,7 @@
         android:textSize="?attr/status_text_medium"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="@id/status_display_name"
-        app:layout_constraintTop_toBottomOf="@id/status_content"
+        app:layout_constraintTop_toBottomOf="@id/status_card_view"
         tools:text="@string/status_content_show_less"
         tools:visibility="visible" />
 

--- a/app/src/main/res/layout/item_status.xml
+++ b/app/src/main/res/layout/item_status.xml
@@ -159,7 +159,7 @@
 
     <LinearLayout
         android:id="@+id/status_card_view"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:background="@drawable/card_frame"
@@ -169,6 +169,7 @@
         android:orientation="vertical"
         app:layout_constraintStart_toStartOf="@id/status_display_name"
         app:layout_constraintTop_toBottomOf="@+id/status_content"
+        app:layout_constraintEnd_toEndOf="parent"
         tools:visibility="gone">
 
         <ImageView

--- a/app/src/main/res/layout/item_status.xml
+++ b/app/src/main/res/layout/item_status.xml
@@ -167,6 +167,7 @@
         android:foreground="?attr/selectableItemBackground"
         android:minHeight="80dp"
         android:orientation="vertical"
+        app:layout_constraintStart_toStartOf="@id/status_display_name"
         app:layout_constraintTop_toBottomOf="@+id/status_content"
         tools:visibility="gone">
 

--- a/app/src/main/res/layout/item_status_detailed.xml
+++ b/app/src/main/res/layout/item_status_detailed.xml
@@ -131,7 +131,7 @@
         tools:text="Status content. Can be pretty long. " />
 
     <LinearLayout
-        android:id="@+id/card_view"
+        android:id="@+id/status_card_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
@@ -204,7 +204,7 @@
         android:layout_marginBottom="4dp"
         android:background="@drawable/media_preview_outline"
         android:importantForAccessibility="noHideDescendants"
-        app:layout_constraintTop_toBottomOf="@id/card_view">
+        app:layout_constraintTop_toBottomOf="@id/status_card_view">
 
         <com.keylesspalace.tusky.view.MediaPreviewImageView
             android:id="@+id/status_media_preview_0"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -548,5 +548,6 @@
     <string name="no_saved_status">You don\'t have any drafts.</string>
     <string name="no_scheduled_status">You don\'t have any scheduled statuses.</string>
     <string name="warning_scheduling_interval">Mastodon has a minimum scheduling interval of 5 minutes.</string>
+    <string name="pref_title_show_cards_in_timelines">Show link previews in timelines</string>
 
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -72,6 +72,12 @@
             android:title="@string/pref_title_show_notifications_filter"
             app:singleLineTitle="false" />
 
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="showCardsInTimelines"
+            android:title="@string/pref_title_show_cards_in_timelines"
+            app:singleLineTitle="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_title_browser_settings">


### PR DESCRIPTION
Addresses #1075

- Moved card setup to `StatusBaseViewHolder`
- Added user preference
- Added status display option for cards
- Tweaked fragments/adapters to set the status display option correctly based on the fragment purpose

![Screenshot_20200212-145450](https://user-images.githubusercontent.com/142250/74341414-f7c54800-4da7-11ea-92b0-46f6df49350a.png)
