### PR TITLE
Adding disclaimer for restricted instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Tusky is a beautiful Android client for [Mastodon](https://github.com/tootsuite/
 - Optimized for all screen sizes
 - Completely open-source - no non-free dependencies like Google services
 
+## Restrictions
+
+Tusky will not work for [spinster.xyz](https://spinster.xyz) instance. This is not censorship, but rather a choice by this house who will facilitate our services to.
+
 ### Testing
 
 The nightly build from master is [available on Google Play](https://play.google.com/store/apps/details?id=com.keylesspalace.tusky.test). 


### PR DESCRIPTION
Hi everyone,

Just saw the Tusky application deserves itself the right to restrict certain instances, and I think it's quite dishonest to not explain or make this public on README.md

Added a small change mentioning the only affected instance. To explain the situation, used the same comment used by Marie Axelsson at commit 5d04a7ccda016e1426fdc6352293c379d28312e9.

Thank you very much.