### PR TITLE
fix crash because of shrinked resources

### DIFF
--- a/app/src/main/res/raw/keep.xml
+++ b/app/src/main/res/raw/keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/ic_local_24dp,@drawable/ic_hashtag" />


### PR DESCRIPTION
ic_local_24dp and ic_hashtag are only referenced in code and not in xml which seems to confuse the resource shrinker. The weird thing is, they are not shrinked everywhere, e.g. the Bitrise CI builds apks correctly but the one by @nailyk-fr shrinks the two drawables. I have no explanation for this.

This adds explicit keep directives to solve the problem.