### PR TITLE
Audio caption improvements

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
@@ -125,7 +125,10 @@ class ViewVideoFragment : ViewMediaFragment() {
             val videoWidth = mp.videoWidth.toFloat()
             val videoHeight = mp.videoHeight.toFloat()
 
-            if (containerWidth / containerHeight > videoWidth / videoHeight) {
+            if (isAudio) {
+                binding.videoView.layoutParams.height = 1
+                binding.videoView.layoutParams.width = ViewGroup.LayoutParams.MATCH_PARENT
+            } else if (containerWidth / containerHeight > videoWidth / videoHeight) {
                 binding.videoView.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
                 binding.videoView.layoutParams.width = ViewGroup.LayoutParams.WRAP_CONTENT
             } else {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
@@ -21,6 +21,7 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.text.method.ScrollingMovementMethod
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
@@ -79,6 +80,7 @@ class ViewVideoFragment : ViewMediaFragment() {
     ) {
         binding.mediaDescription.text = description
         binding.mediaDescription.visible(showingDescription)
+        binding.mediaDescription.movementMethod = ScrollingMovementMethod()
 
         binding.videoView.transitionName = url
         binding.videoView.setVideoPath(url)

--- a/app/src/main/res/layout/fragment_view_video.xml
+++ b/app/src/main/res/layout/fragment_view_video.xml
@@ -20,6 +20,7 @@
         android:textAlignment="center"
         android:textColor="#eee"
         android:textSize="?attr/status_text_medium"
+        android:scrollbars="vertical"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Some media description" />
 

--- a/app/src/main/res/layout/item_media_preview.xml
+++ b/app/src/main/res/layout/item_media_preview.xml
@@ -141,6 +141,8 @@
             android:importantForAccessibility="no"
             android:textSize="?attr/status_text_medium"
             android:visibility="gone"
+            android:maxLines="10"
+            android:ellipsize="end"
             app:drawableTint="?android:attr/textColorTertiary"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -155,6 +157,8 @@
             android:importantForAccessibility="no"
             android:textSize="?attr/status_text_medium"
             android:visibility="gone"
+            android:maxLines="10"
+            android:ellipsize="end"
             app:drawableTint="?android:attr/textColorTertiary"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/status_media_label_0" />
@@ -169,6 +173,8 @@
             android:importantForAccessibility="no"
             android:textSize="?attr/status_text_medium"
             android:visibility="gone"
+            android:maxLines="10"
+            android:ellipsize="end"
             app:drawableTint="?android:attr/textColorTertiary"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/status_media_label_1" />
@@ -183,6 +189,8 @@
             android:importantForAccessibility="no"
             android:textSize="?attr/status_text_medium"
             android:visibility="gone"
+            android:maxLines="10"
+            android:ellipsize="end"
             app:drawableTint="?android:attr/textColorTertiary"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/status_media_label_2" />


### PR DESCRIPTION
- Descriptions for audio attachments are now shown in the media player
- Descriptions for audio and video attachments are now scrollable
- Media labels embedded in statuses are constrained to 10 lines (this doesn't affect the long-press popup)

Before:

![status-label-before](https://user-images.githubusercontent.com/142250/124581960-de67e480-de51-11eb-9284-b94387b84a3e.png) ![viewer-before](https://user-images.githubusercontent.com/142250/124581962-df007b00-de51-11eb-9254-e45af49a4710.png)


After:

![status-label-after](https://user-images.githubusercontent.com/142250/124582019-eb84d380-de51-11eb-8b5d-ccf25da68b3b.png) ![viewer-after](https://user-images.githubusercontent.com/142250/124582022-eb84d380-de51-11eb-9829-7fa0fa2901d8.png)
