### PR TITLE
Fix TalkBack not initializing old views

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -24,11 +24,13 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityManager;
 import android.widget.ProgressBar;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.arch.core.util.Function;
+import androidx.core.content.ContextCompat;
 import androidx.core.util.Pair;
 import androidx.core.widget.ContentLoadingProgressBar;
 import androidx.lifecycle.Lifecycle;
@@ -95,6 +97,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
@@ -1471,9 +1474,21 @@ public class TimelineFragment extends SFragment implements
         }
     };
 
+    AccessibilityManager a11yManager;
+    boolean talkBackWasEnabled;
+
     @Override
     public void onResume() {
         super.onResume();
+        a11yManager = Objects.requireNonNull(
+                ContextCompat.getSystemService(requireContext(), AccessibilityManager.class)
+        );
+        boolean wasEnabled = this.talkBackWasEnabled;
+        talkBackWasEnabled = a11yManager.isEnabled();
+        Log.d(TAG, "talkback was enabled: " + wasEnabled + ", now " + talkBackWasEnabled);
+        if (talkBackWasEnabled && !wasEnabled) {
+            this.adapter.notifyDataSetChanged();
+        }
         startUpdateTimestamp();
     }
 


### PR DESCRIPTION
This is an attempt to fix the problem we have reported.
Basically it goes like this:
1. TalkBack is disabled
2. You open the app
3. You enable TalkBack
4. You try to use accessibility actions (swipe up-and-right)
5. It does not work on rows which were already displayed, only on those which are added later with scrolling

It seems like it should be fixed in libraries but I would try to bandaid it on our own. I think if we make it re-initialize all views it should work but I don't know how do it. `invalidate()` doesn't cut it.