### PR TITLE
Fix tag highlighting in editor

### DIFF
--- a/app/src/test/java/com/keylesspalace/tusky/SpanUtilsTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/SpanUtilsTest.kt
@@ -93,6 +93,38 @@ class SpanUtilsTest {
         }
     }
 
+    @RunWith(Parameterized::class)
+    class HighlightingTestsForTag(private val text: String,
+                                private val expectedStartIndex: Int,
+                                private val expectedEndIndex: Int) {
+        companion object {
+            @Parameterized.Parameters(name = "{0}")
+            @JvmStatic
+            fun data(): Iterable<Any> {
+                return listOf(
+                        arrayOf("#test", 0, 5),
+                        arrayOf(" #AfterSpace", 1, 12),
+                        arrayOf("#BeforeSpace ", 0, 12),
+                        arrayOf("@#after_at", 1, 10),
+                        arrayOf("あいうえお#after_hiragana", 5, 20),
+                        arrayOf("##DoubleHash", 1, 12),
+                        arrayOf("###TripleHash", 2, 13)
+                )
+            }
+        }
+
+        @Test
+        fun matchExpectations() {
+            val inputSpannable = FakeSpannable(text)
+            highlightSpans(inputSpannable, 0xffffff)
+            val spans = inputSpannable.spans
+            Assert.assertEquals(1, spans.size)
+            val span = spans.first()
+            Assert.assertEquals(expectedStartIndex, span.start)
+            Assert.assertEquals(expectedEndIndex, span.end)
+        }
+    }
+
     class FakeSpannable(private val text: String) : Spannable {
         val spans = mutableListOf<BoundedSpan>()
 

--- a/app/src/test/java/com/keylesspalace/tusky/SpanUtilsTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/SpanUtilsTest.kt
@@ -10,11 +10,11 @@ import org.junit.runners.Parameterized
 class SpanUtilsTest {
     @Test
     fun matchesMixedSpans() {
-        val input = "one #one two: @two three : https://thr.ee/meh?foo=bar&wat=@at#hmm four #four five @five"
+        val input = "one #one two: @two three : https://thr.ee/meh?foo=bar&wat=@at#hmm four #four five @five ろく#six"
         val inputSpannable = FakeSpannable(input)
         highlightSpans(inputSpannable, 0xffffff)
         val spans = inputSpannable.spans
-        Assert.assertEquals(5, spans.size)
+        Assert.assertEquals(6, spans.size)
     }
 
     @Test


### PR DESCRIPTION
Tag highlighting in ComposeActivity is not same as Mastodon does, so I fixed it.
I was also tried to fix mentions, but I don't know how to match to `[:word:]` by code point...


## Screenshots

Before

![](https://media.odakyu.app/media_attachments/files/001/534/043/original/5d61a9fb8706d23f.png)


After

![](https://media.odakyu.app/media_attachments/files/001/534/044/original/d0068530ef5229c8.png)

Actual Behaviour

![](https://media.odakyu.app/media_attachments/files/001/534/045/original/633e67553fc53d9f.png)
