### PR TITLE
 Avoid using displayName for displaying purpose

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationEntity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationEntity.kt
@@ -167,7 +167,7 @@ fun Account.toEntity() =
         ConversationAccountEntity(
                 id,
                 username,
-                displayName.orEmpty(),
+                name,
                 avatar,
                 emojis ?: emptyList()
         )

--- a/app/src/main/java/com/keylesspalace/tusky/repository/TimelineRepository.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/repository/TimelineRepository.kt
@@ -298,7 +298,7 @@ fun Account.toEntity(accountId: Long, gson: Gson): TimelineAccountEntity {
             timelineUserId = accountId,
             localUsername = localUsername,
             username = username,
-            displayName = displayName.orEmpty(),
+            displayName = name,
             url = url,
             avatar = avatar,
             emojis = gson.toJson(emojis),

--- a/app/src/main/java/com/keylesspalace/tusky/util/ViewDataUtils.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ViewDataUtils.java
@@ -52,7 +52,7 @@ public final class ViewDataUtils {
                 .setSensitive(visibleStatus.getSensitive())
                 .setIsShowingSensitiveContent(alwaysShowSensitiveMedia || !visibleStatus.getSensitive())
                 .setSpoilerText(visibleStatus.getSpoilerText())
-                .setRebloggedByUsername(status.getReblog() == null ? null : status.getAccount().getDisplayName())
+                .setRebloggedByUsername(status.getReblog() == null ? null : status.getAccount().getName())
                 .setUserFullName(visibleStatus.getAccount().getName())
                 .setVisibility(visibleStatus.getVisibility())
                 .setSenderId(visibleStatus.getAccount().getId())


### PR DESCRIPTION
Sometimes `displayName` was used for displaying username purposes.

(before)
![image](https://user-images.githubusercontent.com/27999567/109969394-302f1f80-7d37-11eb-889c-058a602c38e6.png)
(after)
![image](https://user-images.githubusercontent.com/27999567/109969664-82704080-7d37-11eb-8988-03899f3f20b0.png)

I fixed them in first commit.

Second commit is my proposal. Make `displayName` private to prevent such mistakes.
If you don't like this, I will remove this commit.

