### PR TITLE
Exchange colorSurface and colorBackground to improve text contrast

### DIFF
--- a/app/src/main/res/values/theme_colors.xml
+++ b/app/src/main/res/values/theme_colors.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <color name="colorSurface">@color/white</color>
+    <color name="colorSurface">@color/tusky_grey_95</color>
     <color name="colorPrimaryDark">@color/tusky_grey_70</color>
 
-    <color name="colorBackground">@color/tusky_grey_95</color>
+    <color name="colorBackground">@color/white</color>
     <color name="windowBackground">@color/tusky_grey_80</color>
 
     <color name="textColorPrimary">@color/tusky_grey_10</color>


### PR DESCRIPTION
Small suggested tweak - exchanging the values of colorSurface and colorBackground in the light theme radically improves text contrast/readability and uses Tusky's blue tinted colour as an accent to define the tab area instead.

Should fix #1687, #1831 and #1971 