### PR TITLE
Make account views clickable instead of avatar only

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/BlocksAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/BlocksAdapter.java
@@ -103,7 +103,7 @@ public class BlocksAdapter extends AccountAdapter {
                     listener.onBlock(false, id, position);
                 }
             });
-            avatar.setOnClickListener(v -> listener.onViewAccount(id));
+            itemView.setOnClickListener(v -> listener.onViewAccount(id));
         }
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/FollowRequestViewHolder.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/FollowRequestViewHolder.kt
@@ -44,6 +44,6 @@ internal class FollowRequestViewHolder(itemView: View, private val showHeader: B
                 listener.onRespondToFollowRequest(false, id, position)
             }
         }
-        itemView.avatar.setOnClickListener { listener.onViewAccount(id) }
+        itemView.setOnClickListener { listener.onViewAccount(id) }
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/MutesAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/MutesAdapter.java
@@ -83,7 +83,7 @@ public class MutesAdapter extends AccountAdapter {
 
         void setupActionListener(final AccountActionListener listener) {
             unmute.setOnClickListener(v -> listener.onMute(false, id, getAdapterPosition()));
-            avatar.setOnClickListener(v -> listener.onViewAccount(id));
+            itemView.setOnClickListener(v -> listener.onViewAccount(id));
         }
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -350,7 +350,7 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
         }
 
         void setupButtons(final NotificationActionListener listener, final String accountId) {
-            avatar.setOnClickListener(v -> listener.onViewAccount(accountId));
+            itemView.setOnClickListener(v -> listener.onViewAccount(accountId));
         }
     }
 


### PR DESCRIPTION
Affects:
- New follower request and New follower notifications
- Accounts in Blocked users and Muted users pages

Action buttons, when present, still work.