### PR TITLE
fix list editing by moving account_ids from query to form param

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -428,16 +428,19 @@ interface MastodonApi {
             @Query("limit") limit: Int
     ): Single<List<Account>>
 
-    @DELETE("api/v1/lists/{listId}/accounts")
+    @FormUrlEncoded
+    // @DELETE doesn't support fields
+    @HTTP(method = "DELETE", path = "api/v1/lists/{listId}/accounts", hasBody = true)
     fun deleteAccountFromList(
             @Path("listId") listId: String,
-            @Query("account_ids[]") accountIds: List<String>
+            @Field("account_ids[]") accountIds: List<String>
     ): Completable
 
+    @FormUrlEncoded
     @POST("api/v1/lists/{listId}/accounts")
     fun addCountToList(
             @Path("listId") listId: String,
-            @Query("account_ids[]") accountIds: List<String>
+            @Field("account_ids[]") accountIds: List<String>
     ): Completable
 
     @GET("/api/v1/conversations")

--- a/app/src/main/res/layout/fragment_accounts_in_list.xml
+++ b/app/src/main/res/layout/fragment_accounts_in_list.xml
@@ -29,7 +29,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/searchView" />
 
-
     <com.keylesspalace.tusky.view.BackgroundMessageView
         android:id="@+id/messageView"
         android:layout_width="wrap_content"
@@ -43,16 +42,15 @@
         tools:src="@drawable/elephant_error"
         tools:visibility="visible" />
 
-
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/accountsSearchRecycler"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginTop="8dp"
-        android:background="?android:attr/windowBackground"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/searchView" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -97,7 +97,7 @@
 
     <style name="TuskyDialogFragmentStyle" parent="@style/ThemeOverlay.MaterialComponents.Dialog">
         <item name="dialogCornerRadius">8dp</item>
-        <item name="android:backgroundTint">?attr/windowBackgroundColor</item>
+        <item name="android:backgroundTint">@color/colorBackground</item>
     </style>
 
     <style name="TuskyTabAppearance" parent="Widget.MaterialComponents.TabLayout">


### PR DESCRIPTION
The param goes in the body as per api definition https://docs.joinmastodon.org/methods/timelines/lists/

The question is: Why did this work before?