### PR TITLE
Fix some weird behavior when clicking links in statuses

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/BottomSheetActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/BottomSheetActivity.kt
@@ -180,6 +180,8 @@ abstract class BottomSheetActivity : BaseActivity() {
 // https://friendica.foo.bar/profile/user
 // https://friendica.foo.bar/display/d4643c42-3ae0-4b73-b8b0-c725f5819207
 // https://misskey.foo.bar/notes/83w6r388br (always lowercase)
+// https://pixelfed.social/p/connyduck/391263492998670833
+// https://pixelfed.social/connyduck
 fun looksLikeMastodonUrl(urlString: String): Boolean {
     val uri: URI
     try {
@@ -203,7 +205,9 @@ fun looksLikeMastodonUrl(urlString: String): Boolean {
         path.matches("^/objects/[-a-f0-9]+$".toRegex()) ||
         path.matches("^/notes/[a-z0-9]+$".toRegex()) ||
         path.matches("^/display/[-a-f0-9]+$".toRegex()) ||
-        path.matches("^/profile/\\w+$".toRegex())
+        path.matches("^/profile/\\w+$".toRegex()) ||
+        path.matches("^/p/\\w+/\\d+$".toRegex()) ||
+        path.matches("^/\\w+$".toRegex())
 }
 
 enum class PostLookupFallbackBehavior {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -771,7 +771,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             }
 
             if (cardView != null) {
-                setupCard(status, statusDisplayOptions.cardViewMode(), statusDisplayOptions);
+                setupCard(status, statusDisplayOptions.cardViewMode(), statusDisplayOptions, listener);
             }
 
             setupButtons(listener, actionable.getAccount().getId(), status.getContent().toString(),
@@ -1034,7 +1034,12 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         return pollDescription.getContext().getString(R.string.poll_info_format, votesText, pollDurationInfo);
     }
 
-    protected void setupCard(StatusViewData.Concrete status, CardViewMode cardViewMode, StatusDisplayOptions statusDisplayOptions) {
+    protected void setupCard(
+            StatusViewData.Concrete status,
+            CardViewMode cardViewMode,
+            StatusDisplayOptions statusDisplayOptions,
+            final StatusActionListener listener
+    ) {
         final Card card = status.getActionable().getCard();
         if (cardViewMode != CardViewMode.NONE &&
                 status.getActionable().getAttachments().size() == 0 &&
@@ -1125,7 +1130,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                 cardImage.setImageResource(R.drawable.card_image_placeholder);
             }
 
-            View.OnClickListener visitLink = v -> LinkHelper.openLink(card.getUrl(), v.getContext());
+            View.OnClickListener visitLink = v -> listener.onViewUrl(card.getUrl());
             View.OnClickListener openImage = v -> cardView.getContext().startActivity(ViewMediaActivity.newSingleImageIntent(cardView.getContext(), card.getEmbed_url()));
 
             cardInfo.setOnClickListener(visitLink);

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
@@ -106,7 +106,7 @@ class StatusDetailedViewHolder extends StatusBaseViewHolder {
                                    StatusDisplayOptions statusDisplayOptions,
                                    @Nullable Object payloads) {
         super.setupWithStatus(status, listener, statusDisplayOptions, payloads);
-        setupCard(status, CardViewMode.FULL_WIDTH, statusDisplayOptions); // Always show card for detailed status
+        setupCard(status, CardViewMode.FULL_WIDTH, statusDisplayOptions, listener); // Always show card for detailed status
         if (payloads == null) {
 
             if (!statusDisplayOptions.hideStats()) {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -320,6 +320,19 @@ public final class ViewThreadFragment extends SFragment implements
     }
 
     @Override
+    public void onViewUrl(String url) {
+        Status status = null;
+        if (!statuses.isEmpty()) {
+            status = statuses.get(statusIndex);
+        }
+        if (status != null && status.getUrl().equals(url)) {
+            // already viewing the status with this url
+            return;
+        }
+        super.onViewUrl(url);
+    }
+
+    @Override
     public void onOpenReblog(int position) {
         // there should be no reblogs in the thread but let's implement it to be sure
         super.openReblog(statuses.get(position));

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -60,6 +60,7 @@ import com.keylesspalace.tusky.network.FilterModel;
 import com.keylesspalace.tusky.network.MastodonApi;
 import com.keylesspalace.tusky.settings.PrefKeys;
 import com.keylesspalace.tusky.util.CardViewMode;
+import com.keylesspalace.tusky.util.LinkHelper;
 import com.keylesspalace.tusky.util.ListStatusAccessibilityDelegate;
 import com.keylesspalace.tusky.util.PairedList;
 import com.keylesspalace.tusky.util.StatusDisplayOptions;
@@ -327,6 +328,9 @@ public final class ViewThreadFragment extends SFragment implements
         }
         if (status != null && status.getUrl().equals(url)) {
             // already viewing the status with this url
+            // probably just a preview federated and the user is clicking again to view more -> open the browser
+            // this can happen with some friendica statuses
+            LinkHelper.openLink(url, requireContext());
             return;
         }
         super.onViewUrl(url);


### PR DESCRIPTION
There is some weird behavior in some edgecases:

1) Apparently there are statuses that contain links to themselves, so one can open the detail view in an infinite recursion. Example: https://anonsys.net/display/bf69967c-1961-efc6-22a9-867784751114
2) Pixelfed links are opened in the browser. Example: https://mastodon.social/@ConnyDuck/107684681310479962
3) Clicking on a card will always open the browser, even when the link could be opened in Tusky

This PR fixes those problems and cleans `BottomSheetActivityTests` up a bit