### PR TITLE
Ensure media are marked sensitive any time there's a content warning

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -249,7 +249,7 @@ class ComposeViewModel
                             content,
                             spoilerText,
                             statusVisibility.value!!.serverString(),
-                            mediaUris.isNotEmpty() && markMediaAsSensitive.value!!,
+                            mediaUris.isNotEmpty() && (markMediaAsSensitive.value!! || showContentWarning.value!!),
                             mediaIds,
                             mediaUris.map { it.toString() },
                             mediaDescriptions,


### PR DESCRIPTION
Addresses the most critical part of #1725, and may also apply to #1721