### PR TITLE
 Add preference to disable swipe gesture for switching tabs

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -168,6 +168,11 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
 
         val pageMargin = resources.getDimensionPixelSize(R.dimen.tab_page_margin)
         viewPager.setPageTransformer(MarginPageTransformer(pageMargin))
+
+        val uswSwipeForTabs = PreferenceManager.getDefaultSharedPreferences(this)
+                .getBoolean("enableSwipeForTabs", true)
+        viewPager.isUserInputEnabled = uswSwipeForTabs
+
         tabLayout.addOnTabSelectedListener(object : OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab) {
                 if (tab.position == notificationTabPosition) {

--- a/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.kt
@@ -129,7 +129,7 @@ class PreferencesActivity : BaseActivity(), SharedPreferences.OnSharedPreference
 
             }
             "statusTextSize", "absoluteTimeView", "showBotOverlay", "animateGifAvatars",
-            "useBlurhash", "showCardsInTimelines", "confirmReblogs" -> {
+            "useBlurhash", "showCardsInTimelines", "confirmReblogs", "enableSwipeForTabs" -> {
                 restartActivitiesOnExit = true
             }
             "language" -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -541,6 +541,7 @@
     <string name="failed_search">Failed to search</string>
 
     <string name="pref_title_show_notifications_filter">Show Notifications filter</string>
+    <string name="pref_title_enable_swipe_for_tabs">Enable swipe gesture to switch between tabs</string>
 
 
     <string name="create_poll_title">Poll</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -84,6 +84,12 @@
             android:title="@string/pref_title_confirm_reblogs"
             app:singleLineTitle="false" />
 
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="enableSwipeForTabs"
+            android:title="@string/pref_title_enable_swipe_for_tabs"
+            app:singleLineTitle="false" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/pref_title_browser_settings">


### PR DESCRIPTION
close #1718

I don't like adding more knobs but I dislike having accessibility problems even more and I think it should probably be optional independent of sensitivity.

It's based on `mainactivity_kotlin` branch so I will have to rebase it later
