### PR TITLE
Add tests for compose activity initial state changes

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -1026,7 +1026,7 @@ class ComposeActivity : BaseActivity(),
         private const val MEDIA_TAKE_PHOTO_RESULT = 2
         private const val PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE = 1
 
-        private const val COMPOSE_OPTIONS_EXTRA = "COMPOSE_OPTIONS"
+        internal const val COMPOSE_OPTIONS_EXTRA = "COMPOSE_OPTIONS"
         private const val PHOTO_UPLOAD_URI_KEY = "PHOTO_UPLOAD_URI"
 
         // Mastodon only counts URLs as this long in terms of status character limits

--- a/app/src/test/java/com/keylesspalace/tusky/ComposeActivityTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/ComposeActivityTest.kt
@@ -16,6 +16,7 @@
 
 package com.keylesspalace.tusky
 
+import android.content.Intent
 import android.text.SpannedString
 import android.widget.EditText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -76,6 +77,7 @@ class ComposeActivityTest {
             notificationLight = true
     )
     var instanceResponseCallback: (()->Instance)? = null
+    var composeOptions: ComposeActivity.ComposeOptions? = null
 
     @Before
     fun setupActivity() {
@@ -114,6 +116,9 @@ class ComposeActivityTest {
                 mock(SaveTootHelper::class.java),
                 dbMock
         )
+        activity.intent = Intent(activity, ComposeActivity::class.java).apply {
+            putExtra(ComposeActivity.COMPOSE_OPTIONS_EXTRA, composeOptions)
+        }
 
         val viewModelFactoryMock = mock(ViewModelFactory::class.java)
         `when`(viewModelFactoryMock.create(ComposeViewModel::class.java)).thenReturn(viewModel)
@@ -139,6 +144,14 @@ class ComposeActivityTest {
     }
 
     @Test
+    fun whenModifiedInitialState_andCloseButtonPressed_notFinish() {
+        composeOptions = ComposeActivity.ComposeOptions(modifiedInitialState = true)
+        setupActivity()
+        clickUp()
+        assertFalse(activity.isFinishing)
+    }
+
+    @Test
     fun whenBackButtonPressedAndEmpty_finish() {
         clickBack()
         assertTrue(activity.isFinishing)
@@ -150,6 +163,14 @@ class ComposeActivityTest {
         clickBack()
         assertFalse(activity.isFinishing)
         // We would like to check for dialog but Robolectric doesn't work with AppCompat v7 yet
+    }
+
+    @Test
+    fun whenModifiedInitialState_andBackButtonPressed_notFinish() {
+        composeOptions = ComposeActivity.ComposeOptions(modifiedInitialState = true)
+        setupActivity()
+        clickBack()
+        assertFalse(activity.isFinishing)
     }
 
     @Test


### PR DESCRIPTION
Probably should have been part of #1744, I keep forgetting that we have a nice framework for testing `ComposeActivity` already