### PR TITLE
fix crash when captioning large images

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
@@ -101,8 +101,10 @@ fun <T> T.makeCaptionDialog(existingDescription: String?,
     // size. Maybe we should limit the size of CustomTarget
     Glide.with(this)
             .load(previewUri)
-            .into(object : CustomTarget<Drawable>() {
-                override fun onLoadCleared(placeholder: Drawable?) {}
+            .into(object : CustomTarget<Drawable>(4096, 4096) {
+                override fun onLoadCleared(placeholder: Drawable?) {
+                    imageView.setImageDrawable(placeholder)
+                }
 
                 override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) {
                     imageView.setImageDrawable(resource)


### PR DESCRIPTION
The caption dialog crashes when one tries to caption really large images.
Adding a size to the CustomTarget fixes the problem. I used 4096px because that is also the limit at which we downsize images before uploading them.