### PR TITLE
Upgrade deps

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -108,7 +108,7 @@ dependencies {
 
     implementation "androidx.core:core-ktx:1.2.0-rc01"
     implementation "androidx.appcompat:appcompat:1.2.0-alpha02"
-    implementation "androidx.fragment:fragment-ktx:1.1.0"
+    implementation "androidx.fragment:fragment-ktx:1.2.2"
     implementation "androidx.browser:browser:1.2.0"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
     implementation "androidx.recyclerview:recyclerview:1.1.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -100,7 +100,7 @@ ext.roomVersion = '2.2.3'
 ext.retrofitVersion = '2.6.0'
 ext.okhttpVersion = '4.3.1'
 ext.glideVersion = '4.10.0'
-ext.daggerVersion = '2.25.3'
+ext.daggerVersion = '2.26'
 
 // if libraries are changed here, they should also be changed in LicenseActivity
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,8 +96,8 @@ project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 ext.lifecycleVersion = "2.2.0"
-ext.roomVersion = '2.2.3'
-ext.retrofitVersion = '2.6.0'
+ext.roomVersion = '2.2.4'
+ext.retrofitVersion = '2.7.1'
 ext.okhttpVersion = '4.3.1'
 ext.glideVersion = '4.10.0'
 ext.daggerVersion = '2.26'
@@ -106,7 +106,7 @@ ext.daggerVersion = '2.26'
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    implementation "androidx.core:core-ktx:1.2.0-rc01"
+    implementation "androidx.core:core-ktx:1.2.0"
     implementation "androidx.appcompat:appcompat:1.2.0-alpha02"
     implementation "androidx.fragment:fragment-ktx:1.2.2"
     implementation "androidx.browser:browser:1.2.0"
@@ -128,7 +128,7 @@ dependencies {
     implementation "androidx.room:room-rxjava2:$roomVersion"
     kapt "androidx.room:room-compiler:$roomVersion"
 
-    implementation "com.google.android.material:material:1.1.0-rc01"
+    implementation "com.google.android.material:material:1.1.0"
 
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,7 +95,7 @@ project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     }
 }
 
-ext.lifecycleVersion = "2.1.0"
+ext.lifecycleVersion = "2.2.0"
 ext.roomVersion = '2.2.3'
 ext.retrofitVersion = '2.6.0'
 ext.okhttpVersion = '4.3.1'
