### PR TITLE
Fix disappearing placeholders

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
@@ -53,11 +53,19 @@ class CachedTimelineRemoteMediator(
 
         try {
             var dbEmpty = false
+
+            val topPlaceholderId = if (loadType == LoadType.REFRESH) {
+                timelineDao.getTopPlaceholderId(activeAccount.id)
+            } else {
+                null  // don't execute the query if it is not needed
+            }
+
             if (!initialRefresh && loadType == LoadType.REFRESH) {
                 val topId = timelineDao.getTopId(activeAccount.id)
                 topId?.let { cachedTopId ->
                     val statusResponse = api.homeTimeline(
                         maxId = cachedTopId,
+                        sinceId = topPlaceholderId, // so already existing placeholders don't get accidentally overwritten
                         limit = state.config.pageSize
                     ).await()
 
@@ -74,7 +82,7 @@ class CachedTimelineRemoteMediator(
 
             val statusResponse = when (loadType) {
                 LoadType.REFRESH -> {
-                    api.homeTimeline(limit = state.config.pageSize).await()
+                    api.homeTimeline(sinceId = topPlaceholderId, limit = state.config.pageSize).await()
                 }
                 LoadType.PREPEND -> {
                     return MediatorResult.Success(endOfPaginationReached = true)

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
@@ -57,7 +57,7 @@ class CachedTimelineRemoteMediator(
             val topPlaceholderId = if (loadType == LoadType.REFRESH) {
                 timelineDao.getTopPlaceholderId(activeAccount.id)
             } else {
-                null  // don't execute the query if it is not needed
+                null // don't execute the query if it is not needed
             }
 
             if (!initialRefresh && loadType == LoadType.REFRESH) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -128,7 +128,9 @@ class CachedTimelineViewModel @Inject constructor(
 
                 timelineDao.insertStatus(Placeholder(placeholderId, loading = true).toEntity(activeAccount.id))
 
-                val response = api.homeTimeline(maxId = placeholderId.inc(), limit = 20).await()
+                val nextPlaceholderId = timelineDao.getNextPlaceholderIdAfter(activeAccount.id, placeholderId)
+
+                val response = api.homeTimeline(maxId = placeholderId.inc(), sinceId = nextPlaceholderId, limit = 20).await()
 
                 val statuses = response.body()
                 if (!response.isSuccessful || statuses == null) {

--- a/app/src/main/java/com/keylesspalace/tusky/db/TimelineDao.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/TimelineDao.kt
@@ -142,4 +142,7 @@ AND timelineUserId = :accountId
 
     @Query("SELECT serverId FROM TimelineStatusEntity WHERE timelineUserId = :accountId ORDER BY LENGTH(serverId) DESC, serverId DESC LIMIT 1")
     abstract suspend fun getTopId(accountId: Long): String?
+
+    @Query("SELECT serverId FROM TimelineStatusEntity WHERE timelineUserId = :accountId AND authorServerId IS NULL AND (LENGTH(:serverId) > LENGTH(serverId) OR (LENGTH(:serverId) = LENGTH(serverId) AND :serverId > serverId)) ORDER BY LENGTH(serverId) DESC, serverId DESC LIMIT 1")
+    abstract suspend fun getNextPlaceholderIdAfter(accountId: Long, serverId: String): String?
 }

--- a/app/src/main/java/com/keylesspalace/tusky/db/TimelineDao.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/TimelineDao.kt
@@ -143,6 +143,9 @@ AND timelineUserId = :accountId
     @Query("SELECT serverId FROM TimelineStatusEntity WHERE timelineUserId = :accountId ORDER BY LENGTH(serverId) DESC, serverId DESC LIMIT 1")
     abstract suspend fun getTopId(accountId: Long): String?
 
+    @Query("SELECT serverId FROM TimelineStatusEntity WHERE timelineUserId = :accountId AND authorServerId IS NULL ORDER BY LENGTH(serverId) DESC, serverId DESC LIMIT 1")
+    abstract suspend fun getTopPlaceholderId(accountId: Long): String?
+
     @Query("SELECT serverId FROM TimelineStatusEntity WHERE timelineUserId = :accountId AND authorServerId IS NULL AND (LENGTH(:serverId) > LENGTH(serverId) OR (LENGTH(:serverId) = LENGTH(serverId) AND :serverId > serverId)) ORDER BY LENGTH(serverId) DESC, serverId DESC LIMIT 1")
     abstract suspend fun getNextPlaceholderIdAfter(accountId: Long, serverId: String): String?
 }

--- a/app/src/test/java/com/keylesspalace/tusky/components/timeline/StatusMocker.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/timeline/StatusMocker.kt
@@ -77,3 +77,12 @@ fun mockStatusEntityWithAccount(
         )
     }
 }
+
+fun mockPlaceholderEntityWithAccount(
+    id: String,
+    userId: Long = 1,
+    ): TimelineStatusWithAccount {
+    return TimelineStatusWithAccount().apply {
+        status = Placeholder(id, false).toEntity(userId)
+    }
+}

--- a/app/src/test/java/com/keylesspalace/tusky/components/timeline/StatusMocker.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/timeline/StatusMocker.kt
@@ -81,7 +81,7 @@ fun mockStatusEntityWithAccount(
 fun mockPlaceholderEntityWithAccount(
     id: String,
     userId: Long = 1,
-    ): TimelineStatusWithAccount {
+): TimelineStatusWithAccount {
     return TimelineStatusWithAccount().apply {
         status = Placeholder(id, false).toEntity(userId)
     }

--- a/app/src/test/java/com/keylesspalace/tusky/db/TimelineDaoTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/db/TimelineDaoTest.kt
@@ -6,6 +6,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.gson.Gson
 import com.keylesspalace.tusky.appstore.CacheUpdater
+import com.keylesspalace.tusky.components.timeline.Placeholder
+import com.keylesspalace.tusky.components.timeline.toEntity
 import com.keylesspalace.tusky.entity.Status
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -219,26 +221,28 @@ class TimelineDaoTest {
     @Test
     fun `should return correct topId`() = runBlocking {
 
-        val status1 = makeStatus(
-            statusId = 4,
-            accountId = 1,
-            domain = "mastodon.test",
-            authorServerId = "1"
-        )
-        val status2 = makeStatus(
-            statusId = 33,
-            accountId = 1,
-            domain = "mastodon.test",
-            authorServerId = "2"
-        )
-        val status3 = makeStatus(
-            statusId = 22,
-            accountId = 1,
-            domain = "mastodon.test",
-            authorServerId = "2"
+        val statusData = listOf(
+            makeStatus(
+                statusId = 4,
+                accountId = 1,
+                domain = "mastodon.test",
+                authorServerId = "1"
+            ),
+            makeStatus(
+                statusId = 33,
+                accountId = 1,
+                domain = "mastodon.test",
+                authorServerId = "2"
+            ),
+            makeStatus(
+                statusId = 22,
+                accountId = 1,
+                domain = "mastodon.test",
+                authorServerId = "2"
+            )
         )
 
-        for ((status, author, reblogAuthor) in listOf(status1, status2, status3)) {
+        for ((status, author, reblogAuthor) in statusData) {
             timelineDao.insertAccount(author)
             reblogAuthor?.let {
                 timelineDao.insertAccount(it)
@@ -247,6 +251,41 @@ class TimelineDaoTest {
         }
 
         assertEquals("33", timelineDao.getTopId(1))
+    }
+
+    @Test
+    fun `should return correct placeholderId`() = runBlocking {
+
+        val statusData = listOf(
+            makeStatus(statusId = 10),
+            makePlaceholder(id = 8),
+            makeStatus(statusId = 7),
+            makeStatus(statusId = 5),
+            makePlaceholder(id = 4),
+            makeStatus(statusId = 2)
+        )
+
+        for ((status, author, reblogAuthor) in statusData) {
+            author?.let {
+                timelineDao.insertAccount(it)
+            }
+            reblogAuthor?.let {
+                timelineDao.insertAccount(it)
+            }
+            timelineDao.insertStatus(status)
+        }
+
+        val loadParams: PagingSource.LoadParams<Int> = PagingSource.LoadParams.Refresh(null, 100, false)
+
+        val statusesAccount1 = (timelineDao.getStatusesForAccount(1).load(loadParams) as PagingSource.LoadResult.Page).data
+
+        statusesAccount1.forEach{
+            println("${it.status.serverId} ${it.status.authorServerId}")
+        }
+
+        assertEquals("8", timelineDao.getNextPlaceholderIdAfter(1, "10"))
+        assertEquals("4", timelineDao.getNextPlaceholderIdAfter(1, "7"))
+        assertNull(timelineDao.getNextPlaceholderIdAfter(1, "2"))
     }
 
     private fun makeStatus(
@@ -315,6 +354,14 @@ class TimelineDaoTest {
             pinned = false
         )
         return Triple(status, author, reblogAuthor)
+    }
+
+    private fun makePlaceholder(
+        accountId: Long = 1,
+        id: Long
+    ): Triple<TimelineStatusEntity, TimelineAccountEntity?, TimelineAccountEntity?> {
+        val placeholder = Placeholder(id.toString(), false).toEntity(accountId)
+        return Triple(placeholder, null, null)
     }
 
     private fun assertStatuses(


### PR DESCRIPTION
A disappearing placeholder could be reproduced like this on the home timeline:

Load a lot of new statuses so you get a full page (30 statuses) and a placeholder displayed.
One or more of the just loaded statuses gets deleted.
Refresh the timeline -> the deleted status disappears, but so does the placeholder