### PR TITLE
Fix RxJava UndeliverableException crashes

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.kt
@@ -18,6 +18,7 @@ package com.keylesspalace.tusky
 import android.app.Application
 import android.content.Context
 import android.content.res.Configuration
+import android.util.Log
 import androidx.emoji.text.EmojiCompat
 import androidx.preference.PreferenceManager
 import com.evernote.android.job.JobManager
@@ -29,6 +30,7 @@ import com.keylesspalace.tusky.util.ThemeUtils
 import com.uber.autodispose.AutoDisposePlugins
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
+import io.reactivex.plugins.RxJavaPlugins
 import org.conscrypt.Conscrypt
 import java.security.Security
 import javax.inject.Inject
@@ -64,6 +66,10 @@ class TuskyApplication : Application(), HasAndroidInjector {
         ThemeUtils.setAppNightMode(theme)
 
         JobManager.create(this).addJobCreator(notificationPullJobCreator)
+
+        RxJavaPlugins.setErrorHandler {
+            Log.w("RxJava", "undeliverable exception", it)
+        }
     }
 
     override fun attachBaseContext(base: Context) {


### PR DESCRIPTION
So I learned that these weird crashes can not only occur because of missing error handlers (I think we caught them all), but also when using e.g. `zipWith` on network errors 🙄 ...
Lets fix them with a global error handler

https://medium.com/@bherbst/the-rxjava2-default-error-handler-e50e0cab6f9f