### PR TITLE
fix horizontal insets of AccountActivity

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
@@ -258,8 +258,10 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
             val toolbarParams = binding.accountToolbar.layoutParams as ViewGroup.MarginLayoutParams
             toolbarParams.topMargin = top
 
+            val right = insets.getInsets(systemBars()).right
             val bottom = insets.getInsets(systemBars()).bottom
-            binding.accountCoordinatorLayout.updatePadding(bottom = bottom)
+            val left = insets.getInsets(systemBars()).left
+            binding.accountCoordinatorLayout.updatePadding(right = right, bottom = bottom, left = left)
 
             WindowInsetsCompat.CONSUMED
         }


### PR DESCRIPTION
In #2267 I fixed this for the vertical orientation, but it can happen in horizontal as well 😅 

![Screenshot_20220208_215042](https://user-images.githubusercontent.com/10157047/153073456-9c9a0d0e-ea79-41b3-998f-2b77c4c34391.png)

