### PR TITLE
Work around the bug in ComposeScheduleView, fix #1720

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/view/ComposeScheduleView.java
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/view/ComposeScheduleView.java
@@ -192,6 +192,9 @@ public class ComposeScheduleView extends ConstraintLayout {
     private void onDateSet(long selection) {
         initializeSuggestedTime();
         Calendar newDate = getCalendar();
+        // working around bug in DatePicker where date is UTC #1720
+        // see https://github.com/material-components/material-components-android/issues/882
+        newDate.setTimeZone(TimeZone.getTimeZone("UTC"));
         newDate.setTimeInMillis(selection);
         scheduleDateTime.set(newDate.get(Calendar.YEAR), newDate.get(Calendar.MONTH), newDate.get(Calendar.DATE));
         openPickTimeDialog();


### PR DESCRIPTION
DatePicker seems to think that it's in UTC. So setting selected time
might not work as aspect and receiving value from it might be in UTC
as well. This commit fixes the second issue by interpreting the date
as UTC date. Tested with America/New_York (GMT-5 at the moment) and
Russia/Kamchatka (GMT+12).

cc @Tak, @kyori19 