### PR TITLE
fix notifications sometimes not rendering

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -79,7 +79,6 @@ import com.keylesspalace.tusky.util.ListUtils;
 import com.keylesspalace.tusky.util.NotificationTypeConverterKt;
 import com.keylesspalace.tusky.util.PairedList;
 import com.keylesspalace.tusky.util.StatusDisplayOptions;
-import com.keylesspalace.tusky.util.ThemeUtils;
 import com.keylesspalace.tusky.util.ViewDataUtils;
 import com.keylesspalace.tusky.view.BackgroundMessageView;
 import com.keylesspalace.tusky.view.EndlessOnScrollListener;
@@ -1205,7 +1204,7 @@ public class NotificationsFragment extends SFragment implements
             if (isAdded()) {
                 adapter.notifyItemRangeInserted(position, count);
                 Context context = getContext();
-                if (position == 0 && context != null) {
+                if (position == 0 && context != null && adapter.getItemCount() > 0) {
                     recyclerView.scrollBy(0, Utils.dpToPx(context, -30));
                 }
             }


### PR DESCRIPTION
Sometimes, when switching to the `NotificationsFragment`, it does not render the content of the notifications, only the dividers. Looks like this: 
<img src="https://user-images.githubusercontent.com/10157047/90803992-e0988180-e319-11ea-8535-1b09513af15a.png" width="320"/>

I don't know why, but this fixes the problem
