### PR TITLE
add icon for tabs preference

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/preference/AccountPreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/preference/AccountPreferencesFragment.kt
@@ -71,6 +71,7 @@ class AccountPreferencesFragment : PreferenceFragmentCompat(), Injectable {
 
             preference {
                 setTitle(R.string.title_tab_preferences)
+                icon = getTintedIcon(R.drawable.ic_tabs)
                 setOnPreferenceClickListener {
                     val intent = Intent(context, TabPreferenceActivity::class.java)
                     activity?.startActivity(intent)

--- a/app/src/main/res/drawable/ic_tabs.xml
+++ b/app/src/main/res/drawable/ic_tabs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#000" android:pathData="M22,14A2,2 0 0,1 20,16H4A2,2 0 0,1 2,14V10A2,2 0 0,1 4,8H20A2,2 0 0,1 22,10V14M4,14H8V10H4V14M10,14H14V10H10V14M16,14H20V10H16V14Z" />
+</vector>


### PR DESCRIPTION
I hear quite often that people do not realize that "Tabs" is clickable because it does not have an icon like the surrounding items. This icon is technically a "table row" item but I think it fits ok.

<img src="https://user-images.githubusercontent.com/10157047/90308313-db34d480-dede-11ea-991b-41b12216de0b.png" width="400" />
