### PR TITLE
fix crash when rotating screen in a preference dialog twice

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesActivity.kt
@@ -21,6 +21,7 @@ import android.content.SharedPreferences
 import android.os.Bundle
 import android.util.Log
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
 import androidx.preference.PreferenceManager
 import com.keylesspalace.tusky.BaseActivity
 import com.keylesspalace.tusky.MainActivity
@@ -58,33 +59,36 @@ class PreferencesActivity : BaseActivity(), SharedPreferences.OnSharedPreference
             setDisplayShowHomeEnabled(true)
         }
 
-        val fragment: Fragment = when (intent.getIntExtra(EXTRA_PREFERENCE_TYPE, 0)) {
-            GENERAL_PREFERENCES -> {
-                setTitle(R.string.action_view_preferences)
-                PreferencesFragment.newInstance()
-            }
-            ACCOUNT_PREFERENCES -> {
-                setTitle(R.string.action_view_account_preferences)
-                AccountPreferencesFragment.newInstance()
-            }
-            NOTIFICATION_PREFERENCES -> {
-                setTitle(R.string.pref_title_edit_notification_settings)
-                NotificationPreferencesFragment.newInstance()
-            }
-            TAB_FILTER_PREFERENCES -> {
-                setTitle(R.string.pref_title_status_tabs)
-                TabFilterPreferencesFragment.newInstance()
-            }
-            PROXY_PREFERENCES -> {
-                setTitle(R.string.pref_title_http_proxy_settings)
-                ProxyPreferencesFragment.newInstance()
-            }
-            else -> throw IllegalArgumentException("preferenceType not known")
-        }
+        val fragmentTag = "preference_fragment_$EXTRA_PREFERENCE_TYPE"
 
-        supportFragmentManager.beginTransaction()
-                .replace(R.id.fragment_container, fragment)
-                .commit()
+        val fragment: Fragment = supportFragmentManager.findFragmentByTag(fragmentTag)
+                ?: when (intent.getIntExtra(EXTRA_PREFERENCE_TYPE, 0)) {
+                    GENERAL_PREFERENCES -> {
+                        setTitle(R.string.action_view_preferences)
+                        PreferencesFragment.newInstance()
+                    }
+                    ACCOUNT_PREFERENCES -> {
+                        setTitle(R.string.action_view_account_preferences)
+                        AccountPreferencesFragment.newInstance()
+                    }
+                    NOTIFICATION_PREFERENCES -> {
+                        setTitle(R.string.pref_title_edit_notification_settings)
+                        NotificationPreferencesFragment.newInstance()
+                    }
+                    TAB_FILTER_PREFERENCES -> {
+                        setTitle(R.string.pref_title_status_tabs)
+                        TabFilterPreferencesFragment.newInstance()
+                    }
+                    PROXY_PREFERENCES -> {
+                        setTitle(R.string.pref_title_http_proxy_settings)
+                        ProxyPreferencesFragment.newInstance()
+                    }
+                    else -> throw IllegalArgumentException("preferenceType not known")
+                }
+
+        supportFragmentManager.commit {
+            replace(R.id.fragment_container, fragment, fragmentTag)
+        }
 
         restartActivitiesOnExit = intent.getBooleanExtra("restart", false)
 


### PR DESCRIPTION
<details>
  <summary>Stacktrace</summary>

```
java.lang.IllegalStateException: Target fragment must implement TargetFragment interface
        at androidx.preference.PreferenceDialogFragmentCompat.onCreate(PreferenceDialogFragmentCompat.java:80)
        at androidx.preference.ListPreferenceDialogFragmentCompat.onCreate(ListPreferenceDialogFragmentCompat.java:48)
        at androidx.fragment.app.Fragment.performCreate(Fragment.java:2685)
        at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:280)
        at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1187)
        at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1368)
        at androidx.fragment.app.FragmentManager.moveFragmentToExpectedState(FragmentManager.java:1446)
        at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1509)
        at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:2637)
        at androidx.fragment.app.FragmentManager.dispatchCreate(FragmentManager.java:2583)
        at androidx.fragment.app.FragmentController.dispatchCreate(FragmentController.java:236)
        at androidx.fragment.app.FragmentActivity.onCreate(FragmentActivity.java:315)
        at androidx.appcompat.app.AppCompatActivity.onCreate(AppCompatActivity.java:115)
        at com.keylesspalace.tusky.BaseActivity.onCreate(BaseActivity.java:64)
        at com.keylesspalace.tusky.components.preference.PreferencesActivity.onCreate(PreferencesActivity.kt:51)
        at android.app.Activity.performCreate(Activity.java:7802)
        at android.app.Activity.performCreate(Activity.java:7791)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1299)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3245)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3409) 
        at android.app.ActivityThread.handleRelaunchActivityInner(ActivityThread.java:5279) 
        at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:5187) 
        at android.app.servertransaction.ActivityRelaunchItem.execute(ActivityRelaunchItem.java:69) 
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135) 
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2016) 
        at android.os.Handler.dispatchMessage(Handler.java:107) 
        at android.os.Looper.loop(Looper.java:214) 
        at android.app.ActivityThread.main(ActivityThread.java:7356) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930) 
```

</details>