### PR TITLE
add Thai to the in-app language selector

### DIFF
--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -63,6 +63,7 @@
         <item>বাংলা</item>
         <item>فارسی</item>
         <item>தமிழ்</item>
+        <item>ภาษาไทย</item>
         <item>한국어</item>
         <item>中文(台灣)</item>
         <item>中文(新加坡)</item>
@@ -101,6 +102,7 @@
         <item>bn-in</item>
         <item>fa</item>
         <item>ta</item>
+        <item>th</item>
         <item>ko</item>
         <item>zh-TW</item>
         <item>zh-SG</item>


### PR DESCRIPTION
We also have Ukrainian and Hindi as new languages, but they are translated <50% so I decided to not add them to the language selector