### PR TITLE
filter messages by also looking at media descriptions

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/network/FilterModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/FilterModel.kt
@@ -29,9 +29,16 @@ class FilterModel @Inject constructor() {
         }
 
         val spoilerText = status.actionableStatus.spoilerText
+        val attachmentsDescriptions = status.attachments
+            .mapNotNull { it.description }
+
         return (
             matcher.reset(status.actionableStatus.content).find() ||
-                spoilerText.isNotEmpty() && matcher.reset(spoilerText).find()
+                (spoilerText.isNotEmpty() && matcher.reset(spoilerText).find()) ||
+                (
+                    attachmentsDescriptions.isNotEmpty() &&
+                        matcher.reset(attachmentsDescriptions.joinToString("\n")).find()
+                    )
             )
     }
 

--- a/app/src/test/java/com/keylesspalace/tusky/FilterTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/FilterTest.kt
@@ -2,6 +2,7 @@ package com.keylesspalace.tusky
 
 import android.text.SpannedString
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.keylesspalace.tusky.entity.Attachment
 import com.keylesspalace.tusky.entity.Filter
 import com.keylesspalace.tusky.entity.Poll
 import com.keylesspalace.tusky.entity.PollOption
@@ -14,6 +15,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.util.ArrayList
 import java.util.Date
 
 @Config(sdk = [28])
@@ -126,6 +128,19 @@ class FilterTest {
     }
 
     @Test
+    fun shouldFilter_whenMediaDescriptionDoesMatch() {
+        assertTrue(
+            filterModel.shouldFilterStatus(
+                mockStatus(
+                    content = "should not be filtered",
+                    spoilerText = "should not be filtered",
+                    attachmentsDescriptions = listOf("should not be filtered", "badWord"),
+                )
+            )
+        )
+    }
+
+    @Test
     fun shouldFilterPartialWord_whenWholeWordFilterContainsNonAlphanumericCharacters() {
         assertTrue(
             filterModel.shouldFilterStatus(
@@ -137,7 +152,8 @@ class FilterTest {
     private fun mockStatus(
         content: String = "",
         spoilerText: String = "",
-        pollOptions: List<String>? = null
+        pollOptions: List<String>? = null,
+        attachmentsDescriptions: List<String>? = null
     ): Status {
         return Status(
             id = "123",
@@ -157,7 +173,21 @@ class FilterTest {
             sensitive = false,
             spoilerText = spoilerText,
             visibility = Status.Visibility.PUBLIC,
-            attachments = arrayListOf(),
+            attachments = if (attachmentsDescriptions != null) {
+                ArrayList(
+                    attachmentsDescriptions.map {
+                        Attachment(
+                            id = "1234",
+                            url = "",
+                            previewUrl = null,
+                            meta = null,
+                            type = Attachment.Type.IMAGE,
+                            description = it,
+                            blurhash = null
+                        )
+                    }
+                )
+            } else arrayListOf(),
             mentions = listOf(),
             application = null,
             pinned = false,


### PR DESCRIPTION
Fix #2284

I have not tried it yet, I’ll see if I can test that quickly.