### PR TITLE
Implement optional notifications muting for account muting

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
@@ -58,6 +58,7 @@ import com.keylesspalace.tusky.interfaces.LinkListener
 import com.keylesspalace.tusky.interfaces.ReselectableFragment
 import com.keylesspalace.tusky.pager.AccountPagerAdapter
 import com.keylesspalace.tusky.util.*
+import com.keylesspalace.tusky.view.showMuteAccountDialog
 import com.keylesspalace.tusky.viewmodel.AccountViewModel
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
@@ -382,7 +383,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
         invalidateOptionsMenu()
 
         accountMuteButton.setOnClickListener {
-            viewModel.changeMuteState()
+            viewModel.unmuteAccount()
             updateMuteButton()
         }
     }
@@ -703,13 +704,15 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
 
     private fun toggleMute() {
         if (viewModel.relationshipData.value?.data?.muting != true) {
-            AlertDialog.Builder(this)
-                    .setMessage(getString(R.string.dialog_mute_warning, loadedAccount?.username))
-                    .setPositiveButton(android.R.string.ok) { _, _ -> viewModel.changeMuteState() }
-                    .setNegativeButton(android.R.string.cancel, null)
-                    .show()
+            loadedAccount?.let {
+                showMuteAccountDialog(
+                    this,
+                    it.username,
+                    { notifications -> viewModel.muteAccount(notifications) }
+                )
+            }
         } else {
-            viewModel.changeMuteState()
+            viewModel.unmuteAccount()
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/MutesAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/MutesAdapter.java
@@ -8,6 +8,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.view.ViewCompat;
 import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -17,10 +18,14 @@ import com.keylesspalace.tusky.interfaces.AccountActionListener;
 import com.keylesspalace.tusky.util.CustomEmojiHelper;
 import com.keylesspalace.tusky.util.ImageLoadingHelper;
 
+import java.util.HashMap;
+
 public class MutesAdapter extends AccountAdapter {
+    private HashMap<String, Boolean> mutingNotificationsMap;
 
     public MutesAdapter(AccountActionListener accountActionListener) {
         super(accountActionListener);
+        mutingNotificationsMap = new HashMap<String, Boolean>();
     }
 
     @NonNull
@@ -45,19 +50,31 @@ public class MutesAdapter extends AccountAdapter {
     public void onBindViewHolder(@NonNull RecyclerView.ViewHolder viewHolder, int position) {
         if (getItemViewType(position) == VIEW_TYPE_ACCOUNT) {
             MutedUserViewHolder holder = (MutedUserViewHolder) viewHolder;
-            holder.setupWithAccount(accountList.get(position));
+            Account account = accountList.get(position);
+            holder.setupWithAccount(account, mutingNotificationsMap.get(account.getId()));
             holder.setupActionListener(accountActionListener);
         }
     }
 
+    public void updateMutingNotifications(String id, boolean mutingNotifications, int position) {
+        mutingNotificationsMap.put(id, mutingNotifications);
+        notifyItemChanged(position);
+    }
+
+    public void updateMutingNotificationsMap(HashMap<String, Boolean> newMutingNotificationsMap) {
+        mutingNotificationsMap.putAll(newMutingNotificationsMap);
+        notifyDataSetChanged();
+    }
 
     static class MutedUserViewHolder extends RecyclerView.ViewHolder {
         private ImageView avatar;
         private TextView username;
         private TextView displayName;
         private ImageButton unmute;
+        private ImageButton muteNotifications;
         private String id;
         private boolean animateAvatar;
+        private boolean notifications;
 
         MutedUserViewHolder(View itemView) {
             super(itemView);
@@ -65,11 +82,12 @@ public class MutesAdapter extends AccountAdapter {
             username = itemView.findViewById(R.id.muted_user_username);
             displayName = itemView.findViewById(R.id.muted_user_display_name);
             unmute = itemView.findViewById(R.id.muted_user_unmute);
+            muteNotifications = itemView.findViewById(R.id.muted_user_mute_notifications);
             animateAvatar = PreferenceManager.getDefaultSharedPreferences(itemView.getContext())
                     .getBoolean("animateGifAvatars", false);
         }
 
-        void setupWithAccount(Account account) {
+        void setupWithAccount(Account account, Boolean mutingNotifications) {
             id = account.getId();
             CharSequence emojifiedName = CustomEmojiHelper.emojify(account.getName(), account.getEmojis(), displayName);
             displayName.setText(emojifiedName);
@@ -79,10 +97,38 @@ public class MutesAdapter extends AccountAdapter {
             int avatarRadius = avatar.getContext().getResources()
                     .getDimensionPixelSize(R.dimen.avatar_radius_48dp);
             ImageLoadingHelper.loadAvatar(account.getAvatar(), avatar, avatarRadius, animateAvatar);
+
+            String unmuteString = unmute.getContext().getString(R.string.action_unmute_desc, formattedUsername);
+            unmute.setContentDescription(unmuteString);
+            ViewCompat.setTooltipText(unmute, unmuteString);
+
+            if (mutingNotifications == null) {
+                muteNotifications.setEnabled(false);
+                notifications = true;
+            } else {
+                muteNotifications.setEnabled(true);
+                notifications = mutingNotifications;
+            }
+
+            if (notifications) {
+                muteNotifications.setImageResource(R.drawable.ic_notifications_24dp);
+                String unmuteNotificationsString = muteNotifications.getContext()
+                    .getString(R.string.action_unmute_notifications_desc, formattedUsername);
+                muteNotifications.setContentDescription(unmuteNotificationsString);
+                ViewCompat.setTooltipText(muteNotifications, unmuteNotificationsString);
+            } else {
+                muteNotifications.setImageResource(R.drawable.ic_notifications_off_24dp);
+                String muteNotificationsString = muteNotifications.getContext()
+                    .getString(R.string.action_mute_notifications_desc, formattedUsername);
+                muteNotifications.setContentDescription(muteNotificationsString);
+                ViewCompat.setTooltipText(muteNotifications, muteNotificationsString);
+            }
         }
 
         void setupActionListener(final AccountActionListener listener) {
-            unmute.setOnClickListener(v -> listener.onMute(false, id, getAdapterPosition()));
+            unmute.setOnClickListener(v -> listener.onMute(false, id, getAdapterPosition(), false));
+            muteNotifications.setOnClickListener(
+                v -> listener.onMute(true, id, getAdapterPosition(), !notifications));
             itemView.setOnClickListener(v -> listener.onViewAccount(id));
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
@@ -193,8 +193,8 @@ class SearchViewModel @Inject constructor(
         return accountManager.getAllAccountsOrderedByActive()
     }
 
-    fun muteAccount(accountId: String) {
-        timelineCases.mute(accountId)
+    fun muteAccount(accountId: String, notifications: Boolean) {
+        timelineCases.mute(accountId, notifications)
     }
 
     fun pinAccount(status: Status, isPin: Boolean) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchStatusesFragment.kt
@@ -26,6 +26,8 @@ import android.net.Uri
 import android.os.Environment
 import android.util.Log
 import android.view.View
+import android.widget.CheckBox
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.PopupMenu
@@ -55,6 +57,7 @@ import com.keylesspalace.tusky.interfaces.StatusActionListener
 import com.keylesspalace.tusky.util.CardViewMode
 import com.keylesspalace.tusky.util.NetworkState
 import com.keylesspalace.tusky.util.StatusDisplayOptions
+import com.keylesspalace.tusky.view.showMuteAccountDialog
 import com.keylesspalace.tusky.viewdata.AttachmentViewData
 import com.keylesspalace.tusky.viewdata.StatusViewData
 import com.uber.autodispose.android.lifecycle.AndroidLifecycleScopeProvider.from
@@ -371,11 +374,11 @@ class SearchStatusesFragment : SearchFragment<Pair<Status, StatusViewData.Concre
     }
 
     private fun onMute(accountId: String, accountUsername: String) {
-        AlertDialog.Builder(requireContext())
-                .setMessage(getString(R.string.dialog_mute_warning, accountUsername))
-                .setPositiveButton(android.R.string.ok) { _, _ -> viewModel.muteAccount(accountId) }
-                .setNegativeButton(android.R.string.cancel, null)
-                .show()
+        showMuteAccountDialog(
+            this.requireActivity(),
+            accountUsername,
+            { notifications -> viewModel.muteAccount(accountId, notifications) }
+        )
     }
 
     private fun accountIsInMentions(account: AccountEntity?, mentions: Array<Mention>): Boolean {

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Relationship.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Relationship.kt
@@ -23,6 +23,7 @@ data class Relationship (
     @SerializedName("followed_by") val followedBy: Boolean,
     val blocking: Boolean,
     val muting: Boolean,
+    @SerializedName("muting_notifications") val mutingNotifications: Boolean,
     val requested: Boolean,
     @SerializedName("showing_reblogs") val showingReblogs: Boolean,
     @SerializedName("domain_blocking") val blockingDomain: Boolean

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -823,7 +823,7 @@ public class NotificationsFragment extends SFragment implements
     }
 
     @Override
-    public void onMute(boolean mute, String id, int position) {
+    public void onMute(boolean mute, String id, int position, boolean notifications) {
         // No muting from notifications yet
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
@@ -20,6 +20,7 @@ import android.app.DownloadManager;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -29,6 +30,8 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.CheckBox;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -60,6 +63,7 @@ import com.keylesspalace.tusky.entity.PollOption;
 import com.keylesspalace.tusky.entity.Status;
 import com.keylesspalace.tusky.network.MastodonApi;
 import com.keylesspalace.tusky.network.TimelineCases;
+import com.keylesspalace.tusky.view.MuteAccountDialog;
 import com.keylesspalace.tusky.viewdata.AttachmentViewData;
 
 import java.util.ArrayList;
@@ -70,6 +74,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.inject.Inject;
+
+import kotlin.Unit;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import retrofit2.Call;
@@ -331,11 +337,14 @@ public abstract class SFragment extends BaseFragment implements Injectable {
     }
 
     private void onMute(String accountId, String accountUsername) {
-        new AlertDialog.Builder(requireContext())
-                .setMessage(getString(R.string.dialog_mute_warning, accountUsername))
-                .setPositiveButton(android.R.string.ok, (__, ___) -> timelineCases.mute(accountId))
-                .setNegativeButton(android.R.string.cancel, null)
-                .show();
+        MuteAccountDialog.showMuteAccountDialog(
+            this.getActivity(),
+            accountUsername,
+            (notifications) -> {
+                timelineCases.mute(accountId, notifications);
+                return Unit.INSTANCE;
+            }
+        );
     }
 
     private void onBlock(String accountId, String accountUsername) {

--- a/app/src/main/java/com/keylesspalace/tusky/interfaces/AccountActionListener.java
+++ b/app/src/main/java/com/keylesspalace/tusky/interfaces/AccountActionListener.java
@@ -17,7 +17,7 @@ package com.keylesspalace.tusky.interfaces;
 
 public interface AccountActionListener {
     void onViewAccount(String id);
-    void onMute(final boolean mute, final String id, final int position);
+    void onMute(final boolean mute, final String id, final int position, final boolean notifications);
     void onBlock(final boolean block, final String id, final int position);
     void onRespondToFollowRequest(final boolean accept, final String id, final int position);
 }

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -317,9 +317,11 @@ interface MastodonApi {
             @Path("id") accountId: String
     ): Call<Relationship>
 
+    @FormUrlEncoded
     @POST("api/v1/accounts/{id}/mute")
     fun muteAccount(
-            @Path("id") accountId: String
+            @Path("id") accountId: String,
+            @Field("notifications") notifications: Boolean
     ): Call<Relationship>
 
     @POST("api/v1/accounts/{id}/unmute")

--- a/app/src/main/java/com/keylesspalace/tusky/network/TimelineCases.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/TimelineCases.kt
@@ -36,7 +36,7 @@ interface TimelineCases {
     fun reblog(status: Status, reblog: Boolean): Single<Status>
     fun favourite(status: Status, favourite: Boolean): Single<Status>
     fun bookmark(status: Status, bookmark: Boolean): Single<Status>
-    fun mute(id: String)
+    fun mute(id: String, notifications: Boolean)
     fun block(id: String)
     fun delete(id: String): Single<DeletedStatus>
     fun pin(status: Status, pin: Boolean)
@@ -107,8 +107,8 @@ class TimelineCasesImpl(
         }
     }
 
-    override fun mute(id: String) {
-        val call = mastodonApi.muteAccount(id)
+    override fun mute(id: String, notifications: Boolean) {
+        val call = mastodonApi.muteAccount(id, notifications)
         call.enqueue(object : Callback<Relationship> {
             override fun onResponse(call: Call<Relationship>, response: Response<Relationship>) {}
 

--- a/app/src/main/java/com/keylesspalace/tusky/view/MuteAccountDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/view/MuteAccountDialog.kt
@@ -1,0 +1,27 @@
+@file:JvmName("MuteAccountDialog")
+
+package com.keylesspalace.tusky.view
+
+import android.app.Activity
+import android.widget.CheckBox
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import com.keylesspalace.tusky.R
+
+fun showMuteAccountDialog(
+    activity: Activity,
+    accountUsername: String,
+    onOk: (notifications: Boolean) -> Unit
+) {
+    val view = activity.layoutInflater.inflate(R.layout.dialog_mute_account, null)
+    (view.findViewById(R.id.warning) as TextView).text =
+        activity.getString(R.string.dialog_mute_warning, accountUsername)
+    val checkbox: CheckBox = view.findViewById(R.id.checkbox)
+    checkbox.setChecked(true)
+
+    AlertDialog.Builder(activity)
+            .setView(view)
+            .setPositiveButton(android.R.string.ok) { _, _ -> onOk(checkbox.isChecked) }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+}

--- a/app/src/main/java/com/keylesspalace/tusky/viewmodel/AccountViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/viewmodel/AccountViewModel.kt
@@ -148,12 +148,12 @@ class AccountViewModel @Inject constructor(
         }
     }
 
-    fun changeMuteState() {
-        if (relationshipData.value?.data?.muting == true) {
-            changeRelationship(RelationShipAction.UNMUTE)
-        } else {
-            changeRelationship(RelationShipAction.MUTE)
-        }
+    fun muteAccount(notifications: Boolean) {
+        changeRelationship(RelationShipAction.MUTE, notifications)
+    }
+
+    fun unmuteAccount() {
+        changeRelationship(RelationShipAction.UNMUTE)
     }
 
     fun blockDomain(instance: String) {
@@ -203,7 +203,10 @@ class AccountViewModel @Inject constructor(
         }
     }
 
-    private fun changeRelationship(relationshipAction: RelationShipAction, showReblogs: Boolean = true) {
+    /**
+     * @param parameter showReblogs if RelationShipAction.FOLLOW, notifications if MUTE
+     */
+    private fun changeRelationship(relationshipAction: RelationShipAction, parameter: Boolean? = null) {
         val relation = relationshipData.value?.data
         val account = accountData.value?.data
 
@@ -254,11 +257,11 @@ class AccountViewModel @Inject constructor(
         }
 
         val call = when (relationshipAction) {
-            RelationShipAction.FOLLOW -> mastodonApi.followAccount(accountId, showReblogs)
+            RelationShipAction.FOLLOW -> mastodonApi.followAccount(accountId, parameter ?: true)
             RelationShipAction.UNFOLLOW -> mastodonApi.unfollowAccount(accountId)
             RelationShipAction.BLOCK -> mastodonApi.blockAccount(accountId)
             RelationShipAction.UNBLOCK -> mastodonApi.unblockAccount(accountId)
-            RelationShipAction.MUTE -> mastodonApi.muteAccount(accountId)
+            RelationShipAction.MUTE -> mastodonApi.muteAccount(accountId, parameter ?: true)
             RelationShipAction.UNMUTE -> mastodonApi.unmuteAccount(accountId)
         }
 

--- a/app/src/main/res/drawable/ic_notifications_off_24dp.xml
+++ b/app/src/main/res/drawable/ic_notifications_off_24dp.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:pathData="M0 0h24v24H0z" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M20 18.69L7.84 6.14 5.27 3.49 4 4.76l2.8 2.8v0.01c-0.52 0.99 -0.8 2.16-0.8 3.42v5l-2 2v1h13.73l2 2L21 19.72l-1-1.03zM12 22c1.11 0 2-0.89 2-2h-4c0 1.11 0.89 2 2 2zm6-7.32V11c0-3.08-1.64-5.64-4.5-6.32V4c0-0.83-0.67-1.5-1.5-1.5s-1.5 0.67 -1.5 1.5v0.68c-0.15 0.03 -0.29 0.08 -0.42 0.12 -0.1 0.03 -0.2 0.07 -0.3 0.11 h-0.01c-0.01 0-0.01 0-0.02 0.01 -0.23 0.09 -0.46 0.2 -0.68 0.31 0 0-0.01 0-0.01 0.01 L18 14.68z" />
+</vector>

--- a/app/src/main/res/layout/dialog_mute_account.xml
+++ b/app/src/main/res/layout/dialog_mute_account.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_height="match_parent"
+              android:layout_width="match_parent"
+              android:orientation="vertical"
+              android:paddingTop="20dp"
+              android:paddingLeft="20dp"
+              android:paddingRight="20dp">
+
+    <TextView android:id="@+id/warning"
+              android:layout_height="wrap_content"
+              android:layout_width="wrap_content"
+              android:paddingBottom="20dp"
+              tools:text="@string/dialog_mute_warning"/>
+
+    <CheckBox android:id="@+id/checkbox"
+              android:layout_height="wrap_content"
+              android:layout_width="wrap_content"
+              android:textColor="@color/textColorTertiary"
+              app:buttonTint="@color/compound_button_color"
+              android:text="@string/dialog_mute_hide_notifications"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_muted_user.xml
+++ b/app/src/main/res/layout/item_muted_user.xml
@@ -22,14 +22,26 @@
         style="@style/TuskyImageButton"
         android:layout_width="32dp"
         android:layout_height="32dp"
+        android:layout_toStartOf="@id/muted_user_mute_notifications"
+        android:layout_centerVertical="true"
+        android:layout_gravity="center_vertical"
+        android:layout_marginStart="12dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:padding="4dp"
+        app:srcCompat="@drawable/ic_unmute_24dp" />
+
+    <ImageButton
+        android:id="@+id/muted_user_mute_notifications"
+        style="@style/TuskyImageButton"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
         android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
         android:layout_gravity="center_vertical"
         android:layout_marginStart="12dp"
         android:background="?attr/selectableItemBackgroundBorderless"
-        android:contentDescription="@string/action_unmute"
         android:padding="4dp"
-        app:srcCompat="@drawable/ic_unmute_24dp" />
+        app:srcCompat="@drawable/ic_notifications_24dp" />
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,9 @@
     <string name="action_share">Share</string>
     <string name="action_mute">Mute</string>
     <string name="action_unmute">Unmute</string>
+    <string name="action_unmute_desc">Unmute %s</string>
+    <string name="action_unmute_notifications_desc">Unmute notifications from %s</string>
+    <string name="action_mute_notifications_desc">Mute notifications from %s</string>
     <string name="action_mute_domain">Mute %s</string>
     <string name="action_unmute_domain">Unmute %s</string>
     <string name="action_mute_conversation">Mute conversation</string>
@@ -199,6 +202,7 @@
     <string name="mute_domain_warning_dialog_ok">Hide entire domain</string>
     <string name="dialog_block_warning">Block @%s?</string>
     <string name="dialog_mute_warning">Mute @%s?</string>
+    <string name="dialog_mute_hide_notifications">Hide notifications</string>
 
     <string name="visibility_public">Public: Post to public timelines</string>
     <string name="visibility_unlisted">Unlisted: Do not show in public timelines</string>


### PR DESCRIPTION
fix #484

![Screenshot_20200725-222304_Tusky](https://user-images.githubusercontent.com/2446451/88465769-c0fe6c80-cec5-11ea-8813-05560b694539.png)
![Screenshot_20200720-194632_Tusky](https://user-images.githubusercontent.com/2446451/87969319-30d5b700-cac2-11ea-9f65-152c8ddaad45.png)

Basically, what’s left to do is to find a way to retrieve the `mutingNotifications` state inside the Muted users page (`app/src/main/java/com/keylesspalace/tusky/adapter/MutesAdapter.java`). Since I don’t have a lot of experience with the Tusky codebase, I’m stuck at the moment.