### PR TITLE
Rick-roll users of baraag.net

### DIFF
--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -145,6 +145,7 @@
         <item>gab.com</item>
         <item>gab.ai</item>
         <item>spinster.xyz</item>
+        <item>baraag.net</item>
     </string-array>
 
     <string name="rick_roll_url">https://www.youtube.com/watch?v=dQw4w9WgXcQ</string>


### PR DESCRIPTION
Tusky contains a blacklist of instances which they believe to be unethical or host unethical content. In the interest of ethics, I've added baraag.net to the blacklist. This is a website where you can find [realistic 3D rendered images of adult men raping infant babies](https://baraag.net/@napg).

Since spinster.xyz, a website where women have the freedom to speak freely regarding issues of sex and gender, has been blacklisted, baraag.net surely meets the requirements of being blacklisted.