@@ -118,8 +118,9 @@ dependencies {
     implementation "androidx.sharetarget:sharetarget:1.0.0-rc01"
     implementation "androidx.emoji:emoji:1.0.0"
     implementation "androidx.emoji:emoji-appcompat:1.0.0"
-    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
-    implementation "androidx.lifecycle:lifecycle-reactivestreams:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-reactivestreams-ktx:$lifecycleVersion"
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
     implementation "androidx.paging:paging-runtime-ktx:2.1.1"
     implementation "androidx.viewpager2:viewpager2:1.0.0"

--- a/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
@@ -27,6 +27,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.viewModels
 import androidx.annotation.ColorInt
 import androidx.annotation.Px
 import androidx.appcompat.app.AlertDialog
@@ -34,7 +35,6 @@ import androidx.core.app.ActivityOptionsCompat
 import androidx.core.content.ContextCompat
 import androidx.emoji.text.EmojiCompat
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.viewpager2.widget.MarginPageTransformer
@@ -76,7 +76,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
 
-    private lateinit var viewModel: AccountViewModel
+    private val viewModel: AccountViewModel by viewModels { viewModelFactory }
 
     private val accountFieldAdapter = AccountFieldAdapter(this)
 
@@ -116,9 +116,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
         loadResources()
         makeNotificationBarTransparent()
         setContentView(R.layout.activity_account)
-
-        viewModel = ViewModelProviders.of(this, viewModelFactory)[AccountViewModel::class.java]
-
+        
         // Obtain information to fill out the profile.
         viewModel.setAccountInfo(intent.getStringExtra(KEY_ACCOUNT_ID)!!)
 

--- a/app/src/main/java/com/keylesspalace/tusky/EditProfileActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/EditProfileActivity.kt
@@ -19,7 +19,6 @@ import android.Manifest
 import android.app.Activity
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
@@ -34,6 +33,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.ImageView
+import androidx.activity.viewModels
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.FitCenter
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
@@ -69,7 +69,7 @@ class EditProfileActivity : BaseActivity(), Injectable {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
 
-    private lateinit var viewModel: EditProfileViewModel
+    private val viewModel: EditProfileViewModel by viewModels { viewModelFactory }
 
     private var currentlyPicking: PickType = PickType.NOTHING
 
@@ -89,8 +89,6 @@ class EditProfileActivity : BaseActivity(), Injectable {
         }
 
         setContentView(R.layout.activity_edit_profile)
-
-        viewModel = ViewModelProviders.of(this, viewModelFactory)[EditProfileViewModel::class.java]
 
         setSupportActionBar(toolbar)
         supportActionBar?.run {

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -37,6 +37,7 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.widget.*
+import androidx.activity.viewModels
 import androidx.annotation.ColorInt
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
@@ -49,7 +50,6 @@ import androidx.core.view.inputmethod.InputContentInfoCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -110,7 +110,7 @@ class ComposeActivity : BaseActivity(),
     var maximumTootCharacters = DEFAULT_CHARACTER_LIMIT
 
     private var composeOptions: ComposeOptions? = null
-    private lateinit var viewModel: ComposeViewModel
+    private val viewModel: ComposeViewModel by viewModels { viewModelFactory }
 
     private var mediaCount = 0
 
@@ -141,8 +141,6 @@ class ComposeActivity : BaseActivity(),
                 LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false)
         composeMediaPreviewBar.adapter = mediaAdapter
         composeMediaPreviewBar.itemAnimator = null
-
-        viewModel = ViewModelProviders.of(this, viewModelFactory)[ComposeViewModel::class.java]
 
         subscribeToUpdates(mediaAdapter)
         setupButtons()

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
@@ -20,8 +20,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import androidx.paging.PagedList
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -50,15 +50,13 @@ class ConversationsFragment : SFragment(), StatusActionListener, Injectable, Res
     @Inject
     lateinit var db: AppDatabase
 
-    private lateinit var viewModel: ConversationsViewModel
+    private val viewModel: ConversationsViewModel by viewModels { viewModelFactory }
 
     private lateinit var adapter: ConversationAdapter
 
     private var layoutManager: LinearLayoutManager? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        viewModel = ViewModelProviders.of(this, viewModelFactory)[ConversationsViewModel::class.java]
-
         return inflater.inflate(R.layout.fragment_timeline, container, false)
     }
 
@@ -87,10 +85,10 @@ class ConversationsFragment : SFragment(), StatusActionListener, Injectable, Res
 
         initSwipeToRefresh()
 
-        viewModel.conversations.observe(this, Observer<PagedList<ConversationEntity>> {
+        viewModel.conversations.observe(viewLifecycleOwner, Observer<PagedList<ConversationEntity>> {
             adapter.submitList(it)
         })
-        viewModel.networkState.observe(this, Observer {
+        viewModel.networkState.observe(viewLifecycleOwner, Observer {
             adapter.setNetworkState(it)
         })
 
@@ -99,7 +97,7 @@ class ConversationsFragment : SFragment(), StatusActionListener, Injectable, Res
     }
 
     private fun initSwipeToRefresh() {
-        viewModel.refreshState.observe(this, Observer {
+        viewModel.refreshState.observe(viewLifecycleOwner, Observer {
             swipeRefreshLayout.isRefreshing = it == NetworkState.LOADING
         })
         swipeRefreshLayout.setOnRefreshListener {

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/ReportActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/ReportActivity.kt
@@ -19,14 +19,12 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
-import androidx.appcompat.content.res.AppCompatResources
+import androidx.activity.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import com.keylesspalace.tusky.BottomSheetActivity
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.components.report.adapter.ReportPagerAdapter
 import com.keylesspalace.tusky.di.ViewModelFactory
-import com.keylesspalace.tusky.util.ThemeUtils
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
 import kotlinx.android.synthetic.main.activity_report.*
@@ -42,11 +40,10 @@ class ReportActivity : BottomSheetActivity(), HasAndroidInjector {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
 
-    private lateinit var viewModel: ReportViewModel
+    private val viewModel: ReportViewModel by viewModels { viewModelFactory }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        viewModel = ViewModelProviders.of(this, viewModelFactory)[ReportViewModel::class.java]
         val accountId = intent?.getStringExtra(ACCOUNT_ID)
         val accountUserName = intent?.getStringExtra(ACCOUNT_USERNAME)
         if (accountId.isNullOrBlank() || accountUserName.isNullOrBlank()) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportDoneFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportDoneFragment.kt
@@ -21,8 +21,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.components.report.ReportViewModel
 import com.keylesspalace.tusky.components.report.Screen
@@ -40,12 +40,7 @@ class ReportDoneFragment : Fragment(), Injectable {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
 
-    private lateinit var viewModel: ReportViewModel
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)[ReportViewModel::class.java]
-    }
+    private val viewModel: ReportViewModel by viewModels { viewModelFactory }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
@@ -69,8 +64,8 @@ class ReportDoneFragment : Fragment(), Injectable {
                 progressMute.hide()
             }
 
-            buttonMute.setText(when {
-                it.data == true -> R.string.action_unmute
+            buttonMute.setText(when (it.data) {
+                true -> R.string.action_unmute
                 else -> R.string.action_mute
             })
         })
@@ -84,8 +79,8 @@ class ReportDoneFragment : Fragment(), Injectable {
                 buttonBlock.hide()
                 progressBlock.hide()
             }
-            buttonBlock.setText(when {
-                it.data == true -> R.string.action_unblock
+            buttonBlock.setText(when (it.data) {
+                true -> R.string.action_unblock
                 else -> R.string.action_block
             })
         })

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportDoneFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportDoneFragment.kt
@@ -40,7 +40,7 @@ class ReportDoneFragment : Fragment(), Injectable {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
 
-    private val viewModel: ReportViewModel by viewModels { viewModelFactory }
+    private val viewModel: ReportViewModel by viewModels({ requireActivity() }) { viewModelFactory }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportNoteFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportNoteFragment.kt
@@ -21,8 +21,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.snackbar.Snackbar
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.components.report.ReportViewModel
@@ -39,12 +39,7 @@ class ReportNoteFragment : Fragment(), Injectable {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
 
-    private lateinit var viewModel: ReportViewModel
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)[ReportViewModel::class.java]
-    }
+    private val viewModel: ReportViewModel by viewModels { viewModelFactory }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportNoteFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportNoteFragment.kt
@@ -39,7 +39,7 @@ class ReportNoteFragment : Fragment(), Injectable {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
 
-    private val viewModel: ReportViewModel by viewModels { viewModelFactory }
+    private val viewModel: ReportViewModel by viewModels({ requireActivity() }) { viewModelFactory }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportStatusesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportStatusesFragment.kt
@@ -22,8 +22,8 @@ import android.view.ViewGroup
 import androidx.core.app.ActivityOptionsCompat
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import androidx.paging.PagedList
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -59,18 +59,12 @@ class ReportStatusesFragment : Fragment(), Injectable, AdapterHandler {
     @Inject
     lateinit var accountManager: AccountManager
 
-    private lateinit var viewModel: ReportViewModel
+    private val viewModel: ReportViewModel by viewModels { viewModelFactory }
 
     private lateinit var adapter: StatusesAdapter
     private lateinit var layoutManager: LinearLayoutManager
 
     private var snackbarErrorRetry: Snackbar? = null
-
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)[ReportViewModel::class.java]
-    }
 
     override fun showMedia(v: View?, status: Status?, idx: Int) {
         status?.actionableStatus?.let { actionable ->

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportStatusesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportStatusesFragment.kt
@@ -59,7 +59,7 @@ class ReportStatusesFragment : Fragment(), Injectable, AdapterHandler {
     @Inject
     lateinit var accountManager: AccountManager
 
-    private val viewModel: ReportViewModel by viewModels { viewModelFactory }
+    private val viewModel: ReportViewModel by viewModels({ requireActivity() }) { viewModelFactory }
 
     private lateinit var adapter: StatusesAdapter
     private lateinit var layoutManager: LinearLayoutManager

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
@@ -21,8 +21,8 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import androidx.activity.viewModels
 import androidx.appcompat.widget.SearchView
-import androidx.lifecycle.ViewModelProviders
 import com.google.android.material.tabs.TabLayoutMediator
 import com.keylesspalace.tusky.BottomSheetActivity
 import com.keylesspalace.tusky.R
@@ -40,12 +40,11 @@ class SearchActivity : BottomSheetActivity(), HasAndroidInjector {
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
 
-    private lateinit var viewModel: SearchViewModel
+    private val viewModel: SearchViewModel by viewModels { viewModelFactory }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_search)
-        viewModel = ViewModelProviders.of(this, viewModelFactory)[SearchViewModel::class.java]
         setSupportActionBar(toolbar)
         supportActionBar?.apply {
             setDisplayHomeAsUpEnabled(true)

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchFragment.kt
@@ -5,9 +5,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import androidx.paging.PagedList
 import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -30,11 +30,12 @@ import javax.inject.Inject
 abstract class SearchFragment<T> : Fragment(),
         LinkListener, Injectable, SwipeRefreshLayout.OnRefreshListener {
 
-    private var snackbarErrorRetry: Snackbar? = null
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
 
-    protected lateinit var viewModel: SearchViewModel
+    protected val viewModel: SearchViewModel by viewModels({requireActivity()}) { viewModelFactory }
+
+    private var snackbarErrorRetry: Snackbar? = null
 
     abstract fun createAdapter(): PagedListAdapter<T, *>
 
@@ -42,11 +43,6 @@ abstract class SearchFragment<T> : Fragment(),
     abstract val networkState: LiveData<NetworkState>
     abstract val data: LiveData<PagedList<T>>
     protected lateinit var adapter: PagedListAdapter<T, *>
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        viewModel = ViewModelProviders.of(requireActivity(), viewModelFactory)[SearchViewModel::class.java]
-    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_search, container, false)

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchFragment.kt
@@ -33,7 +33,7 @@ abstract class SearchFragment<T> : Fragment(),
     @Inject
     lateinit var viewModelFactory: ViewModelFactory
 
-    protected val viewModel: SearchViewModel by viewModels({requireActivity()}) { viewModelFactory }
+    protected val viewModel: SearchViewModel by viewModels({ requireActivity() }) { viewModelFactory }
 
     private var snackbarErrorRetry: Snackbar? = null
 

--- a/app/src/main/res/layout/activity_account_list.xml
+++ b/app/src/main/res/layout/activity_account_list.xml
@@ -9,7 +9,7 @@
 
     <include layout="@layout/toolbar_basic" />
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_modal_timeline.xml
+++ b/app/src/main/res/layout/activity_modal_timeline.xml
@@ -9,7 +9,7 @@
 
     <include layout="@layout/toolbar_basic" />
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/contentFrame"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_preferences.xml
+++ b/app/src/main/res/layout/activity_preferences.xml
@@ -9,7 +9,7 @@
 
     <include layout="@layout/toolbar_basic" />
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_statuslist.xml
+++ b/app/src/main/res/layout/activity_statuslist.xml
@@ -9,7 +9,7 @@
 
     <include layout="@layout/toolbar_basic" />
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_view_tag.xml
+++ b/app/src/main/res/layout/activity_view_tag.xml
@@ -9,7 +9,7 @@
 
     <include layout="@layout/toolbar_basic" />
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_view_thread.xml
+++ b/app/src/main/res/layout/activity_view_thread.xml
@@ -9,7 +9,7 @@
 
     <include layout="@layout/toolbar_basic" />
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,5 @@ org.gradle.jvmargs=-Xmx4096m
 # use parallel execution
 org.gradle.parallel=true
 
-android.enableJetifier=true
-android.useAndroidX=true
 android.enableUnitTestBinaryResources=true
 android.enableR8.fullMode=true


### PR DESCRIPTION
- Its now recommeded to use `FragmentContainerView` to host fragments 
- `ViewModelProviders.of` is deprecated
- Dagger migrated to AndroidX so the flags in `build.gradle` are no longer needed