### PR TITLE
fix toot sending twice when using a hardware keyboard

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -907,19 +907,20 @@ class ComposeActivity : BaseActivity(),
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
         Log.d(TAG, event.toString())
-        if (event.isCtrlPressed) {
-            if (keyCode == KeyEvent.KEYCODE_ENTER) {
-                // send toot by pressing CTRL + ENTER
-                this.onSendClicked()
+        if(event.action == KeyEvent.ACTION_DOWN) {
+            if (event.isCtrlPressed) {
+                if (keyCode == KeyEvent.KEYCODE_ENTER) {
+                    // send toot by pressing CTRL + ENTER
+                    this.onSendClicked()
+                    return true
+                }
+            }
+
+            if (keyCode == KeyEvent.KEYCODE_BACK) {
+                onBackPressed()
                 return true
             }
         }
-
-        if (keyCode == KeyEvent.KEYCODE_BACK) {
-            onBackPressed()
-            return true
-        }
-
         return super.onKeyDown(keyCode, event)
     }
 


### PR DESCRIPTION
closes #1648 

The problem is, that method is called twice for each keypress because we call it from a listener that listens to all events. I'm not 100% percent sure if that override would be necessary, but lets leave it in for now.