### PR TITLE
[Tusky10] adjust poll result background, status divider & button outline color

### DIFF
--- a/app/src/main/res/drawable/status_divider.xml
+++ b/app/src/main/res/drawable/status_divider.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <size android:height="1dp" />
-    <solid android:color="?attr/colorBackgroundAccent" />
+    <solid android:color="?attr/dividerColor" />
 </shape>

--- a/app/src/main/res/values-night/theme_colors.xml
+++ b/app/src/main/res/values-night/theme_colors.xml
@@ -15,6 +15,7 @@
     <color name="iconColor">@color/tusky_grey_70</color>
 
     <color name="colorBackgroundAccent">@color/tusky_grey_30</color>
+    <color name="dividerColor">@color/tusky_grey_25</color>
 
     <color name="favoriteButtonActiveColor">@color/tusky_orange</color>
 

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -7,20 +7,20 @@
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowLightNavigationBar">false</item>
         <item name="android:navigationBarColor">@color/tusky_grey_20</item>
-        <item name="android:navigationBarDividerColor">?attr/dividerColor</item>
+        <item name="android:navigationBarDividerColor">@color/tusky_grey_25</item>
     </style>
 
     <style name="TuskyTheme" parent="TuskyBaseTheme">
         <item name="android:windowLightNavigationBar">@bool/lightNavigationBar</item>
         <item name="android:navigationBarColor">@color/colorBackground</item>
-        <item name="android:navigationBarDividerColor">@color/colorBackgroundAccent</item>
+        <item name="android:navigationBarDividerColor">?attr/dividerColor</item>
     </style>
 
     <!--Black Application Theme Styles-->
     <style name="TuskyBlackTheme" parent="TuskyBlackThemeBase">
         <item name="android:windowLightNavigationBar">false</item>
         <item name="android:navigationBarColor">@color/black</item>
-        <item name="android:navigationBarDividerColor">@color/tusky_grey_10</item>
+        <item name="android:navigationBarDividerColor">?attr/dividerColor</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -7,7 +7,7 @@
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowLightNavigationBar">false</item>
         <item name="android:navigationBarColor">@color/tusky_grey_20</item>
-        <item name="android:navigationBarDividerColor">@color/tusky_grey_30</item>
+        <item name="android:navigationBarDividerColor">?attr/dividerColor</item>
     </style>
 
     <style name="TuskyTheme" parent="TuskyBaseTheme">
@@ -20,7 +20,7 @@
     <style name="TuskyBlackTheme" parent="TuskyBlackThemeBase">
         <item name="android:windowLightNavigationBar">false</item>
         <item name="android:navigationBarColor">@color/black</item>
-        <item name="android:navigationBarDividerColor">@color/tusky_grey_05</item>
+        <item name="android:navigationBarDividerColor">@color/tusky_grey_10</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -13,6 +13,7 @@
     <attr name="textColorDisabled" format="reference|color" />
     <attr name="iconColor" format="reference|color" />
     <attr name="windowBackgroundColor" format="reference|color" />
+    <attr name="dividerColor" format="reference|color" />
 
     <attr name="status_text_small" format="dimension" />
     <attr name="status_text_medium" format="dimension" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -63,6 +63,7 @@
         <item name="iconColor">@color/iconColor</item>
 
         <item name="android:listDivider">@drawable/status_divider</item>
+        <item name="dividerColor">@color/dividerColor</item>
 
         <item name="textColorDisabled">@color/textColorDisabled</item>
 
@@ -71,7 +72,7 @@
         <item name="material_drawer_primary_icon">@color/iconColor</item>
         <item name="material_drawer_secondary_text">@color/textColorTertiary</item>
         <item name="material_drawer_hint_text">@color/textColorTertiary</item>
-        <item name="material_drawer_divider">@color/colorBackgroundAccent</item>
+        <item name="material_drawer_divider">?attr/dividerColor</item>
         <item name="material_drawer_header_selection_text">@color/white</item>
         <item name="material_drawer_header_selection_subtext">@color/white</item>
 
@@ -115,6 +116,7 @@
     </style>
 
     <style name="TuskyButton.Outlined" parent="Widget.MaterialComponents.Button.OutlinedButton">
+        <item name="strokeColor">?attr/colorBackgroundAccent</item>
         <item name="android:letterSpacing">0</item>
     </style>
 
@@ -137,11 +139,12 @@
         <item name="colorSurface">@color/tusky_grey_10</item>
 
         <item name="iconColor">@color/tusky_grey_40</item>
-        <item name="colorBackgroundAccent">@color/tusky_grey_05</item>
+        <item name="colorBackgroundAccent">@color/tusky_grey_20</item>
+
+        <item name="dividerColor">@color/tusky_grey_10</item>
 
         <item name="material_drawer_background">@color/black</item>
         <item name="material_drawer_primary_icon">@color/tusky_grey_40</item>
-        <item name="material_drawer_divider">@color/tusky_grey_05</item>
     </style>
 
     <style name="TuskyBlackTheme" parent="TuskyBlackThemeBase" />

--- a/app/src/main/res/values/theme_colors.xml
+++ b/app/src/main/res/values/theme_colors.xml
@@ -14,7 +14,8 @@
 
     <color name="iconColor">@color/tusky_grey_50</color>
 
-    <color name="colorBackgroundAccent">@color/tusky_grey_80</color>
+    <color name="colorBackgroundAccent">@color/tusky_grey_70</color>
+    <color name="dividerColor">@color/tusky_grey_80</color>
 
     <color name="favoriteButtonActiveColor">@color/tusky_orange_light</color>
 


### PR DESCRIPTION
This is based on feedback from beta users. I split up the poll background and status divider colors so they can be set individually. 

closes https://github.com/tuskyapp/Tusky/issues/1679