### PR TITLE
update Android Image Cropper and get rid of deprecated onActivityResult

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -168,7 +168,7 @@ dependencies {
     implementation "com.mikepenz:materialdrawer-iconics:$materialdrawerVersion"
     implementation 'com.mikepenz:google-material-typeface:4.0.0.2-kotlin@aar'
 
-    implementation "com.github.CanHub:Android-Image-Cropper:3.1.0"
+    implementation "com.github.CanHub:Android-Image-Cropper:4.1.0"
 
     implementation "de.c1710:filemojicompat:1.0.18"
 

--- a/app/src/main/java/com/keylesspalace/tusky/EditProfileActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/EditProfileActivity.kt
@@ -78,10 +78,10 @@ class EditProfileActivity : BaseActivity(), Injectable {
 
     private val cropImage = registerForActivityResult(CropImageContract()) { result ->
         if (result.isSuccessful) {
-            if (result.uriContent == viewModel.getAvatarUri(this)) {
-                viewModel.newAvatarPicked(this)
+            if (result.uriContent == viewModel.getAvatarUri()) {
+                viewModel.newAvatarPicked()
             } else {
-                viewModel.newHeaderPicked(this)
+                viewModel.newHeaderPicked()
             }
         } else {
             onPickFailure(result.error)
@@ -246,7 +246,7 @@ class EditProfileActivity : BaseActivity(), Injectable {
                         setRequestedSize(AVATAR_SIZE, AVATAR_SIZE)
                         setAspectRatio(AVATAR_SIZE, AVATAR_SIZE)
                         setImageSource(includeGallery = true, includeCamera = false)
-                        setOutputUri(viewModel.getAvatarUri(this@EditProfileActivity))
+                        setOutputUri(viewModel.getAvatarUri())
                         setOutputCompressFormat(Bitmap.CompressFormat.PNG)
                     }
                 )
@@ -257,7 +257,7 @@ class EditProfileActivity : BaseActivity(), Injectable {
                         setRequestedSize(HEADER_WIDTH, HEADER_HEIGHT)
                         setAspectRatio(HEADER_WIDTH, HEADER_HEIGHT)
                         setImageSource(includeGallery = true, includeCamera = false)
-                        setOutputUri(viewModel.getHeaderUri(this@EditProfileActivity))
+                        setOutputUri(viewModel.getHeaderUri())
                         setOutputCompressFormat(Bitmap.CompressFormat.PNG)
                     }
                 )
@@ -285,8 +285,7 @@ class EditProfileActivity : BaseActivity(), Injectable {
             binding.displayNameEditText.text.toString(),
             binding.noteEditText.text.toString(),
             binding.lockedCheckBox.isChecked,
-            accountFieldEditAdapter.getFieldData(),
-            this
+            accountFieldEditAdapter.getFieldData()
         )
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/EditProfileActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/EditProfileActivity.kt
@@ -215,6 +215,8 @@ class EditProfileActivity : BaseActivity(), Injectable {
         liveData.observe(
             this
         ) { imageUri ->
+
+            // skipping all caches so we can always reuse the same uri
             val glide = Glide.with(imageView)
                 .load(imageUri)
                 .skipMemoryCache(true)

--- a/app/src/main/java/com/keylesspalace/tusky/viewmodel/EditProfileViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/viewmodel/EditProfileViewModel.kt
@@ -15,7 +15,7 @@
 
 package com.keylesspalace.tusky.viewmodel
 
-import android.content.Context
+import android.app.Application
 import android.net.Uri
 import androidx.core.net.toUri
 import androidx.lifecycle.MutableLiveData
@@ -51,7 +51,8 @@ private const val AVATAR_FILE_NAME = "avatar.png"
 
 class EditProfileViewModel @Inject constructor(
     private val mastodonApi: MastodonApi,
-    private val eventHub: EventHub
+    private val eventHub: EventHub,
+    private val application: Application
 ) : ViewModel() {
 
     val profileData = MutableLiveData<Resource<Account>>()
@@ -83,19 +84,19 @@ class EditProfileViewModel @Inject constructor(
         }
     }
 
-    fun getAvatarUri(context: Context) = getCacheFileForName(context, AVATAR_FILE_NAME).toUri()
+    fun getAvatarUri() = getCacheFileForName(AVATAR_FILE_NAME).toUri()
 
-    fun getHeaderUri(context: Context) = getCacheFileForName(context, HEADER_FILE_NAME).toUri()
+    fun getHeaderUri() = getCacheFileForName(HEADER_FILE_NAME).toUri()
 
-    fun newAvatarPicked(context: Context) {
-        avatarData.value = getAvatarUri(context)
+    fun newAvatarPicked() {
+        avatarData.value = getAvatarUri()
     }
 
-    fun newHeaderPicked(context: Context) {
-        headerData.value = getHeaderUri(context)
+    fun newHeaderPicked() {
+        headerData.value = getHeaderUri()
     }
 
-    fun save(newDisplayName: String, newNote: String, newLocked: Boolean, newFields: List<StringField>, context: Context) {
+    fun save(newDisplayName: String, newNote: String, newLocked: Boolean, newFields: List<StringField>) {
 
         if (saveData.value is Loading || profileData.value !is Success) {
             return
@@ -122,14 +123,14 @@ class EditProfileViewModel @Inject constructor(
         }
 
         val avatar = if (avatarData.value != null) {
-            val avatarBody = getCacheFileForName(context, AVATAR_FILE_NAME).asRequestBody("image/png".toMediaTypeOrNull())
+            val avatarBody = getCacheFileForName(AVATAR_FILE_NAME).asRequestBody("image/png".toMediaTypeOrNull())
             MultipartBody.Part.createFormData("avatar", randomAlphanumericString(12), avatarBody)
         } else {
             null
         }
 
         val header = if (headerData.value != null) {
-            val headerBody = getCacheFileForName(context, HEADER_FILE_NAME).asRequestBody("image/png".toMediaTypeOrNull())
+            val headerBody = getCacheFileForName(HEADER_FILE_NAME).asRequestBody("image/png".toMediaTypeOrNull())
             MultipartBody.Part.createFormData("header", randomAlphanumericString(12), headerBody)
         } else {
             null
@@ -203,8 +204,8 @@ class EditProfileViewModel @Inject constructor(
         )
     }
 
-    private fun getCacheFileForName(context: Context, filename: String): File {
-        return File(context.cacheDir, filename)
+    private fun getCacheFileForName(filename: String): File {
+        return File(application.cacheDir, filename)
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/keylesspalace/tusky/viewmodel/EditProfileViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/viewmodel/EditProfileViewModel.kt
@@ -16,14 +16,10 @@
 package com.keylesspalace.tusky.viewmodel
 
 import android.content.Context
-import android.graphics.Bitmap
 import android.net.Uri
-import android.util.Log
+import androidx.core.net.toUri
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.keylesspalace.tusky.EditProfileActivity.Companion.AVATAR_SIZE
-import com.keylesspalace.tusky.EditProfileActivity.Companion.HEADER_HEIGHT
-import com.keylesspalace.tusky.EditProfileActivity.Companion.HEADER_WIDTH
 import com.keylesspalace.tusky.appstore.EventHub
 import com.keylesspalace.tusky.appstore.ProfileEditedEvent
 import com.keylesspalace.tusky.entity.Account
@@ -31,16 +27,12 @@ import com.keylesspalace.tusky.entity.Instance
 import com.keylesspalace.tusky.entity.StringField
 import com.keylesspalace.tusky.network.MastodonApi
 import com.keylesspalace.tusky.util.Error
-import com.keylesspalace.tusky.util.IOUtils
 import com.keylesspalace.tusky.util.Loading
 import com.keylesspalace.tusky.util.Resource
 import com.keylesspalace.tusky.util.Success
-import com.keylesspalace.tusky.util.getSampledBitmap
 import com.keylesspalace.tusky.util.randomAlphanumericString
-import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.kotlin.addTo
-import io.reactivex.rxjava3.schedulers.Schedulers
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
@@ -52,15 +44,10 @@ import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 import java.io.File
-import java.io.FileNotFoundException
-import java.io.FileOutputStream
-import java.io.OutputStream
 import javax.inject.Inject
 
 private const val HEADER_FILE_NAME = "header.png"
 private const val AVATAR_FILE_NAME = "avatar.png"
-
-private const val TAG = "EditProfileViewModel"
 
 class EditProfileViewModel @Inject constructor(
     private val mastodonApi: MastodonApi,
@@ -68,14 +55,14 @@ class EditProfileViewModel @Inject constructor(
 ) : ViewModel() {
 
     val profileData = MutableLiveData<Resource<Account>>()
-    val avatarData = MutableLiveData<Resource<Bitmap>>()
-    val headerData = MutableLiveData<Resource<Bitmap>>()
+    val avatarData = MutableLiveData<Uri>()
+    val headerData = MutableLiveData<Uri>()
     val saveData = MutableLiveData<Resource<Nothing>>()
     val instanceData = MutableLiveData<Resource<Instance>>()
 
     private var oldProfileData: Account? = null
 
-    private val disposeables = CompositeDisposable()
+    private val disposables = CompositeDisposable()
 
     fun obtainProfile() {
         if (profileData.value == null || profileData.value is Error) {
@@ -92,62 +79,20 @@ class EditProfileViewModel @Inject constructor(
                         profileData.postValue(Error())
                     }
                 )
-                .addTo(disposeables)
+                .addTo(disposables)
         }
     }
 
-    fun newAvatar(uri: Uri, context: Context) {
-        val cacheFile = getCacheFileForName(context, AVATAR_FILE_NAME)
+    fun getAvatarUri(context: Context) = getCacheFileForName(context, AVATAR_FILE_NAME).toUri()
 
-        resizeImage(uri, context, AVATAR_SIZE, AVATAR_SIZE, cacheFile, avatarData)
+    fun getHeaderUri(context: Context) = getCacheFileForName(context, HEADER_FILE_NAME).toUri()
+
+    fun newAvatarPicked(context: Context) {
+        avatarData.value = getAvatarUri(context)
     }
 
-    fun newHeader(uri: Uri, context: Context) {
-        val cacheFile = getCacheFileForName(context, HEADER_FILE_NAME)
-
-        resizeImage(uri, context, HEADER_WIDTH, HEADER_HEIGHT, cacheFile, headerData)
-    }
-
-    private fun resizeImage(
-        uri: Uri,
-        context: Context,
-        resizeWidth: Int,
-        resizeHeight: Int,
-        cacheFile: File,
-        imageLiveData: MutableLiveData<Resource<Bitmap>>
-    ) {
-
-        Single.fromCallable {
-            val contentResolver = context.contentResolver
-            val sourceBitmap = getSampledBitmap(contentResolver, uri, resizeWidth, resizeHeight)
-
-            if (sourceBitmap == null) {
-                throw Exception()
-            }
-
-            // dont upscale image if its smaller than the desired size
-            val bitmap =
-                if (sourceBitmap.width <= resizeWidth && sourceBitmap.height <= resizeHeight) {
-                    sourceBitmap
-                } else {
-                    Bitmap.createScaledBitmap(sourceBitmap, resizeWidth, resizeHeight, true)
-                }
-
-            if (!saveBitmapToFile(bitmap, cacheFile)) {
-                throw Exception()
-            }
-
-            bitmap
-        }.subscribeOn(Schedulers.io())
-            .subscribe(
-                {
-                    imageLiveData.postValue(Success(it))
-                },
-                {
-                    imageLiveData.postValue(Error())
-                }
-            )
-            .addTo(disposeables)
+    fun newHeaderPicked(context: Context) {
+        headerData.value = getHeaderUri(context)
     }
 
     fun save(newDisplayName: String, newNote: String, newLocked: Boolean, newFields: List<StringField>, context: Context) {
@@ -155,6 +100,8 @@ class EditProfileViewModel @Inject constructor(
         if (saveData.value is Loading || profileData.value !is Success) {
             return
         }
+
+        saveData.value = Loading()
 
         val displayName = if (oldProfileData?.displayName == newDisplayName) {
             null
@@ -174,14 +121,14 @@ class EditProfileViewModel @Inject constructor(
             newLocked.toString().toRequestBody(MultipartBody.FORM)
         }
 
-        val avatar = if (avatarData.value is Success && avatarData.value?.data != null) {
+        val avatar = if (avatarData.value != null) {
             val avatarBody = getCacheFileForName(context, AVATAR_FILE_NAME).asRequestBody("image/png".toMediaTypeOrNull())
             MultipartBody.Part.createFormData("avatar", randomAlphanumericString(12), avatarBody)
         } else {
             null
         }
 
-        val header = if (headerData.value is Success && headerData.value?.data != null) {
+        val header = if (headerData.value != null) {
             val headerBody = getCacheFileForName(context, HEADER_FILE_NAME).asRequestBody("image/png".toMediaTypeOrNull())
             MultipartBody.Part.createFormData("header", randomAlphanumericString(12), headerBody)
         } else {
@@ -260,25 +207,8 @@ class EditProfileViewModel @Inject constructor(
         return File(context.cacheDir, filename)
     }
 
-    private fun saveBitmapToFile(bitmap: Bitmap, file: File): Boolean {
-
-        val outputStream: OutputStream
-
-        try {
-            outputStream = FileOutputStream(file)
-        } catch (e: FileNotFoundException) {
-            Log.w(TAG, Log.getStackTraceString(e))
-            return false
-        }
-
-        bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
-        IOUtils.closeQuietly(outputStream)
-
-        return true
-    }
-
     override fun onCleared() {
-        disposeables.dispose()
+        disposables.dispose()
     }
 
     fun obtainInstance() {
@@ -293,7 +223,7 @@ class EditProfileViewModel @Inject constructor(
                     instanceData.postValue(Error())
                 }
             )
-                .addTo(disposeables)
+                .addTo(disposables)
         }
     }
 }

--- a/app/src/main/res/layout/activity_edit_profile.xml
+++ b/app/src/main/res/layout/activity_edit_profile.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.keylesspalace.tusky.EditProfileActivity">
+    tools:context=".EditProfileActivity">
 
     <include
         android:id="@+id/includedToolbar"
@@ -37,17 +37,6 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_add_a_photo_32dp" />
 
-            <ProgressBar
-                android:id="@+id/headerProgressBar"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:indeterminate="true"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="@id/headerPreview"
-                app:layout_constraintEnd_toEndOf="@id/headerPreview"
-                app:layout_constraintStart_toStartOf="@id/headerPreview"
-                app:layout_constraintTop_toTopOf="@id/headerPreview" />
-
             <ImageView
                 android:id="@+id/avatarPreview"
                 android:layout_width="80dp"
@@ -70,18 +59,6 @@
                 app:layout_constraintStart_toStartOf="@id/contentContainer"
                 app:layout_constraintTop_toBottomOf="@id/headerPreview"
                 app:srcCompat="@drawable/ic_add_a_photo_32dp" />
-
-            <ProgressBar
-                android:id="@+id/avatarProgressBar"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerInParent="true"
-                android:indeterminate="true"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="@id/avatarPreview"
-                app:layout_constraintEnd_toEndOf="@id/avatarPreview"
-                app:layout_constraintStart_toStartOf="@id/avatarPreview"
-                app:layout_constraintTop_toTopOf="@id/avatarPreview" />
 
             <LinearLayout
                 android:id="@+id/contentContainer"


### PR DESCRIPTION
Turns out that
- the cropping library can handle both picking & resizing for us
- no permission is necessary since the picking is done by a system app

200 lines of code less for us 😍 