### PR TITLE
Add log sending functionality

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/AboutActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AboutActivity.kt
@@ -1,8 +1,22 @@
+/* Copyright 2017 Andrew Dawson
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>. */
+
 package com.keylesspalace.tusky
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.annotation.StringRes
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import android.text.method.LinkMovementMethod
@@ -10,8 +24,12 @@ import android.text.style.URLSpan
 import android.text.util.Linkify
 import android.view.MenuItem
 import android.widget.TextView
+import androidx.annotation.StringRes
+import androidx.core.content.FileProvider
+import androidx.core.net.toFile
 import com.keylesspalace.tusky.di.Injectable
 import com.keylesspalace.tusky.util.CustomURLSpan
+import com.keylesspalace.tusky.util.LogReader
 import com.keylesspalace.tusky.util.hide
 import kotlinx.android.synthetic.main.activity_about.*
 import kotlinx.android.synthetic.main.toolbar_basic.*
@@ -32,7 +50,7 @@ class AboutActivity : BottomSheetActivity(), Injectable {
 
         versionTextView.text = getString(R.string.about_app_version, getString(R.string.app_name), BuildConfig.VERSION_NAME)
 
-        if(BuildConfig.CUSTOM_INSTANCE.isBlank()) {
+        if (BuildConfig.CUSTOM_INSTANCE.isBlank()) {
             aboutPoweredByTusky.hide()
         }
 
@@ -48,6 +66,9 @@ class AboutActivity : BottomSheetActivity(), Injectable {
             startActivityWithSlideInAnimation(Intent(this, LicenseActivity::class.java))
         }
 
+        sendLogsButton.setOnClickListener {
+            sendLogs()
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -60,6 +81,20 @@ class AboutActivity : BottomSheetActivity(), Injectable {
         return super.onOptionsItemSelected(item)
     }
 
+    private fun sendLogs() {
+        val logFileUri = LogReader.getLogFile(this)
+        val shareFileUri = FileProvider.getUriForFile(applicationContext,
+                "${BuildConfig.APPLICATION_ID}.fileprovider", logFileUri.toFile())
+
+        val sendIntent = Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_STREAM, shareFileUri)
+            type = "text/plain"
+        }
+
+        startActivity(Intent.createChooser(sendIntent,
+                getText(R.string.action_send_logs)))
+    }
 }
 
 private fun TextView.setClickableTextWithoutUnderlines(@StringRes textId: Int) {

--- a/app/src/main/java/com/keylesspalace/tusky/util/LogReader.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LogReader.kt
@@ -1,0 +1,46 @@
+/* Copyright 2017 Andrew Dawson
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>. */
+
+package com.keylesspalace.tusky.util
+
+import android.content.Context
+import android.net.Uri
+import java.io.File
+import java.io.IOException
+
+
+object LogReader {
+    fun getLogFile(context: Context): Uri {
+        return try {
+
+            val logFile = File(context.cacheDir, "log.txt")
+            logFile.delete()
+            logFile.createNewFile()
+            // -d means print and exit, -T gets last lines, -f outputs to file
+            val process = Runtime.getRuntime().exec(arrayOf("logcat", "-d", "-T", "1500", "-f", logFile.absolutePath))
+            try {
+                process.waitFor()
+            } catch (ignored: InterruptedException) {
+            }
+            if (process.exitValue() != 0) {
+                val error: String = process.errorStream.bufferedReader().readText()
+                throw RuntimeException("Reading logs failed: " + process.exitValue() + ", " + error)
+            }
+            Uri.fromFile(logFile)
+        } catch (e: IOException) {
+            throw RuntimeException(e)
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -39,7 +39,8 @@
                     android:textColor="?android:attr/textColorPrimary"
                     android:textIsSelectable="true"
                     android:textSize="24sp"
-                    android:textStyle="bold" />
+                    android:textStyle="bold"
+                    tools:text="@string/app_name" />
 
                 <TextView
                     android:id="@+id/aboutPoweredByTusky"
@@ -112,6 +113,18 @@
                     android:layout_marginTop="12dp"
                     android:lineSpacingMultiplier="1.2"
                     android:text="@string/title_licenses"
+                    android:textAlignment="center"
+                    android:textAllCaps="false"
+                    android:textSize="16sp" />
+
+                <Button
+                    android:id="@+id/sendLogsButton"
+                    style="@style/TuskyButton.Outlined"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:lineSpacingMultiplier="1.2"
+                    android:text="@string/action_send_logs"
                     android:textAlignment="center"
                     android:textAllCaps="false"
                     android:textSize="16sp" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="title_saved_toot">Drafts</string>
     <string name="title_scheduled_toot">Scheduled toots</string>
     <string name="title_licenses">Licenses</string>
+    <string name="action_send_logs">Send logs</string>
 
     <string name="status_username_format">\@%s</string>
     <string name="status_boosted_format">%s boosted</string>


### PR DESCRIPTION
This might be useful when we want to debug some strange behavior/crash.
We obviously get only our own logs (unless you give Tusky permission to read all of them and I hope no one does that).

Current approach is prompting to send file. We could fill in some email address but I don't know if it's a good idea because it's quite spam prone, maybe we would tell it to people when they ask or propose some other channel.