### PR TITLE
add proguard rule to keep DraftAttachment.Type

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -43,6 +43,10 @@
     public *;
 }
 
+-keep enum com.keylesspalace.tusky.db.DraftAttachment$Type {
+    public *;
+}
+
 # preserve line numbers for crash reporting
 -keepattributes SourceFile,LineNumberTable
 -renamesourcefileattribute SourceFile


### PR DESCRIPTION
Otherwise Gson fails to deserialize draft attachments

closes #2053