### PR TITLE
fix String.inc() and String.dec() not being inverse operations

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -143,7 +143,7 @@ class CachedTimelineViewModel @Inject constructor(
 
                 val nextPlaceholderId = timelineDao.getNextPlaceholderIdAfter(activeAccount.id, placeholderId)
 
-                val response = api.homeTimeline(maxId = placeholderId.inc(), sinceId = nextPlaceholderId, limit = 20).await()
+                val response = api.homeTimeline(maxId = placeholderId.inc(), sinceId = nextPlaceholderId, limit = LOAD_AT_ONCE).await()
 
                 val statuses = response.body()
                 if (!response.isSuccessful || statuses == null) {

--- a/app/src/main/java/com/keylesspalace/tusky/util/StringUtils.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/StringUtils.kt
@@ -17,27 +17,39 @@ fun randomAlphanumericString(count: Int): String {
 }
 
 // We sort statuses by ID. Something we need to invent some ID for placeholder.
-// Not sure if inc()/dec() should be made `operator` or not
 
 /**
- * "Increment" string so that during sorting it's bigger than [this].
+ * "Increment" string so that during sorting it's bigger than [this]. Inverse operation to [dec].
  */
 fun String.inc(): String {
-    // We assume that we will stay in the safe range for now
     val builder = this.toCharArray()
-    builder[lastIndex] = builder[lastIndex].inc()
-    return String(builder)
+    var i = builder.lastIndex
+
+    while (i >= 0) {
+        if (builder[i] < 'z') {
+            builder[i] = builder[i].inc()
+            return String(builder)
+        } else {
+            builder[i] = '0'
+        }
+        i--
+    }
+    return String(
+        CharArray(builder.size + 1) { index ->
+            if (index == 0) '0' else builder[index - 1]
+        }
+    )
 }
 
 /**
- * "Decrement" string so that during sorting it's smaller than [this].
+ * "Decrement" string so that during sorting it's smaller than [this]. Inverse operation to [inc].
  */
 fun String.dec(): String {
     if (this.isEmpty()) return this
 
     val builder = this.toCharArray()
     var i = builder.lastIndex
-    while (i > 0) {
+    while (i >= 0) {
         if (builder[i] > '0') {
             builder[i] = builder[i].dec()
             return String(builder)
@@ -46,12 +58,7 @@ fun String.dec(): String {
         }
         i--
     }
-    return if (builder[0] > '1') {
-        builder[0] = builder[0].dec()
-        String(builder)
-    } else {
-        String(builder.copyOfRange(1, builder.size))
-    }
+    return String(builder.copyOfRange(1, builder.size))
 }
 
 /**
@@ -68,15 +75,6 @@ fun String.isLessThan(other: String): Boolean {
         this.length < other.length -> true
         this.length > other.length -> false
         else -> this < other
-    }
-}
-
-fun String.idCompareTo(other: String): Int {
-    return when {
-        this === other -> 0
-        this.length < other.length -> -1
-        this.length > other.length -> 1
-        else -> this.compareTo(other)
     }
 }
 

--- a/app/src/test/java/com/keylesspalace/tusky/StringUtilsTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/StringUtilsTest.kt
@@ -27,22 +27,37 @@ class StringUtilsTest {
     @Test
     fun inc() {
         listOf(
+            "10786565059022968z" to "107865650590229690",
             "122" to "123",
             "12A" to "12B",
-            "1" to "2"
+            "11z" to "120",
+            "0zz" to "100",
+            "zz" to "000",
+            "4zzbz" to "4zzc0",
+            "" to "0",
+            "1" to "2",
+            "0" to "1",
+            "AGdxwSQqT3pW4xrLJA" to "AGdxwSQqT3pW4xrLJB",
+            "AGdfqi1HnlBFVl0tkz" to "AGdfqi1HnlBFVl0tl0"
         ).forEach { (l, r) -> assertEquals("$l + 1 = $r", r, l.inc()) }
     }
 
     @Test
     fun dec() {
         listOf(
+            "" to "",
+            "107865650590229690" to "10786565059022968z",
             "123" to "122",
             "12B" to "12A",
             "120" to "11z",
-            "100" to "zz",
+            "100" to "0zz",
+            "000" to "zz",
+            "4zzc0" to "4zzbz",
             "0" to "",
-            "" to "",
-            "2" to "1"
+            "2" to "1",
+            "1" to "0",
+            "AGdxwSQqT3pW4xrLJB" to "AGdxwSQqT3pW4xrLJA",
+            "AGdfqi1HnlBFVl0tl0" to "AGdfqi1HnlBFVl0tkz"
         ).forEach { (l, r) -> assertEquals("$l - 1 = $r", r, l.dec()) }
     }
 }


### PR DESCRIPTION
Problem: `String.inc()` and `String.dec()` were not inverse in all cases, so a placeholder id created by status id dec() could not be turned into the status id again with inc(), which caused the timeline to miss statuses.

Example:

`"1230".dec() = "122z"`
`"122z".inc() = "122{"`
`api/v1/timelines/home?max_id=122{` returns empty array.

This PR fixes the problem by making sure `"AnyAlphanumericString".dec().inc() == "AnyAlphanumericString"`.

(And I also improved the TimelineDaoTest while looking for the bug)