### PR TITLE
Change characters left color to red when negative

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -682,17 +682,15 @@ class ComposeActivity : BaseActivity(),
     }
 
     private fun updateVisibleCharactersLeft() {
-        var remainingLength = maximumTootCharacters - calculateTextLength();
+        val remainingLength = maximumTootCharacters - calculateTextLength();
         composeCharactersLeftView.text = String.format(Locale.getDefault(), "%d", remainingLength)
 
-        if(remainingLength < 0) {
-            val textColor = ThemeUtils.getColor(this, android.R.attr.colorError)
-            composeCharactersLeftView.setTextColor(textColor)
+        val textColor = if (remainingLength < 0) {
+            ContextCompat.getColor(this, R.color.tusky_red)
+        } else {
+            ThemeUtils.getColor(this, android.R.attr.textColorTertiary)
         }
-        else {
-            val textColor = ThemeUtils.getColor(this, android.R.attr.textColorTertiary)
-            composeCharactersLeftView.setTextColor(textColor)
-        }
+        composeCharactersLeftView.setTextColor(textColor)
     }
 
     private fun onContentWarningChanged() {

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -682,7 +682,17 @@ class ComposeActivity : BaseActivity(),
     }
 
     private fun updateVisibleCharactersLeft() {
-        composeCharactersLeftView.text = String.format(Locale.getDefault(), "%d", maximumTootCharacters - calculateTextLength())
+        var remainingLength = maximumTootCharacters - calculateTextLength();
+        composeCharactersLeftView.text = String.format(Locale.getDefault(), "%d", remainingLength)
+
+        if(remainingLength < 0) {
+            val textColor = ThemeUtils.getColor(this, android.R.attr.colorError)
+            composeCharactersLeftView.setTextColor(textColor)
+        }
+        else {
+            val textColor = ThemeUtils.getColor(this, android.R.attr.textColorTertiary)
+            composeCharactersLeftView.setTextColor(textColor)
+        }
     }
 
     private fun onContentWarningChanged() {

--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -327,6 +327,7 @@
             android:layout_height="wrap_content"
             android:textColor="?android:textColorTertiary"
             android:textSize="?attr/status_text_medium"
+            android:textStyle="bold"
             tools:text="500" />
 
         <com.keylesspalace.tusky.components.compose.view.TootButton

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,8 +6,8 @@
     <color name="tusky_orange_light">#fab207</color>
     <color name="tusky_green">#19a341</color>
     <color name="tusky_green_light">#25d069</color>
-    <color name="tusky_red">#FF0000</color>
-
+    <color name="tusky_red">#DF1553</color>
+k
     <color name="white">#fff</color>
     <color name="black">#000</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,6 +6,8 @@
     <color name="tusky_orange_light">#fab207</color>
     <color name="tusky_green">#19a341</color>
     <color name="tusky_green_light">#25d069</color>
+    <color name="tusky_red">#FF0000</color>
+
 
     <color name="white">#fff</color>
     <color name="black">#000</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,7 +8,6 @@
     <color name="tusky_green_light">#25d069</color>
     <color name="tusky_red">#FF0000</color>
 
-
     <color name="white">#fff</color>
     <color name="black">#000</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,7 +7,7 @@
     <color name="tusky_green">#19a341</color>
     <color name="tusky_green_light">#25d069</color>
     <color name="tusky_red">#DF1553</color>
-k
+
     <color name="white">#fff</color>
     <color name="black">#000</color>
 


### PR DESCRIPTION
Implements request by @Porrumentzio in #1943

The remaining character length indicator in the compose screen turns red when the message exceeds the limit.

### Additional Context
<img src="https://user-images.githubusercontent.com/13066221/95014585-78052a00-0665-11eb-86cb-f9fd18778617.gif" width="300" height="500">