### PR TITLE
NavIcon Avatar fix

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -694,7 +694,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
             .into(object : CustomTarget<Drawable>(navIconSize, navIconSize) {
 
                 override fun onLoadStarted(placeholder: Drawable?) {
-                    if(placeholder != null) {
+                    if (placeholder != null) {
                         mainToolbar.navigationIcon = FixedSizeDrawable(placeholder, navIconSize, navIconSize)
                     }
                 }
@@ -703,7 +703,9 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
                 }
 
                 override fun onLoadCleared(placeholder: Drawable?) {
-                    mainToolbar.navigationIcon = placeholder
+                    if (placeholder != null) {
+                        mainToolbar.navigationIcon = FixedSizeDrawable(placeholder, navIconSize, navIconSize)
+                    }
                 }
             })
     }

--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -699,7 +699,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
                     }
                 }
                 override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) {
-                    mainToolbar.navigationIcon = resource
+                    mainToolbar.navigationIcon = FixedSizeDrawable(resource, navIconSize, navIconSize)
                 }
 
                 override fun onLoadCleared(placeholder: Drawable?) {


### PR DESCRIPTION
As mentioned in the Matrix devroom, the *navigation icon* avatar acted strangely in some devices. The use of `FixedSizeDrawable` fixes it.