### PR TITLE
fix crash in drafts caused by minification of DraftAttachment

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -47,11 +47,12 @@
     public *;
 }
 
+-keepclassmembers class com.keylesspalace.tusky.components.conversation.ConversationAccountEntity { *; }
+-keepclassmembers class com.keylesspalace.tusky.db.DraftAttachment { *; }
+
 -keep enum com.keylesspalace.tusky.db.DraftAttachment$Type {
     public *;
 }
-
--keepclassmembers class com.keylesspalace.tusky.components.conversation.ConversationAccountEntity { *; }
 
 # https://github.com/google/gson/blob/master/examples/android-proguard-example/proguard.cfg
 

--- a/app/src/main/java/com/keylesspalace/tusky/db/DraftEntity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/DraftEntity.kt
@@ -21,6 +21,7 @@ import androidx.core.net.toUri
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
+import com.google.gson.annotations.SerializedName
 import com.keylesspalace.tusky.entity.NewPoll
 import com.keylesspalace.tusky.entity.Status
 import kotlinx.parcelize.Parcelize
@@ -40,11 +41,16 @@ data class DraftEntity(
     val failedToSend: Boolean
 )
 
+/**
+ * The alternate names are here because we accidentally published versions were DraftAttachment was minified
+ * Tusky 15: uriString = e, description = f, type = g
+ * Tusky 16 beta: uriString = i, description = j, type = k
+ */
 @Parcelize
 data class DraftAttachment(
-    val uriString: String,
-    val description: String?,
-    val type: Type
+    @SerializedName(value="uriString", alternate=["e", "i"]) val uriString: String,
+    @SerializedName(value="description", alternate=["f", "j"]) val description: String?,
+    @SerializedName(value="type", alternate=["g", "k"]) val type: Type
 ) : Parcelable {
     val uri: Uri
         get() = uriString.toUri()


### PR DESCRIPTION
This is very ugly, but at least it won't loose any drafts.
Thx @mal0ki for reporting
This needs to be included in Tusky 16