### PR TITLE
Fix crash in TimelineFragment

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
@@ -208,9 +208,11 @@ class TimelineFragment :
             override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
                 if (positionStart == 0 && adapter.itemCount != itemCount) {
                     binding.recyclerView.post {
-                        if (isSwipeToRefreshEnabled) {
-                            binding.recyclerView.scrollBy(0, Utils.dpToPx(requireContext(), -30))
-                        } else binding.recyclerView.scrollToPosition(0)
+                        if (getView() != null) {
+                            if (isSwipeToRefreshEnabled) {
+                                binding.recyclerView.scrollBy(0, Utils.dpToPx(requireContext(), -30))
+                            } else binding.recyclerView.scrollToPosition(0)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Had 2 occurences of this in the Play console, could not reproduce it, but since `getViewLifecycleOwner` says it fails when `getView` returns null, I am pretty sure this fixes it.

```
java.lang.IllegalStateException: 
  at androidx.fragment.app.Fragment.getViewLifecycleOwner (Fragment.java:361)
  at com.keylesspalace.tusky.util.FragmentViewBindingDelegate.getValue (ViewBindingExtensions.kt:57)
  at com.keylesspalace.tusky.components.timeline.TimelineFragment.getBinding (TimelineFragment.kt:98)
  at com.keylesspalace.tusky.components.timeline.TimelineFragment.access$getBinding (TimelineFragment.java:73)
  at com.keylesspalace.tusky.components.timeline.TimelineFragment$onViewCreated$2.onItemRangeInserted$lambda-0 (TimelineFragment.java:212)
  at androidx.core.widget.ContentLoadingProgressBar$$InternalSyntheticLambda$0$493ea19ec193ccae637d28862add574c7b1024af3755002071d3b7b355e290ae$0.run$bridge (ContentLoadingProgressBar.java)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:201)
  at android.os.Looper.loop (Looper.java:288)
  at android.app.ActivityThread.main (ActivityThread.java:7839)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:548)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1003)
```