### PR TITLE
don't upscale images in caption dialog

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
@@ -98,8 +98,7 @@ fun <T> T.makeCaptionDialog(existingDescription: String?,
 
     dialog.show()
 
-    // Load the image and manually set it into the ImageView because it doesn't have a fixed
-    // size. Maybe we should limit the size of CustomTarget
+    // Load the image and manually set it into the ImageView because it doesn't have a fixed  size.
     Glide.with(this)
             .load(previewUri)
             .downsample(DownsampleStrategy.CENTER_INSIDE)

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import at.connyduck.sparkbutton.helpers.Utils
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
 import com.github.chrisbanes.photoview.PhotoView
@@ -101,6 +102,7 @@ fun <T> T.makeCaptionDialog(existingDescription: String?,
     // size. Maybe we should limit the size of CustomTarget
     Glide.with(this)
             .load(previewUri)
+            .downsample(DownsampleStrategy.CENTER_INSIDE)
             .into(object : CustomTarget<Drawable>(4096, 4096) {
                 override fun onLoadCleared(placeholder: Drawable?) {
                     imageView.setImageDrawable(placeholder)


### PR DESCRIPTION
In #2149 I fixed crashes with too large images, but now I'm seeing even more crashes and I think it is because smaller images get upscaled.