### PR TITLE
remove redundant options from account toolbar

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
@@ -660,14 +660,6 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
         menuInflater.inflate(R.menu.account_toolbar, menu)
 
         if (!viewModel.isSelf) {
-            val follow = menu.findItem(R.id.action_follow)
-            follow.title = if (followState == FollowState.NOT_FOLLOWING) {
-                getString(R.string.action_follow)
-            } else {
-                getString(R.string.action_unfollow)
-            }
-
-            follow.isVisible = followState != FollowState.REQUESTED
 
             val block = menu.findItem(R.id.action_block)
             block.title = if (blocking) {
@@ -711,8 +703,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
             }
 
         } else {
-            // It shouldn't be possible to block, follow, mute or report yourself.
-            menu.removeItem(R.id.action_follow)
+            // It shouldn't be possible to block, mute or report yourself.
             menu.removeItem(R.id.action_block)
             menu.removeItem(R.id.action_mute)
             menu.removeItem(R.id.action_mute_domain)
@@ -804,19 +795,11 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
-            R.id.action_mention -> {
-                mention()
-                return true
-            }
             R.id.action_open_in_web -> {
                 // If the account isn't loaded yet, eat the input.
                 if (loadedAccount != null) {
                     LinkHelper.openLink(loadedAccount?.url, this)
                 }
-                return true
-            }
-            R.id.action_follow -> {
-                viewModel.changeFollowState()
                 return true
             }
             R.id.action_block -> {

--- a/app/src/main/res/menu/account_toolbar.xml
+++ b/app/src/main/res/menu/account_toolbar.xml
@@ -2,16 +2,8 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <item android:id="@+id/action_mention"
-        android:title="@string/action_mention"
-        app:showAsAction="never" />
-
     <item android:id="@+id/action_open_in_web"
         android:title="@string/action_open_in_web"
-        app:showAsAction="never" />
-
-    <item android:id="@+id/action_follow"
-        android:title="@string/action_follow"
         app:showAsAction="never" />
 
     <item android:id="@+id/action_mute"


### PR DESCRIPTION
I got a complaint that there is no confirmation dialog when unfollowing somebody via the menu. Instead of adding the dialog there, I think it is better to remove the option alltogether since it is redundant anyway and there are already a lot of options in that menu.