### PR TITLE
Fix settings default values for preferences

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/settings/SettingsDSL.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/settings/SettingsDSL.kt
@@ -12,22 +12,22 @@ class PreferenceParent(
 
 inline fun PreferenceParent.preference(builder: Preference.() -> Unit): Preference {
     val pref = Preference(context)
-    addPref(pref)
     builder(pref)
+    addPref(pref)
     return pref
 }
 
 inline fun PreferenceParent.listPreference(builder: ListPreference.() -> Unit): ListPreference {
     val pref = ListPreference(context)
-    addPref(pref)
     builder(pref)
+    addPref(pref)
     return pref
 }
 
 inline fun PreferenceParent.emojiPreference(builder: EmojiPreference.() -> Unit): EmojiPreference {
     val pref = EmojiPreference(context)
-    addPref(pref)
     builder(pref)
+    addPref(pref)
     return pref
 }
 
@@ -35,8 +35,8 @@ inline fun PreferenceParent.switchPreference(
         builder: SwitchPreference.() -> Unit
 ): SwitchPreference {
     val pref = SwitchPreference(context)
-    addPref(pref)
     builder(pref)
+    addPref(pref)
     return pref
 }
 
@@ -44,8 +44,8 @@ inline fun PreferenceParent.editTextPreference(
         builder: EditTextPreference.() -> Unit
 ): EditTextPreference {
     val pref = EditTextPreference(context)
-    addPref(pref)
     builder(pref)
+    addPref(pref)
     return pref
 }
 
@@ -53,8 +53,8 @@ inline fun PreferenceParent.checkBoxPreference(
         builder: CheckBoxPreference.() -> Unit
 ): CheckBoxPreference {
     val pref = CheckBoxPreference(context)
-    addPref(pref)
     builder(pref)
+    addPref(pref)
     return pref
 }
 


### PR DESCRIPTION
At some point settings DSL was refactored to first add a preference and
then run the builder. We shouldn't add a preference to the hierarchy
without setting a key for the preference first because preference gets
it's default value in `onAttachedToHierarchy()` and if the key is not set
then no default value will be set either.

This commit changes the order to execute builder (and set the key)
first and and preference to the point later.

thanks @MasterGroosha for the report