### PR TITLE
upgrade SwipeRefreshLayout to 1.1.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.2.0-rc01"
     implementation "androidx.fragment:fragment-ktx:1.2.5"
     implementation "androidx.browser:browser:1.2.0"
-    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.exifinterface:exifinterface:1.2.0"
     implementation "androidx.cardview:cardview:1.0.0"

--- a/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
@@ -353,8 +353,6 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
             swipeToRefreshLayout.isRefreshing = isRefreshing == true
         })
         swipeToRefreshLayout.setColorSchemeResources(R.color.tusky_blue)
-        swipeToRefreshLayout.setProgressBackgroundColorSchemeColor(ThemeUtils.getColor(this,
-                android.R.attr.colorBackground))
     }
 
     private fun onAccountChanged(account: Account?) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
@@ -102,7 +102,6 @@ class ConversationsFragment : SFragment(), StatusActionListener, Injectable, Res
             viewModel.refresh()
         }
         swipeRefreshLayout.setColorSchemeResources(R.color.tusky_blue)
-        swipeRefreshLayout.setProgressBackgroundColorSchemeColor(ThemeUtils.getColor(swipeRefreshLayout.context, android.R.attr.colorBackground))
     }
 
     private fun onTopLoaded() {

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportStatusesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/fragments/ReportStatusesFragment.kt
@@ -101,7 +101,6 @@ class ReportStatusesFragment : Fragment(), Injectable, AdapterHandler {
 
     private fun setupSwipeRefreshLayout() {
         swipeRefreshLayout.setColorSchemeResources(R.color.tusky_blue)
-        swipeRefreshLayout.setProgressBackgroundColorSchemeColor(ThemeUtils.getColor(swipeRefreshLayout.context, android.R.attr.colorBackground))
 
         swipeRefreshLayout.setOnRefreshListener {
             snackbarErrorRetry?.dismiss()

--- a/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledTootActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledTootActivity.kt
@@ -59,8 +59,6 @@ class ScheduledTootActivity : BaseActivity(), ScheduledTootActionListener, Injec
 
         swipeRefreshLayout.setOnRefreshListener(this::refreshStatuses)
         swipeRefreshLayout.setColorSchemeResources(R.color.tusky_blue)
-        swipeRefreshLayout.setProgressBackgroundColorSchemeColor(
-                ThemeUtils.getColor(this, android.R.attr.colorBackground))
 
         scheduledTootList.setHasFixedSize(true)
         scheduledTootList.layoutManager = LinearLayoutManager(this)

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchFragment.kt
@@ -58,9 +58,6 @@ abstract class SearchFragment<T> : Fragment(),
     private fun setupSwipeRefreshLayout() {
         swipeRefreshLayout.setOnRefreshListener(this)
         swipeRefreshLayout.setColorSchemeResources(R.color.tusky_blue)
-        swipeRefreshLayout.setProgressBackgroundColorSchemeColor(
-                ThemeUtils.getColor(swipeRefreshLayout.context, android.R.attr.colorBackground)
-        )
     }
 
     private fun subscribeObservables() {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/AccountMediaFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/AccountMediaFragment.kt
@@ -188,7 +188,6 @@ class AccountMediaFragment : BaseFragment(), RefreshableFragment, Injectable {
                 refresh()
             }
             swipeRefreshLayout.setColorSchemeResources(R.color.tusky_blue)
-            swipeRefreshLayout.setProgressBackgroundColorSchemeColor(ThemeUtils.getColor(view.context, android.R.attr.colorBackground))
         }
         statusView.visibility = View.GONE
 

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -223,7 +223,6 @@ public class NotificationsFragment extends SFragment implements
 
         swipeRefreshLayout.setOnRefreshListener(this);
         swipeRefreshLayout.setColorSchemeResources(R.color.tusky_blue);
-        swipeRefreshLayout.setProgressBackgroundColorSchemeColor(ThemeUtils.getColor(context, android.R.attr.colorBackground));
 
         loadNotificationsFilter();
 

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -421,11 +421,8 @@ public class TimelineFragment extends SFragment implements
     private void setupSwipeRefreshLayout() {
         swipeRefreshLayout.setEnabled(isSwipeToRefreshEnabled);
         if (isSwipeToRefreshEnabled) {
-            Context context = swipeRefreshLayout.getContext();
             swipeRefreshLayout.setOnRefreshListener(this);
             swipeRefreshLayout.setColorSchemeResources(R.color.tusky_blue);
-            swipeRefreshLayout.setProgressBackgroundColorSchemeColor(ThemeUtils.getColor(context,
-                    android.R.attr.colorBackground));
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -150,8 +150,6 @@ public final class ViewThreadFragment extends SFragment implements
         swipeRefreshLayout = rootView.findViewById(R.id.swipeRefreshLayout);
         swipeRefreshLayout.setOnRefreshListener(this);
         swipeRefreshLayout.setColorSchemeResources(R.color.tusky_blue);
-        swipeRefreshLayout.setProgressBackgroundColorSchemeColor(
-                ThemeUtils.getColor(context, android.R.attr.colorBackground));
 
         recyclerView = rootView.findViewById(R.id.recyclerView);
         recyclerView.setHasFixedSize(true);

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -77,6 +77,8 @@
         <item name="minTouchTargetSize">32dp</item> <!-- this affects RadioButton size -->
         <item name="elevationOverlayEnabled">false</item> <!-- disable the automatic tinting of surfaces with elevation in dark mode -->
 
+        <item name="swipeRefreshLayoutProgressSpinnerBackgroundColor">?attr/colorSurface</item>
+
     </style>
 
     <style name="ViewMediaActivity.AppBarLayout" parent="ThemeOverlay.AppCompat">


### PR DESCRIPTION
They added a new theme attribute for the background color of the progress indicator. I decided to switch to `colorSurface` as it makes it more visible. 
I don't understand why there is no attribute to set the color of the spinner inside as well.