### PR TITLE
Prototype of bottom navigation with collabible appbar

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -13,6 +13,7 @@
         tools:context="com.keylesspalace.tusky.MainActivity">
 
         <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:elevation="@dimen/actionbar_elevation"
@@ -22,17 +23,8 @@
                 android:id="@+id/mainToolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:contentInsetStartWithNavigation="0dp">
-
-                <com.google.android.material.tabs.TabLayout
-                    android:id="@+id/tabLayout"
-                    style="@style/TuskyTabAppearance"
-                    android:layout_width="match_parent"
-                    android:layout_height="?attr/actionBarSize"
-                    app:tabGravity="fill"
-                    app:tabMaxWidth="0dp"
-                    app:tabMode="fixed"
-                    app:tabUnboundedRipple="false" />
+                app:contentInsetStartWithNavigation="0dp"
+                app:layout_scrollFlags="scroll|enterAlways">
 
             </androidx.appcompat.widget.Toolbar>
 
@@ -42,21 +34,30 @@
             android:id="@+id/viewPager"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_below="@id/tabLayout"
+            android:layout_below="@id/appbar"
             android:background="?attr/windowBackgroundColor"
             app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
+        <!-- Positioned with hacks for now -->
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/composeButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="16dp"
+            android:layout_gravity="bottom|end"
+            android:layout_marginLeft="16dp"
+            android:layout_marginRight="16dp"
+            android:layout_marginBottom="68dp"
             android:contentDescription="@string/action_compose"
-            app:layout_anchor="@id/viewPager"
-            app:layout_anchorGravity="bottom|end"
             app:srcCompat="@drawable/ic_create_24dp" />
 
         <include layout="@layout/item_status_bottom_sheet" />
+
+        <com.google.android.material.bottomnavigation.BottomNavigationView
+            android:id="@+id/bottomNav"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            app:labelVisibilityMode="unlabeled" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 


### PR DESCRIPTION
Like proposed [here](https://github.com/tuskyapp/Tusky/pull/1808#issuecomment-634256507) it's a prototype of moving navigation to the bottom, having full app bar and moving some of the functions we need there.
The goal was to get it to work as quick as possible so there are quite a few shortcuts taken.
1. Refresh in menu doesn't work currently
2. Appbar could be moved inside the fragment
3. With bottom nav I used `order` to distinguish tabs which might be brittle.
4. I hardcoded FAB margin
5. Search icon is incorrect
6. Notifications fragment doesn't need its own `CoordinatorLayout` anymore. Bar with filter/clear was not removed correctly, it just accidentally disappeared.

I would appreciate help in some places (like how to position bottom nav/fab and with search icon) but the best thing you can do is to try it out and tell if you agree with how it works or not.