### PR TITLE
add additional R8 rules so conversations work again

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -51,6 +51,8 @@
     public *;
 }
 
+-keepclassmembers class com.keylesspalace.tusky.components.conversation.ConversationAccountEntity { *; }
+
 # https://github.com/google/gson/blob/master/examples/android-proguard-example/proguard.cfg
 
 # Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
@@ -70,6 +72,10 @@
 -keep,allowobfuscation,allowshrinking class kotlin.collections.List
 -keep,allowobfuscation,allowshrinking class kotlin.collections.Map
 -keep,allowobfuscation,allowshrinking class retrofit2.Call
+
+# https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md#retrofit
+-keepattributes Signature
+-keep class kotlin.coroutines.Continuation
 
 # preserve line numbers for crash reporting
 -keepattributes SourceFile,LineNumberTable


### PR DESCRIPTION
Issue 1: `suspend` functions in `MastodonApi`were stripped of their type information
Issue 2: `ConversationAccountEntity` was minified so Gson failed to create instances of it

![Screenshot_20220209_171139](https://user-images.githubusercontent.com/10157047/153241731-fc1eb3ab-0a44-43a3-b83b-fe6b01bffb7f.png)

