### PR TITLE
change draft attachment directory

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/drafts/DraftHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/drafts/DraftHelper.kt
@@ -59,11 +59,17 @@ class DraftHelper @Inject constructor(
     ): Completable {
         return Single.fromCallable {
 
-            val draftDirectory = context.getExternalFilesDir("Tusky")
+            val externalFilesDir = context.getExternalFilesDir("Tusky")
 
-            if (draftDirectory == null || !(draftDirectory.exists())) {
+            if (externalFilesDir == null || !(externalFilesDir.exists())) {
                 Log.e("DraftHelper", "Error obtaining directory to save media.")
                 throw Exception()
+            }
+
+            val draftDirectory = File(externalFilesDir, "Drafts")
+
+            if (!draftDirectory.exists()) {
+                draftDirectory.mkdir()
             }
 
             val uris = mediaUris.map { uriString ->


### PR DESCRIPTION
This is so that when removing the old drafts feature we can savely delete the attachment files as well. When the old & new feature use the same directory, one file could belong to two drafts.