### PR TITLE
Reduce horizontal scroll sensibility of view pagers

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -173,6 +173,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
         val uswSwipeForTabs = PreferenceManager.getDefaultSharedPreferences(this)
                 .getBoolean("enableSwipeForTabs", true)
         viewPager.isUserInputEnabled = uswSwipeForTabs
+        if (uswSwipeForTabs) viewPager.reduceHorizontalScrollSensibility()
 
         tabLayout.addOnTabSelectedListener(object : OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
@@ -28,6 +28,7 @@ import com.keylesspalace.tusky.BottomSheetActivity
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.components.search.adapter.SearchPagerAdapter
 import com.keylesspalace.tusky.di.ViewModelFactory
+import com.keylesspalace.tusky.util.reduceHorizontalScrollSensibility
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
 import kotlinx.android.synthetic.main.activity_search.*
@@ -57,6 +58,7 @@ class SearchActivity : BottomSheetActivity(), HasAndroidInjector {
 
     private fun setupPages() {
         pages.adapter = SearchPagerAdapter(this)
+        pages.reduceHorizontalScrollSensibility()
 
         TabLayoutMediator(tabs, pages) {
             tab, position ->

--- a/app/src/main/java/com/keylesspalace/tusky/util/ViewPager2Ext.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ViewPager2Ext.kt
@@ -1,0 +1,42 @@
+package com.keylesspalace.tusky.util
+
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.ViewPager2
+import com.keylesspalace.tusky.BuildConfig
+import java.lang.reflect.Field
+import kotlin.reflect.KClass
+
+private const val SLOP_REDUCE_FACTOR = 4
+
+/**
+ * View Pager does not provide an API to manage the scroll sensibility despite possible…
+ * Through reflection we can manage to tune it and improve our UX.
+ */
+fun ViewPager2.reduceHorizontalScrollSensibility() {
+    try {
+        // get the reflection fields
+        val recyclerField: Field = ViewPager2::class["mRecyclerView"].accessible()
+        val slopField: Field = RecyclerView::class["mTouchSlop"].accessible()
+
+        // get the recycler property (1st layer) and the slop property (2nd layer)
+        val recycler = recyclerField.get(this) as? RecyclerView ?: return
+        val slop = slopField.get(recycler) as? Int? ?: return
+
+        // changing the slope by a scale multiplier is the best way to prevent different
+        // behaviour between different screen resolutions
+        slopField.set(recycler, slop * SLOP_REDUCE_FACTOR)
+    } catch (ignored: Throwable) {
+        if (BuildConfig.DEBUG) {
+            ignored.printStackTrace()
+        }
+    }
+}
+
+private fun Field.accessible(): Field {
+    this.isAccessible = true
+    return this
+}
+
+private inline operator fun <reified T : Any> KClass<T>.get(name: String): Field {
+    return T::class.java.getDeclaredField(name)
+}


### PR DESCRIPTION
I have been using the app for some days, and I did notice a strange behaviour when you are scrolling, the horizontal scroll (ViewPager scroll) is far more sensible than the vertical scrolls (RecyclerView scroll).


A lot of times when I try to scroll down (finger from bottom to up) I did trigger the horizontal scroll and I get a change of tab instead of trigger the vertical scroll.


Android has notorious issues with the nested scroll and the API those views provide don't help much to solve the matter, but it is possible to manage the scroll sensibility, though it has a cost, it requires a piece of reflection because the relevant property is part of the internals of the recycler view.


So I'm opening this MR to the consideration of the maintainers, so you can see the UX difference and judge if it worth to adopt this reflection based code or not. I know Android apps usually don't want reflection for two main reasons, 1 performance and 2 unpredictable behaviour, so please consider the following.


About performance, in this specific case, the reflection is triggered only once at the activity creation stage, so it hits the performance but it is not a level of loss that is noticeable, in my personal experience I could not notice any difference.


About the predictability, the reflection is being made on 2 classes that are bundled in the App, the ViewPager2 and RecyclerView so we know the behaviour will be the same across different android devices and android version, but we are not in control of library update that changes those classes internals, anyway in case of update that changes the internals, at least this code will just not have any effect anymore it will stop to work but will not crash.


The last but not least, check these two videos, the blue app is from play store and green version is my build with the reflection changes. Notice that scrolls at 90º degree and 180º degree has the same behaviour on both, the difference is notable on scrolls between the 120º and 150º degrees because the current app triggers the tab switch and with my changes, it triggers the vertical list movement.


So please, test it on your own, and judge if it is worth it, In my humble opinion, it is a tremendous UX improvement if it were not so I would not be opening this MR using reflection :)

The Home:
https://vimeo.com/421289681

The search:
https://vimeo.com/421289730