### PR TITLE
increase default poll max option chars from 25 to 50

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -505,7 +505,7 @@ fun <T> mutableLiveData(default: T) = MutableLiveData<T>().apply { value = defau
 
 const val DEFAULT_CHARACTER_LIMIT = 500
 private const val DEFAULT_MAX_OPTION_COUNT = 4
-private const val DEFAULT_MAX_OPTION_LENGTH = 25
+private const val DEFAULT_MAX_OPTION_LENGTH = 50
 
 data class ComposeInstanceParams(
     val maxChars: Int,


### PR DESCRIPTION
25 is old Mastodon default, it’s 50 since almost two years now:

- https://github.com/mastodon/mastodon/releases/tag/v3.1.3
- https://github.com/mastodon/mastodon/commit/37b3985bfac5ffdc8e452f92869dcdefb5c92594#diff-fe4ba091ed185315779c8bb492666772a32609b8f200134ce11542d86e1ed5cfR5

So the only problem could be very old Mastodon instances, or people decreasing their Mastodon instance poll max option chars, but it’s not very likely.

I know it’s late but I hope it could land in Tusky 16, especially because it’s such a small change and because it’s so annoying to be limited by the old limit of 25 characters on Tusky.

Related: #2338 