### PR TITLE
NotificationsFragment: show appbar if there is no notifications

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -288,7 +288,7 @@ public class NotificationsFragment extends SFragment implements
     private void updateFilterVisibility() {
         CoordinatorLayout.LayoutParams params =
                 (CoordinatorLayout.LayoutParams) swipeRefreshLayout.getLayoutParams();
-        if (showNotificationsFilter && !showingError && !notifications.isEmpty()) {
+        if (showNotificationsFilter && !showingError) {
             appBarOptions.setExpanded(true, false);
             appBarOptions.setVisibility(View.VISIBLE);
             //Set content behaviour to hide filter on scroll


### PR DESCRIPTION
Thus, if user accidentally will filter everything, they will be able to return to initial state.

Although, I'm wondering, does "Clear" button must be shown or greyed out as well if it's useless?