### PR TITLE
Fix filtering timelines

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineViewModel.kt
@@ -451,9 +451,9 @@ class TimelineViewModel @Inject constructor(
             } else {
                 throw HttpException(response)
             }
-        }
+        }.toMutableList()
 
-        filterStatuses(statuses.toMutableList())
+        filterStatuses(statuses)
 
         return statuses
     }
@@ -530,7 +530,7 @@ class TimelineViewModel @Inject constructor(
         if (statuses.size > 1) {
             clearPlaceholdersForResponse(mutableStatusResponse)
             this.statuses.clear()
-            this.statuses.addAll(statuses.toViewData())
+            this.statuses.addAll(mutableStatusResponse.toViewData())
         }
     }
 


### PR DESCRIPTION
In two places, we were filtering a temporary copy of the list that was never applied.

~~This maybe also fixes the infinite loading placeholder? (because placeholders were also removed from a disposable copy)~~