### PR TITLE
Fix some of the StrictMode violations

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -81,6 +81,7 @@ import com.uber.autodispose.android.lifecycle.autoDispose
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
 import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.activity_main.*
 import javax.inject.Inject
 
@@ -227,8 +228,10 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
                     }
                 }
 
-        // Flush old media that was cached for sharing
-        deleteStaleCachedMedia(applicationContext.getExternalFilesDir("Tusky"))
+        Schedulers.io().scheduleDirect {
+            // Flush old media that was cached for sharing
+            deleteStaleCachedMedia(applicationContext.getExternalFilesDir("Tusky"))
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.kt
@@ -25,11 +25,15 @@ import androidx.work.WorkManager
 import com.keylesspalace.tusky.components.notifications.NotificationWorkerFactory
 import com.keylesspalace.tusky.di.AppInjector
 import com.keylesspalace.tusky.settings.PrefKeys
-import com.keylesspalace.tusky.util.*
+import com.keylesspalace.tusky.util.EmojiCompatFont
+import com.keylesspalace.tusky.util.LocaleManager
+import com.keylesspalace.tusky.util.ThemeUtils
 import com.uber.autodispose.AutoDisposePlugins
+import dagger.Lazy
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
 import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.schedulers.Schedulers
 import org.conscrypt.Conscrypt
 import java.security.Security
 import javax.inject.Inject
@@ -38,11 +42,21 @@ class TuskyApplication : Application(), HasAndroidInjector {
 
     @Inject
     lateinit var androidInjector: DispatchingAndroidInjector<Any>
+
     @Inject
-    lateinit var notificationWorkerFactory: NotificationWorkerFactory
+    lateinit var notificationWorkerFactory: Lazy<NotificationWorkerFactory>
 
     override fun onCreate() {
-
+        // Uncomment me to get StrictMode violation logs
+//        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+//            StrictMode.setThreadPolicy(StrictMode.ThreadPolicy.Builder()
+//                    .detectDiskReads()
+//                    .detectDiskWrites()
+//                    .detectNetwork()
+//                    .detectUnbufferedIo()
+//                    .penaltyLog()
+//                    .build())
+//        }
         super.onCreate()
 
         Security.insertProviderAt(Conscrypt.newProvider(), 1)
@@ -64,15 +78,18 @@ class TuskyApplication : Application(), HasAndroidInjector {
         val theme = preferences.getString("appTheme", ThemeUtils.APP_THEME_DEFAULT)
         ThemeUtils.setAppNightMode(theme)
 
-        WorkManager.initialize(
-                this,
-                androidx.work.Configuration.Builder()
-                        .setWorkerFactory(notificationWorkerFactory)
-                        .build()
-        )
-
         RxJavaPlugins.setErrorHandler {
             Log.w("RxJava", "undeliverable exception", it)
+        }
+
+        // This will initialize the whole network stack and cache so we don't wan to wait for it
+        Schedulers.computation().scheduleDirect {
+            WorkManager.initialize(
+                    this,
+                    androidx.work.Configuration.Builder()
+                            .setWorkerFactory(notificationWorkerFactory.get())
+                            .build()
+            )
         }
     }
 


### PR DESCRIPTION
Mostly it's disk reads/writes. I fixed those for AccountManager which
are reported at startup.

Conscrypt reads own version on startup which reads from disk multiple
times. There's no solution for it right now.

SharedPreferences which are used in BaseActivity also read from disk
and pretty early but it shouldn't be a problem.