### PR TITLE
Fix recollapsing expanded sensitive content in the thread view

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -328,7 +328,7 @@ public final class ViewThreadFragment extends SFragment implements
                         .setIsExpanded(expanded)
                         .createStatusViewData();
         statuses.setPairedItem(position, newViewData);
-        adapter.setItem(position, newViewData, false);
+        adapter.setItem(position, newViewData, true);
         updateRevealIcon();
     }
 


### PR DESCRIPTION
On `develop`, clicking "Show Less" in the thread view doesn't recollapse the content
(because the adapter never gets notified that the status view data has been updated after changing the expanded state)