### PR TITLE
Move the "more" button towards the edge

### DIFF
--- a/app/src/main/res/layout/item_status.xml
+++ b/app/src/main/res/layout/item_status.xml
@@ -554,7 +554,6 @@
         style="@style/TuskyImageButton"
         android:layout_width="24dp"
         android:layout_height="30dp"
-        android:layout_marginEnd="8dp"
         android:contentDescription="@string/action_more"
         android:importantForAccessibility="no"
         android:padding="4dp"


### PR DESCRIPTION
having space on the right side causes me to miss the button
and select the whole toot instead

fixes #1813 

Signed-off-by: Guntbert Reiter <guntbert@gmx.at>