### PR TITLE
Fix filtering of boosts

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -1209,7 +1209,7 @@ public class TimelineFragment extends SFragment implements
             if (status != null
                     && ((status.getInReplyToId() != null && filterRemoveReplies)
                     || (status.getReblog() != null && filterRemoveReblogs)
-                    || shouldFilterStatus(status))) {
+                    || shouldFilterStatus(status.getActionableStatus()))) {
                 it.remove();
             }
         }


### PR DESCRIPTION
Boosts aren't currently getting filters applied, because we're checking the content of the boost status instead of the content of the original status :facepalm: 