### PR TITLE
work around mastodon mute bug

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
@@ -193,7 +193,7 @@ class SearchViewModel @Inject constructor(
         return accountManager.getAllAccountsOrderedByActive()
     }
 
-    fun muteAccount(accountId: String, notifications: Boolean, duration: Int) {
+    fun muteAccount(accountId: String, notifications: Boolean, duration: Int?) {
         timelineCases.mute(accountId, notifications, duration)
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/network/TimelineCases.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/TimelineCases.kt
@@ -33,7 +33,7 @@ interface TimelineCases {
     fun reblog(status: Status, reblog: Boolean): Single<Status>
     fun favourite(status: Status, favourite: Boolean): Single<Status>
     fun bookmark(status: Status, bookmark: Boolean): Single<Status>
-    fun mute(id: String, notifications: Boolean, duration: Int)
+    fun mute(id: String, notifications: Boolean, duration: Int?)
     fun block(id: String)
     fun delete(id: String): Single<DeletedStatus>
     fun pin(status: Status, pin: Boolean)
@@ -104,7 +104,7 @@ class TimelineCasesImpl(
         }
     }
 
-    override fun mute(id: String, notifications: Boolean, duration: Int) {
+    override fun mute(id: String, notifications: Boolean, duration: Int?) {
         mastodonApi.muteAccount(id, notifications, duration)
                 .subscribe({
                     eventHub.dispatch(MuteEvent(id))

--- a/app/src/main/java/com/keylesspalace/tusky/view/MuteAccountDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/view/MuteAccountDialog.kt
@@ -10,7 +10,7 @@ import com.keylesspalace.tusky.databinding.DialogMuteAccountBinding
 fun showMuteAccountDialog(
     activity: Activity,
     accountUsername: String,
-    onOk: (notifications: Boolean, duration: Int) -> Unit
+    onOk: (notifications: Boolean, duration: Int?) -> Unit
 ) {
     val binding = DialogMuteAccountBinding.inflate(activity.layoutInflater)
     binding.warning.text = activity.getString(R.string.dialog_mute_warning, accountUsername)
@@ -20,7 +20,16 @@ fun showMuteAccountDialog(
             .setView(binding.root)
             .setPositiveButton(android.R.string.ok) { _, _ ->
                 val durationValues = activity.resources.getIntArray(R.array.mute_duration_values)
-                onOk(binding.checkbox.isChecked, durationValues[binding.duration.selectedItemPosition])
+
+                // workaround to make indefinite muting work with Mastodon 3.3.0
+                // https://github.com/tuskyapp/Tusky/issues/2107
+                val duration = if(binding.duration.selectedItemPosition == 0) {
+                    null
+                } else {
+                    durationValues[binding.duration.selectedItemPosition]
+                }
+
+                onOk(binding.checkbox.isChecked, duration)
             }
             .setNegativeButton(android.R.string.cancel, null)
             .show()

--- a/app/src/main/java/com/keylesspalace/tusky/viewmodel/AccountViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/viewmodel/AccountViewModel.kt
@@ -119,7 +119,7 @@ class AccountViewModel @Inject constructor(
         }
     }
 
-    fun muteAccount(notifications: Boolean, duration: Int) {
+    fun muteAccount(notifications: Boolean, duration: Int?) {
         changeRelationship(RelationShipAction.MUTE, notifications, duration)
     }
 


### PR DESCRIPTION
The bug is fixed, but not yet released on mastodons side. https://github.com/tootsuite/mastodon/pull/15516
This workaround makes at least muting indefinitely work again with Mastodon 3.3.0
