### PR TITLE
Fix comparing statuses and diffing in NotificationsFragment

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/entity/Status.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Status.kt
@@ -55,10 +55,11 @@ data class Status(
     val actionableStatus: Status
         get() = reblog ?: this
 
-    /** Helper for Java */
+    /** Helpers for Java */
+    fun copyWithFavourited(favourited: Boolean): Status = copy(favourited = favourited)
+    fun copyWithReblogged(reblogged: Boolean): Status = copy(reblogged = reblogged)
+    fun copyWithBookmarked(bookmarked: Boolean): Status = copy(bookmarked = bookmarked)
     fun copyWithPoll(poll: Poll?): Status = copy(poll = poll)
-
-    /** Helper for Java */
     fun copyWithPinned(pinned: Boolean): Status = copy(pinned = pinned)
 
     enum class Visibility(val num: Int) {
@@ -145,18 +146,6 @@ data class Status(
             }
         }
         return builder.toString()
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || javaClass != other.javaClass) return false
-
-        val status = other as Status?
-        return id == status?.id
-    }
-
-    override fun hashCode(): Int {
-        return id.hashCode()
     }
 
     data class Mention(

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -412,10 +412,7 @@ public class NotificationsFragment extends SFragment implements
     }
 
     private void setReblogForStatus(String statusId, boolean reblog) {
-        updateStatus(statusId, (s) -> {
-            s.setReblogged(reblog);
-            return s;
-        });
+        updateStatus(statusId, (s) -> s.copyWithReblogged(reblog));
     }
 
     @Override
@@ -434,10 +431,7 @@ public class NotificationsFragment extends SFragment implements
     }
 
     private void setFavouriteForStatus(String statusId, boolean favourite) {
-        updateStatus(statusId, (s) -> {
-            s.setFavourited(favourite);
-            return s;
-        });
+        updateStatus(statusId, (s) -> s.copyWithFavourited(favourite));
     }
 
     @Override
@@ -456,10 +450,7 @@ public class NotificationsFragment extends SFragment implements
     }
 
     private void setBookmarkForStatus(String statusId, boolean bookmark) {
-        updateStatus(statusId, (s) -> {
-            s.setBookmarked(bookmark);
-            return s;
-        });
+        updateStatus(statusId, (s) -> s.copyWithBookmarked(bookmark));
     }
 
     public void onVoteInPoll(int position, @NonNull List<Integer> choices) {
@@ -519,10 +510,7 @@ public class NotificationsFragment extends SFragment implements
     }
 
     private void setPinForStatus(String statusId, boolean pinned) {
-        updateStatus(statusId, status -> {
-            status.copyWithPinned(pinned);
-            return status;
-        });
+        updateStatus(statusId, status -> status.copyWithPinned(pinned));
     }
 
     @Override


### PR DESCRIPTION
I don't remember why equals/hashcode was overwritten in `Status` 🤔 

Anyway, _something_ in #2238 broke the diffing in NotificationsFragment, but I don't yet know what. Actually it is weird that it works in other places.

closes https://github.com/tuskyapp/Tusky/issues/2306