### PR TITLE
fix duplicate detail status

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -499,7 +499,7 @@ public final class ViewThreadFragment extends SFragment implements
     private int setStatus(Status status) {
         if (statuses.size() > 0
                 && statusIndex < statuses.size()
-                && statuses.get(statusIndex).equals(status)) {
+                && statuses.get(statusIndex).getId().equals(status.getId())) {
             // Do not add this status on refresh, it's already in there.
             statuses.set(statusIndex, status);
             return statusIndex;


### PR DESCRIPTION
Now I know why the custom Status `equals` code was there that I removed in #2318
Note: The code in ViewThreadFragment is old and has a lot of other problems and this is only another hacky patch. I will rewrite it with Kotlin/coroutines/ViewModel as soon as possible but I don't want to delay Tusky 16 any longer.

Steps to reproduce: Open any status details, pull to refresh, the detailed status duplicates. It is kind of a race condition, sometimes one has to refresh multiple times for the duplicate to appear.