### PR TITLE
Use blurhash for preview cards

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
@@ -106,7 +106,7 @@ class StatusDetailedViewHolder extends StatusBaseViewHolder {
                                    StatusDisplayOptions statusDisplayOptions,
                                    @Nullable Object payloads) {
         super.setupWithStatus(status, listener, statusDisplayOptions, payloads);
-        setupCard(status, CardViewMode.FULL_WIDTH); // Always show card for detailed status
+        setupCard(status, CardViewMode.FULL_WIDTH, statusDisplayOptions); // Always show card for detailed status
         if (payloads == null) {
             setReblogAndFavCount(status.getReblogsCount(), status.getFavouritesCount(), listener);
 

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Card.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Card.kt
@@ -26,7 +26,8 @@ data class Card(
         val image: String,
         val type: String,
         val width: Int,
-        val height: Int
+        val height: Int,
+        val blurhash: String?
 ) {
 
     override fun hashCode(): Int {


### PR DESCRIPTION
When blurhash is enabled in the user preferences:
- Adds a blurhash placeholder for card images
- Uses blurhash for card images when the user has disabled media preview download
- Uses blurhash for card images when the post is marked sensitive (mostly useful for posts originating from other fediverse software?)