### PR TITLE
fix the notification buttons on the muted users page

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/AccountListFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/AccountListFragment.kt
@@ -330,6 +330,7 @@ class AccountListFragment : BaseFragment(), AccountActionListener, Injectable {
 
     private fun fetchRelationships(ids: List<String>) {
         api.relationships(ids)
+                .observeOn(AndroidSchedulers.mainThread())
                 .autoDispose(from(this))
                 .subscribe(::onFetchRelationshipsSuccess) {
                     onFetchRelationshipsFailure(ids)


### PR DESCRIPTION
The adapter was notified on the wrong thread, making it ignore the new data. The bug would not always occur, because if something else triggered a rebinding of the viewholder, it would fix itself.

closes #2005