### PR TITLE
SpanUtils: highlight nicknames with dashes

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/SpanUtils.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/SpanUtils.kt
@@ -18,7 +18,7 @@ private const val TAG_REGEX = "(?:^|[^/)A-Za-z0-9_])#([\\w_]*[\\p{Alpha}_][\\w_]
  * @see <a href="https://github.com/tootsuite/mastodon/blob/master/app/models/account.rb">
  *     Account#MENTION_RE</a>
  */
-private const val MENTION_REGEX = "(?:^|[^/[:word:]])@([a-z0-9_]+(?:@[a-z0-9\\.\\-]+[a-z0-9]+)?)"
+private const val MENTION_REGEX = "(?:^|[^/[:word:]])@([a-z0-9_-]+(?:@[a-z0-9\\.\\-]+[a-z0-9]+)?)"
 
 private const val HTTP_URL_REGEX = "(?:(^|\\b)http://[^\\s]+)"
 private const val HTTPS_URL_REGEX = "(?:(^|\\b)https://[^\\s]+)"


### PR DESCRIPTION
While it's not allowed to create such accounts on Mastodon, it federates fine with servers that allow dashes.