### PR TITLE
fix LiveData nullability issues

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/announcements/AnnouncementsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/announcements/AnnouncementsViewModel.kt
@@ -67,7 +67,7 @@ class AnnouncementsViewModel @Inject constructor(
                     appDatabase.instanceDao().insertOrReplace(it)
                 }
                 .subscribe({
-                    emojisMutable.postValue(it.emojiList)
+                    emojisMutable.postValue(it.emojiList.orEmpty())
                 }, {
                     Log.w(TAG, "Failed to get custom emojis.", it)
                 })

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsRepository.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsRepository.kt
@@ -71,7 +71,7 @@ class ConversationsRepository @Inject constructor(val mastodonApi: MastodonApi, 
         // we are using a mutable live data to trigger refresh requests which eventually calls
         // refresh method and gets a new live data. Each refresh request by the user becomes a newly
         // dispatched data in refreshTrigger
-        val refreshTrigger = MutableLiveData<Unit>()
+        val refreshTrigger = MutableLiveData<Unit?>()
         val refreshState = Transformations.switchMap(refreshTrigger) {
             refresh(accountId, true)
         }

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/ReportViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/ReportViewModel.kt
@@ -37,8 +37,8 @@ class ReportViewModel @Inject constructor(
         private val eventHub: EventHub,
         private val statusesRepository: StatusesRepository) : RxAwareViewModel() {
 
-    private val navigationMutable = MutableLiveData<Screen>()
-    val navigation: LiveData<Screen> = navigationMutable
+    private val navigationMutable = MutableLiveData<Screen?>()
+    val navigation: LiveData<Screen?> = navigationMutable
 
     private val muteStateMutable = MutableLiveData<Resource<Boolean>>()
     val muteState: LiveData<Resource<Boolean>> = muteStateMutable
@@ -49,8 +49,8 @@ class ReportViewModel @Inject constructor(
     private val reportingStateMutable = MutableLiveData<Resource<Boolean>>()
     var reportingState: LiveData<Resource<Boolean>> = reportingStateMutable
 
-    private val checkUrlMutable = MutableLiveData<String>()
-    val checkUrl: LiveData<String> = checkUrlMutable
+    private val checkUrlMutable = MutableLiveData<String?>()
+    val checkUrl: LiveData<String?> = checkUrlMutable
 
     private val repoResult = MutableLiveData<BiListing<Status>>()
     val statuses: LiveData<PagedList<Status>> = Transformations.switchMap(repoResult) { it.pagedList }


### PR DESCRIPTION
There is a new lint inspection that tells you when you set `null` into non-null LiveData. This PR fixes the issues it reports.