### PR TITLE
Improve notifications fetching

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -425,7 +425,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
                     }
             )
 
-            if(addSearchButton) {
+            if (addSearchButton) {
                 mainDrawer.addItemsAtPosition(4,
                         primaryDrawerItem {
                             nameRes = R.string.action_search
@@ -457,7 +457,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
 
     private fun setupTabs(selectNotificationTab: Boolean) {
 
-        val activeTabLayout = if(preferences.getString("mainNavPosition", "top") == "bottom") {
+        val activeTabLayout = if (preferences.getString("mainNavPosition", "top") == "bottom") {
             val actionBarSize = ThemeUtils.getDimension(this, R.attr.actionBarSize)
             val fabMargin = resources.getDimensionPixelSize(R.dimen.fabMargin)
             (composeButton.layoutParams as CoordinatorLayout.LayoutParams).bottomMargin = actionBarSize + fabMargin
@@ -621,10 +621,11 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
                 .transform(
                         RoundedCorners(resources.getDimensionPixelSize(R.dimen.avatar_radius_36dp))
                 )
-                .into(object : CustomTarget<Drawable>(){
+                .into(object : CustomTarget<Drawable>() {
                     override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) {
                         mainToolbar.navigationIcon = resource
                     }
+
                     override fun onLoadCleared(placeholder: Drawable?) {
                         mainToolbar.navigationIcon = placeholder
                     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
@@ -1,0 +1,83 @@
+package com.keylesspalace.tusky.components.notifications
+
+import android.util.Log
+import com.keylesspalace.tusky.db.AccountEntity
+import com.keylesspalace.tusky.db.AccountManager
+import com.keylesspalace.tusky.entity.Marker
+import com.keylesspalace.tusky.entity.Notification
+import com.keylesspalace.tusky.network.MastodonApi
+import com.keylesspalace.tusky.util.isLessThan
+import javax.inject.Inject
+
+class NotificationFetcher @Inject constructor(
+        private val mastodonApi: MastodonApi,
+        private val accountManager: AccountManager,
+        private val notifier: Notifier
+) {
+    fun fetchAndShow() {
+        val accountList = accountManager.getAllAccountsOrderedByActive()
+        for (account in accountList) {
+            if (account.notificationsEnabled) {
+                try {
+                    val notifications = fetchNotifications(account)
+                    notifications.forEachIndexed { index, notification ->
+                        notifier.show(notification, account, index == 0)
+                    }
+                    accountManager.saveAccount(account)
+                } catch (e: Exception) {
+                    Log.w(TAG, "Error while fetching notifications", e)
+                }
+            }
+        }
+    }
+
+    private fun fetchNotifications(account: AccountEntity): MutableList<Notification> {
+        val authHeader = String.format("Bearer %s", account.accessToken)
+        // We fetch marker to not load/show notifications which user has already seen
+        val marker = fetchMarker(authHeader, account)
+        if (marker != null && account.lastNotificationId.isLessThan(marker.lastReadId)) {
+            account.lastNotificationId = marker.lastReadId
+        }
+        Log.d(TAG, "getting Notifications for " + account.fullName)
+        val notifications = mastodonApi.notificationsWithAuth(
+                authHeader,
+                account.domain,
+                account.lastNotificationId
+        ).blockingGet()
+
+        val newId = account.lastNotificationId
+        var newestId = ""
+        val result = mutableListOf<Notification>()
+        for (notification in notifications.reversed()) {
+            val currentId = notification.id
+            if (newestId.isLessThan(currentId)) {
+                newestId = currentId
+                account.lastNotificationId = currentId
+            }
+            if (newId.isLessThan(currentId)) {
+                result.add(notification)
+            }
+        }
+        return result
+    }
+
+    private fun fetchMarker(authHeader: String, account: AccountEntity): Marker? {
+        return try {
+            val allMarkers = mastodonApi.markersWithAuth(
+                    authHeader,
+                    account.domain,
+                    listOf("notifications")
+            ).blockingGet()
+            val notificationMarker = allMarkers["notifications"]
+            Log.d(TAG, "Fetched marker: $notificationMarker")
+            notificationMarker
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to fetch marker", e)
+            null
+        }
+    }
+
+    companion object {
+        const val TAG = "NotificationFetcher"
+    }
+}

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
@@ -15,8 +15,7 @@ class NotificationFetcher @Inject constructor(
         private val notifier: Notifier
 ) {
     fun fetchAndShow() {
-        val accountList = accountManager.getAllAccountsOrderedByActive()
-        for (account in accountList) {
+        for (account in accountManager.getAllAccountsOrderedByActive()) {
             if (account.notificationsEnabled) {
                 try {
                     val notifications = fetchNotifications(account)

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/Notifier.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/Notifier.kt
@@ -1,0 +1,20 @@
+package com.keylesspalace.tusky.components.notifications
+
+import android.content.Context
+import com.keylesspalace.tusky.db.AccountEntity
+import com.keylesspalace.tusky.entity.Notification
+
+/**
+ * Shows notifications.
+ */
+interface Notifier {
+    fun show(notification: Notification, account: AccountEntity, isFirstInBatch: Boolean)
+}
+
+class SystemNotifier(
+        private val context: Context
+) : Notifier {
+    override fun show(notification: Notification, account: AccountEntity, isFirstInBatch: Boolean) {
+        NotificationHelper.make(context, notification, account, isFirstInBatch)
+    }
+}

--- a/app/src/main/java/com/keylesspalace/tusky/di/AppModule.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/di/AppModule.kt
@@ -25,6 +25,8 @@ import androidx.room.Room
 import com.keylesspalace.tusky.TuskyApplication
 import com.keylesspalace.tusky.appstore.EventHub
 import com.keylesspalace.tusky.appstore.EventHubImpl
+import com.keylesspalace.tusky.components.notifications.Notifier
+import com.keylesspalace.tusky.components.notifications.SystemNotifier
 import com.keylesspalace.tusky.db.AppDatabase
 import com.keylesspalace.tusky.network.MastodonApi
 import com.keylesspalace.tusky.network.TimelineCases
@@ -79,7 +81,11 @@ class AppModule {
                         AppDatabase.MIGRATION_16_17, AppDatabase.MIGRATION_17_18, AppDatabase.MIGRATION_18_19,
                         AppDatabase.MIGRATION_19_20, AppDatabase.MIGRATION_20_21, AppDatabase.MIGRATION_21_22,
                         AppDatabase.MIGRATION_22_23)
-        .build()
+                .build()
     }
+
+    @Provides
+    @Singleton
+    fun notifier(context: Context): Notifier = SystemNotifier(context)
 
 }

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Marker.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Marker.kt
@@ -1,0 +1,15 @@
+package com.keylesspalace.tusky.entity
+
+import com.google.gson.annotations.SerializedName
+import java.util.*
+
+/**
+ * API type for saving scroll a position in timeline.
+ */
+data class Marker(
+        @SerializedName("last_read_id")
+        val lastReadId: String,
+        val version: Int,
+        @SerializedName("updated_at")
+        val updatedAt: Date
+)

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Marker.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Marker.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 import java.util.*
 
 /**
- * API type for saving scroll a position in timeline.
+ * API type for saving the scroll position of a timeline.
  */
 data class Marker(
         @SerializedName("last_read_id")

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -99,11 +99,19 @@ interface MastodonApi {
             @Query("exclude_types[]") excludes: Set<Notification.Type>?
     ): Call<List<Notification>>
 
+    @GET("api/v1/markers")
+    fun markersWithAuth(
+            @Header("Authorization") auth: String,
+            @Header(DOMAIN_HEADER) domain: String,
+            @Query("timeline[]") timelines: List<String>
+    ): Single<Map<String, Marker>>
+
     @GET("api/v1/notifications")
     fun notificationsWithAuth(
             @Header("Authorization") auth: String,
-            @Header(DOMAIN_HEADER) domain: String
-    ): Call<List<Notification>>
+            @Header(DOMAIN_HEADER) domain: String,
+            @Query("since_id") sinceId: String?
+    ): Single<List<Notification>>
 
     @POST("api/v1/notifications/clear")
     fun clearNotifications(): Call<ResponseBody>


### PR DESCRIPTION
 - Only fetch notifications up to the latest fetched one
 - Use timeline markers to avoid showing already seen notifications

I extracted `NotificationsFetcher` to test notifications more easily: both manually (to not wait 15 minutes) and with unit tests. I didn't add unit tests yet but I extracted `Notifier` to do it more easily.

I tried out and vanilla Mastodon client updates markers for notifications on opening the client. Doesn't seem like it changes markers with websocket updates so I think it's pretty safe to skip notifications which should already have been seen.