### PR TITLE
Fix opening the public filter list from account preferences

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/preference/AccountPreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/preference/AccountPreferencesFragment.kt
@@ -203,8 +203,8 @@ class AccountPreferencesFragment : PreferenceFragmentCompat(), Injectable {
                 preference {
                     setTitle(R.string.pref_title_public_filter_keywords)
                     setOnPreferenceClickListener {
-                        launchFilterActivity(Filter.THREAD,
-                                R.string.pref_title_thread_filter_keywords)
+                        launchFilterActivity(Filter.PUBLIC,
+                                R.string.pref_title_public_filter_keywords)
                         true
                     }
                 }


### PR DESCRIPTION
Previously, clicking "public timelines" would open the "conversations" list.

It looks like this happened during the settings refactor?