### PR TITLE
Adds link to account page when clicking on displayName

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -618,6 +618,8 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                                 final String statusContent,
                                 StatusDisplayOptions statusDisplayOptions) {
         avatar.setOnClickListener(v -> listener.onViewAccount(accountId));
+        displayName.setOnClickListener(v -> listener.onViewAccount(accountId));
+
         replyButton.setOnClickListener(v -> {
             int position = getAdapterPosition();
             if (position != RecyclerView.NO_POSITION) {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -617,8 +617,12 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                                 final String accountId,
                                 final String statusContent,
                                 StatusDisplayOptions statusDisplayOptions) {
-        avatar.setOnClickListener(v -> listener.onViewAccount(accountId));
-        displayName.setOnClickListener(v -> listener.onViewAccount(accountId));
+
+        View.OnClickListener profileButtonClickListener = button -> {
+            listener.onViewAccount(accountId);
+        };
+        avatar.setOnClickListener(profileButtonClickListener);
+        displayName.setOnClickListener(profileButtonClickListener);
 
         replyButton.setOnClickListener(v -> {
             int position = getAdapterPosition();

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -617,10 +617,10 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                                 final String accountId,
                                 final String statusContent,
                                 StatusDisplayOptions statusDisplayOptions) {
-
         View.OnClickListener profileButtonClickListener = button -> {
             listener.onViewAccount(accountId);
         };
+
         avatar.setOnClickListener(profileButtonClickListener);
         displayName.setOnClickListener(profileButtonClickListener);
 


### PR DESCRIPTION
After finding out [here](https://social.randombits.host/web/statuses/105187994632656075) that you can get to a user profile by clicking their avatar and not their display name I felt dumb so I made this to have what I feel is the expected behavior of also going to a profile when you click the display name.