### PR TITLE
use POST api/v2/media to upload media

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -185,7 +185,7 @@ class ComposeViewModel @Inject constructor(
                         is UploadEvent.ProgressEvent ->
                             item.copy(uploadPercent = event.percentage)
                         is UploadEvent.FinishedEvent ->
-                            item.copy(id = event.attachment.id, uploadPercent = -1)
+                            item.copy(id = event.mediaId, uploadPercent = -1)
                     }
                     synchronized(media) {
                         val mediaValue = media.value!!

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
@@ -25,7 +25,6 @@ import androidx.core.net.toUri
 import com.keylesspalace.tusky.BuildConfig
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.components.compose.ComposeActivity.QueuedMedia
-import com.keylesspalace.tusky.entity.Attachment
 import com.keylesspalace.tusky.network.MastodonApi
 import com.keylesspalace.tusky.network.ProgressRequestBody
 import com.keylesspalace.tusky.util.MEDIA_SIZE_UNKNOWN
@@ -45,7 +44,7 @@ import javax.inject.Inject
 
 sealed class UploadEvent {
     data class ProgressEvent(val percentage: Int) : UploadEvent()
-    data class FinishedEvent(val attachment: Attachment) : UploadEvent()
+    data class FinishedEvent(val mediaId: String) : UploadEvent()
 }
 
 fun createNewImageFile(context: Context): File {
@@ -183,8 +182,8 @@ class MediaUploader @Inject constructor(
 
             val uploadDisposable = mastodonApi.uploadMedia(body, description)
                 .subscribe(
-                    { attachment ->
-                        emitter.onNext(UploadEvent.FinishedEvent(attachment))
+                    { result ->
+                        emitter.onNext(UploadEvent.FinishedEvent(result.id))
                         emitter.onComplete()
                     },
                     { e ->

--- a/app/src/main/java/com/keylesspalace/tusky/entity/MediaUploadResult.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/MediaUploadResult.kt
@@ -1,0 +1,9 @@
+package com.keylesspalace.tusky.entity
+
+/**
+ * The same as Attachment, except the url is null - see https://docs.joinmastodon.org/methods/statuses/media/
+ * We are only interested in the id, so other attributes are omitted
+ */
+data class MediaUploadResult(
+    val id: String
+)

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -28,6 +28,7 @@ import com.keylesspalace.tusky.entity.IdentityProof
 import com.keylesspalace.tusky.entity.Instance
 import com.keylesspalace.tusky.entity.Marker
 import com.keylesspalace.tusky.entity.MastoList
+import com.keylesspalace.tusky.entity.MediaUploadResult
 import com.keylesspalace.tusky.entity.NewStatus
 import com.keylesspalace.tusky.entity.Notification
 import com.keylesspalace.tusky.entity.Poll
@@ -142,11 +143,11 @@ interface MastodonApi {
     fun clearNotifications(): Single<ResponseBody>
 
     @Multipart
-    @POST("api/v1/media")
+    @POST("api/v2/media")
     fun uploadMedia(
         @Part file: MultipartBody.Part,
         @Part description: MultipartBody.Part? = null
-    ): Single<Attachment>
+    ): Single<MediaUploadResult>
 
     @FormUrlEncoded
     @PUT("api/v1/media/{mediaId}")


### PR DESCRIPTION
Why didn't we do this sooner 😲 
v2 is async and should be much faster.
Hopefully fixes stuff like #995 
I think v2 is only available since Mastodon 3.1.3