### PR TITLE
better distinction between green and blue build flavors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,7 @@ android {
     productFlavors {
         blue {}
         green {
+            resValue "string", "app_name", APP_NAME + " Test"
             applicationIdSuffix ".test"
             versionNameSuffix "-" + getGitSha()
         }

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationHelper.java
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationHelper.java
@@ -295,7 +295,7 @@ public class NotificationHelper {
                 .setSmallIcon(R.drawable.ic_notify)
                 .setContentIntent(summary ? summaryResultPendingIntent : eventResultPendingIntent)
                 .setDeleteIntent(deletePendingIntent)
-                .setColor(BuildConfig.DEBUG ? Color.parseColor("#19A341") : ContextCompat.getColor(context, R.color.tusky_blue))
+                .setColor(BuildConfig.FLAVOR == "green" ? Color.parseColor("#19A341") : ContextCompat.getColor(context, R.color.tusky_blue))
                 .setGroup(account.getAccountId())
                 .setAutoCancel(true)
                 .setShortcutId(Long.toString(account.getId()))


### PR DESCRIPTION
I have both Tusky nightly and regular Tusky installed on my phone and sometimes I cannot tell them apart (mostly in notifications and when the crash dialog appears while the app is in background). This should improve the situation.