### PR TITLE
get rid of jcenter

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,9 +167,9 @@ dependencies {
     implementation "com.mikepenz:materialdrawer-iconics:$materialdrawerVersion"
     implementation 'com.mikepenz:google-material-typeface:3.0.1.4.original-kotlin@aar'
 
-    implementation "com.theartofdev.edmodo:android-image-cropper:2.8.0"
+    implementation "com.github.CanHub:Android-Image-Cropper:3.1.0"
 
-    implementation "de.c1710:filemojicompat:1.0.17"
+    implementation "de.c1710:filemojicompat:1.0.18"
 
     testImplementation "androidx.test.ext:junit:1.1.2"
     testImplementation "org.robolectric:robolectric:4.4"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -179,4 +179,5 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"
     androidTestImplementation "androidx.room:room-testing:$roomVersion"
     androidTestImplementation "androidx.test.ext:junit:1.1.2"
+    testImplementation "androidx.arch.core:core-testing:2.1.0"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -123,7 +123,7 @@
         <activity android:name=".AboutActivity" />
         <activity android:name=".TabPreferenceActivity" />
         <activity
-            android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
+            android:name="com.canhub.cropper.CropImageActivity"
             android:theme="@style/Base.Theme.AppCompat" />
         <activity
             android:name=".components.search.SearchActivity"

--- a/app/src/main/java/com/keylesspalace/tusky/EditProfileActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/EditProfileActivity.kt
@@ -47,7 +47,7 @@ import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
-import com.theartofdev.edmodo.cropper.CropImage
+import com.canhub.cropper.CropImage
 import javax.inject.Inject
 
 class EditProfileActivity : BaseActivity(), Injectable {
@@ -374,7 +374,7 @@ class EditProfileActivity : BaseActivity(), Injectable {
             CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE -> {
                 val result = CropImage.getActivityResult(data)
                 when (resultCode) {
-                    Activity.RESULT_OK -> beginResize(result.uri)
+                    Activity.RESULT_OK -> beginResize(result?.uriContent)
                     CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE -> onResizeFailure()
                     else -> endMediaPicking()
                 }
@@ -382,7 +382,12 @@ class EditProfileActivity : BaseActivity(), Injectable {
         }
     }
 
-    private fun beginResize(uri: Uri) {
+    private fun beginResize(uri: Uri?) {
+        if(uri == null) {
+            currentlyPicking = PickType.NOTHING
+            return
+        }
+
         beginMediaPicking()
 
         when (currentlyPicking) {
@@ -398,7 +403,6 @@ class EditProfileActivity : BaseActivity(), Injectable {
         }
 
         currentlyPicking = PickType.NOTHING
-
     }
 
     private fun onResizeFailure() {

--- a/app/src/main/res/layout/activity_license.xml
+++ b/app/src/main/res/layout/activity_license.xml
@@ -171,7 +171,7 @@
                 android:layout_marginStart="12dp"
                 android:layout_marginTop="12dp"
                 license:license="@string/license_apache_2"
-                license:link="https://github.com/ArthurHub/Android-Image-Cropper"
+                license:link="https://github.com/CanHub/Android-Image-Cropper"
                 license:name="Android Image Cropper" />
 
             <com.keylesspalace.tusky.view.LicenseCard

--- a/app/src/test/java/com/keylesspalace/tusky/BottomSheetActivityTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/BottomSheetActivityTest.kt
@@ -17,6 +17,7 @@ package com.keylesspalace.tusky
 
 import android.text.SpannedString
 import android.widget.LinearLayout
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.keylesspalace.tusky.entity.Account
 import com.keylesspalace.tusky.entity.SearchResult
@@ -28,6 +29,7 @@ import io.reactivex.rxjava3.plugins.RxJavaPlugins
 import io.reactivex.rxjava3.schedulers.TestScheduler
 import org.junit.Assert
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -38,6 +40,10 @@ import java.util.concurrent.TimeUnit
 
 
 class BottomSheetActivityTest {
+
+    @get:Rule
+    val instantTaskExecutorRule: InstantTaskExecutorRule = InstantTaskExecutorRule()
+
     private lateinit var activity : FakeBottomSheetActivity
     private lateinit var apiMock: MastodonApi
     private val accountQuery = "http://mastodon.foo.bar/@User"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.4.31'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.2'
@@ -13,7 +13,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
JCenter is getting turned off sometime next year https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

Only two libraries we use were not available on Maven central: FileEmojiCompat, which @C1710 published there (thx again!) and the Image Cropper, which I replaced with a better fork because the original library is no longer maintained.