### PR TITLE
fix content warning in notifications when alwaysShowSpoiler is on

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -516,7 +516,7 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
                     statusContent.setVisibility(statusViewData.isExpanded() ? View.GONE : View.VISIBLE);
                 });
 
-                setupContentAndSpoiler(notificationViewData, listener);
+                setupContentAndSpoiler(listener);
             }
 
         }
@@ -558,9 +558,9 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
             }
         }
 
-        private void setupContentAndSpoiler(NotificationViewData.Concrete notificationViewData, final LinkListener listener) {
+        private void setupContentAndSpoiler(final LinkListener listener) {
 
-            boolean shouldShowContentIfSpoiler = notificationViewData.isExpanded();
+            boolean shouldShowContentIfSpoiler = statusViewData.isExpanded();
             boolean hasSpoiler = !TextUtils.isEmpty(statusViewData.getSpoilerText());
             if (!shouldShowContentIfSpoiler && hasSpoiler) {
                 statusContent.setVisibility(View.GONE);
@@ -571,7 +571,7 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
             Spanned content = statusViewData.getContent();
             List<Emoji> emojis = statusViewData.getStatusEmojis();
 
-            if (statusViewData.isCollapsible() && (notificationViewData.isExpanded() || !hasSpoiler)) {
+            if (statusViewData.isCollapsible() && (statusViewData.isExpanded() || !hasSpoiler)) {
                 contentCollapseButton.setOnClickListener(view -> {
                     int position = getAdapterPosition();
                     if (position != RecyclerView.NO_POSITION && notificationActionListener != null) {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -445,7 +445,7 @@ public class NotificationsFragment extends SFragment implements
 
         NotificationViewData.Concrete newViewData = new NotificationViewData.Concrete(
                 viewdata.getType(), viewdata.getId(), viewdata.getAccount(),
-                viewDataBuilder.createStatusViewData(), viewdata.isExpanded());
+                viewDataBuilder.createStatusViewData());
 
         notifications.setPairedItem(position, newViewData);
         updateAdapter();
@@ -480,7 +480,7 @@ public class NotificationsFragment extends SFragment implements
 
         NotificationViewData.Concrete newViewData = new NotificationViewData.Concrete(
                 viewdata.getType(), viewdata.getId(), viewdata.getAccount(),
-                viewDataBuilder.createStatusViewData(), viewdata.isExpanded());
+                viewDataBuilder.createStatusViewData());
 
         notifications.setPairedItem(position, newViewData);
         updateAdapter();
@@ -515,7 +515,7 @@ public class NotificationsFragment extends SFragment implements
 
         NotificationViewData.Concrete newViewData = new NotificationViewData.Concrete(
                 viewdata.getType(), viewdata.getId(), viewdata.getAccount(),
-                viewDataBuilder.createStatusViewData(), viewdata.isExpanded());
+                viewDataBuilder.createStatusViewData());
 
         notifications.setPairedItem(position, newViewData);
         updateAdapter();
@@ -544,7 +544,7 @@ public class NotificationsFragment extends SFragment implements
 
         NotificationViewData.Concrete newViewData = new NotificationViewData.Concrete(
                 viewdata.getType(), viewdata.getId(), viewdata.getAccount(),
-                viewDataBuilder.createStatusViewData(), viewdata.isExpanded());
+                viewDataBuilder.createStatusViewData());
 
         notifications.setPairedItem(position, newViewData);
         updateAdapter();
@@ -584,7 +584,7 @@ public class NotificationsFragment extends SFragment implements
                         .setIsExpanded(expanded)
                         .createStatusViewData();
         NotificationViewData notificationViewData = new NotificationViewData.Concrete(old.getType(),
-                old.getId(), old.getAccount(), statusViewData, expanded);
+                old.getId(), old.getAccount(), statusViewData);
         notifications.setPairedItem(position, notificationViewData);
         updateAdapter();
     }
@@ -598,7 +598,7 @@ public class NotificationsFragment extends SFragment implements
                         .setIsShowingSensitiveContent(isShowing)
                         .createStatusViewData();
         NotificationViewData notificationViewData = new NotificationViewData.Concrete(old.getType(),
-                old.getId(), old.getAccount(), statusViewData, old.isExpanded());
+                old.getId(), old.getAccount(), statusViewData);
         notifications.setPairedItem(position, notificationViewData);
         updateAdapter();
     }
@@ -652,8 +652,7 @@ public class NotificationsFragment extends SFragment implements
                 concreteNotification.getType(),
                 concreteNotification.getId(),
                 concreteNotification.getAccount(),
-                updatedStatus,
-                concreteNotification.isExpanded()
+                updatedStatus
         );
         notifications.setPairedItem(position, updatedNotification);
         updateAdapter();

--- a/app/src/main/java/com/keylesspalace/tusky/util/ViewDataUtils.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ViewDataUtils.java
@@ -79,8 +79,7 @@ public final class ViewDataUtils {
                         notification.getStatus(),
                         alwaysShowSensitiveData,
                         alwaysOpenSpoiler
-                ),
-                false
+                )
         );
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/viewdata/NotificationViewData.java
+++ b/app/src/main/java/com/keylesspalace/tusky/viewdata/NotificationViewData.java
@@ -47,15 +47,13 @@ public abstract class NotificationViewData {
         private final Account account;
         @Nullable
         private final StatusViewData.Concrete statusViewData;
-        private final boolean isExpanded;
 
         public Concrete(Notification.Type type, String id, Account account,
-                        @Nullable StatusViewData.Concrete statusViewData, boolean isExpanded) {
+                        @Nullable StatusViewData.Concrete statusViewData) {
             this.type = type;
             this.id = id;
             this.account = account;
             this.statusViewData = statusViewData;
-            this.isExpanded = isExpanded;
         }
 
         public Notification.Type getType() {
@@ -75,10 +73,6 @@ public abstract class NotificationViewData {
             return statusViewData;
         }
 
-        public boolean isExpanded() {
-            return isExpanded;
-        }
-
         @Override
         public long getViewDataId() {
             return id.hashCode();
@@ -89,8 +83,7 @@ public abstract class NotificationViewData {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Concrete concrete = (Concrete) o;
-            return isExpanded == concrete.isExpanded &&
-                    type == concrete.type &&
+            return type == concrete.type &&
                     Objects.equals(id, concrete.id) &&
                     account.getId().equals(concrete.account.getId()) &&
                     (statusViewData == concrete.statusViewData ||
@@ -101,7 +94,7 @@ public abstract class NotificationViewData {
         @Override
         public int hashCode() {
 
-            return Objects.hash(type, id, account, statusViewData, isExpanded);
+            return Objects.hash(type, id, account, statusViewData);
         }
     }
 


### PR DESCRIPTION
closes https://github.com/tuskyapp/Tusky/issues/1753

I have no idea why `NotificationViewData` has an `expanded` attribute when its already in `StatusViewData`