### PR TITLE
fix muting accounts

### DIFF
--- a/app/src/main/res/raw/keep.xml
+++ b/app/src/main/res/raw/keep.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools"
-    tools:keep="@drawable/ic_local_24dp,@drawable/ic_hashtag" />
+    tools:keep="@drawable/ic_local_24dp,@drawable/ic_hashtag,@layout/dialog_mute_account" />


### PR DESCRIPTION
For some reason the dialog layout is removed during the build which causes the app to crash when muting 

closes https://github.com/tuskyapp/Tusky/issues/2233