### PR TITLE
fix some mentions not being opened in Tusky

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.java
@@ -87,17 +87,11 @@ public class LinkHelper {
                     public void onClick(@NonNull View widget) { listener.onViewTag(tag); }
                 };
             } else if (text.charAt(0) == '@' && mentions != null && mentions.size() > 0) {
-                String accountUsername = text.subSequence(1, text.length()).toString();
-                /* There may be multiple matches for users on different instances with the same
-                 * username. If a match has the same domain we know it's for sure the same, but if
-                 * that can't be found then just go with whichever one matched last. */
                 String id = null;
                 for (Status.Mention mention : mentions) {
-                    if (mention.getLocalUsername().equalsIgnoreCase(accountUsername)) {
+                    if (mention.getUrl().equals(span.getURL())) {
                         id = mention.getId();
-                        if (mention.getUrl().contains(getDomain(span.getURL()))) {
-                            break;
-                        }
+                        break;
                     }
                 }
                 if (id != null) {


### PR DESCRIPTION
I don't really know what is going on here, maybe Mastodon changed something in how they render Mentions or it never worked.

Anyway, the thing is that fully qualified mentions (e.g. `@connyduck@chaos.social`) would not open directly, but were looked up via the search first (that is why we only noticed when somebody made such a mention that failed the `looksLikeMastodonUrl` in `BottonSheetActivity`).

Thx for reporting, @mal0ki 