### PR TITLE
Delete scheduled post after editing

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/SavedTootActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/SavedTootActivity.java
@@ -164,6 +164,7 @@ public final class SavedTootActivity extends BaseActivity implements SavedTootAd
         List<String> descriptions = gson.fromJson(item.getDescriptions(), stringListType);
 
         ComposeOptions composeOptions = new ComposeOptions(
+                /*scheduledTootUid*/null,
                 item.getUid(),
                 item.getText(),
                 jsonUrls,

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -994,6 +994,7 @@ class ComposeActivity : BaseActivity(),
     @Parcelize
     data class ComposeOptions(
             // Let's keep fields var until all consumers are Kotlin
+            var scheduledTootUid: Int? = null,
             var savedTootUid: Int? = null,
             var tootText: String? = null,
             var mediaUrls: List<String>? = null,

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -737,9 +737,11 @@ class ComposeActivity : BaseActivity(),
             composeEditField.error = getString(R.string.error_empty)
             enableButtons(true)
         } else if (characterCount <= maximumTootCharacters) {
-            finishingUploadDialog = ProgressDialog.show(
-                    this, getString(R.string.dialog_title_finishing_media_upload),
-                    getString(R.string.dialog_message_uploading_media), true, true)
+            if (viewModel.media.value!!.isNotEmpty()) {
+                finishingUploadDialog = ProgressDialog.show(
+                        this, getString(R.string.dialog_title_finishing_media_upload),
+                        getString(R.string.dialog_message_uploading_media), true, true)
+            }
 
             viewModel.sendStatus(contentText, spoilerText).observe(this, Observer {
                 finishingUploadDialog?.dismiss()

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -994,7 +994,7 @@ class ComposeActivity : BaseActivity(),
     @Parcelize
     data class ComposeOptions(
             // Let's keep fields var until all consumers are Kotlin
-            var scheduledTootUid: Int? = null,
+            var scheduledTootUid: String? = null,
             var savedTootUid: Int? = null,
             var tootText: String? = null,
             var mediaUrls: List<String>? = null,

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -36,6 +36,7 @@ import com.keylesspalace.tusky.service.ServiceClient
 import com.keylesspalace.tusky.service.TootToSend
 import com.keylesspalace.tusky.util.*
 import io.reactivex.Observable.empty
+import io.reactivex.Observable.just
 import io.reactivex.disposables.Disposable
 import io.reactivex.rxkotlin.Singles
 import java.util.*
@@ -249,7 +250,7 @@ class ComposeViewModel
         val deletionObservable = if (isEditingScheduledToot) {
             api.deleteScheduledStatus(scheduledTootUid.toString()).toObservable().map { Unit }
         } else {
-            empty()
+            just(Unit)
         }.toLiveData()
 
         val sendObservable = media

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -96,6 +96,7 @@ class ComposeViewModel
 
     private val mediaToDisposable = mutableMapOf<Long, Disposable>()
 
+    private val isEditingScheduledToot get() = !scheduledTootUid.isNullOrEmpty()
 
     init {
 
@@ -244,7 +245,7 @@ class ComposeViewModel
             spoilerText: String
     ): LiveData<Unit> {
 
-        val deletionObservable = if (isEditingScheduledToot()) {
+        val deletionObservable = if (isEditingScheduledToot) {
             api.deleteScheduledStatus(scheduledTootUid.toString()).toObservable().map { Unit }
         } else {
             empty()
@@ -464,10 +465,6 @@ class ComposeViewModel
 
     fun updateScheduledAt(newScheduledAt: String?) {
         scheduledAt.value = newScheduledAt
-    }
-
-    private fun isEditingScheduledToot(): Boolean {
-        return !scheduledTootUid.isNullOrEmpty()
     }
 
     private companion object {

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
+import androidx.work.impl.utils.LiveDataUtils
 import com.keylesspalace.tusky.adapter.ComposeAutoCompleteAdapter
 import com.keylesspalace.tusky.components.compose.ComposeActivity.QueuedMedia
 import com.keylesspalace.tusky.components.search.SearchType
@@ -291,7 +292,7 @@ class ComposeViewModel
         result.addSource(deletionObservable) { value -> result.setValue(value) }
         result.addSource(sendObservable) { value -> result.setValue(value) }
 
-        return result
+        return combineLiveData(deletionObservable, sendObservable) { _, _ -> Unit }
 
 
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -58,6 +58,7 @@ class ComposeViewModel
     private var replyingStatusContent: String? = null
     internal var startingText: String? = null
     private var savedTootUid: Int = 0
+    private var scheduledTootUid: Int = 0
     private var startingContentWarning: String = ""
     private var inReplyToId: String? = null
     private var startingVisibility: Status.Visibility = Status.Visibility.UNKNOWN
@@ -271,6 +272,10 @@ class ComposeViewModel
                             idempotencyKey = randomAlphanumericString(16),
                             retries = 0
                     )
+
+                    if (isEditingScheduledToot())
+                        api.deleteScheduledStatus(scheduledTootUid.toString())
+
                     serviceClient.sendToot(tootToSend)
                 }
     }
@@ -405,6 +410,7 @@ class ComposeViewModel
 
 
         savedTootUid = composeOptions?.savedTootUid ?: 0
+        scheduledTootUid = composeOptions?.scheduledTootUid ?: 0
         startingText = composeOptions?.tootText
 
 
@@ -443,6 +449,10 @@ class ComposeViewModel
 
     fun updateScheduledAt(newScheduledAt: String?) {
         scheduledAt.value = newScheduledAt
+    }
+
+    private fun isEditingScheduledToot(): Boolean {
+        return scheduledTootUid > 0
     }
 
     private companion object {

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -287,11 +287,6 @@ class ComposeViewModel
                     serviceClient.sendToot(tootToSend)
                 }
 
-        val result = MediatorLiveData<Unit>()
-
-        result.addSource(deletionObservable) { value -> result.setValue(value) }
-        result.addSource(sendObservable) { value -> result.setValue(value) }
-
         return combineLiveData(deletionObservable, sendObservable) { _, _ -> Unit }
 
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledTootActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledTootActivity.kt
@@ -30,7 +30,6 @@ import com.keylesspalace.tusky.di.Injectable
 import com.keylesspalace.tusky.di.ViewModelFactory
 import com.keylesspalace.tusky.entity.ScheduledStatus
 import com.keylesspalace.tusky.util.Status
-import com.keylesspalace.tusky.util.ThemeUtils
 import com.keylesspalace.tusky.util.hide
 import com.keylesspalace.tusky.util.show
 import kotlinx.android.synthetic.main.activity_scheduled_toot.*
@@ -124,6 +123,7 @@ class ScheduledTootActivity : BaseActivity(), ScheduledTootActionListener, Injec
 
     override fun edit(item: ScheduledStatus) {
         val intent = ComposeActivity.startIntent(this, ComposeActivity.ComposeOptions(
+                scheduledTootUid = item.id,
                 tootText = item.params.text,
                 contentWarning = item.params.spoilerText,
                 mediaAttachments = item.mediaAttachments,


### PR DESCRIPTION
This ensures that editing a scheduled toot will not duplicate it.

If the ID of a scheduled post is being passed to the compose activity, it will delete this scheduled post and create a new post with the same parameters.

Fixes #1924 

## Room for improvement

Deleting a toot and reposting it was the simplest way to accomplish this. There is a very slight chance of something going wrong in one of these two operations though. Alternatively, there is `PUT /scheduled_statuses/:id`, but it is not yet implemented in the app. Please let me know what you think about this, and if you need help with possibly implementing it.