### PR TITLE
fix profile note "Saved" message appearing on other account changes

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountActivity.kt
@@ -568,11 +568,12 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
                 subscribing = relation.subscribing
         }
 
+        // remove the listener so it doesn't fire on non-user changes
+        accountNoteTextInputLayout.editText?.removeTextChangedListener(noteWatcher)
+
         accountNoteTextInputLayout.visible(relation.note != null)
         accountNoteTextInputLayout.editText?.setText(relation.note)
 
-        // add the listener late to avoid it firing on the first change
-        accountNoteTextInputLayout.editText?.removeTextChangedListener(noteWatcher)
         accountNoteTextInputLayout.editText?.addTextChangedListener(noteWatcher)
 
         updateButtons()


### PR DESCRIPTION
Steps to reproduce: Go to a user profile & change the relationshio (e.g mute). Note the "saved" message appearing below the profile note. The app even makes a network request.

This PR changes the behavior so the note is only saved on actual user changes.