### PR TITLE
Fix relinkifying tags in posts from remote servers

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -47,10 +47,6 @@ fun getDomain(urlString: String?): String {
     }
 }
 
-private fun getPath(urlString: String?): String {
-    return urlString?.toUri()?.path ?: ""
-}
-
 /**
  * Finds links, mentions, and hashtags in a piece of text and makes them clickable, associating
  * them with callbacks to notify when they're clicked.
@@ -102,15 +98,16 @@ fun setClickableText(
 }
 
 @VisibleForTesting
-fun getTagName(text: CharSequence, tags: List<HashTag>?, span: URLSpan): String? {
+fun getTagName(text: CharSequence, tags: List<HashTag>?): String? {
+    val scrapedName = text.subSequence(1, text.length).toString()
     return when (tags) {
-        null -> text.subSequence(1, text.length).toString()
-        else -> tags.firstOrNull { getPath(it.url) == getPath(span.url) }?.name
+        null -> scrapedName
+        else -> tags.firstOrNull { it.name.equals(scrapedName, true) }?.name
     }
 }
 
 private fun getCustomSpanForTag(text: CharSequence, tags: List<HashTag>?, span: URLSpan, listener: LinkListener): ClickableSpan? {
-    return getTagName(text, tags, span)?.let {
+    return getTagName(text, tags)?.let {
         object : NoUnderlineURLSpan(span.url) {
             override fun onClick(view: View) = listener.onViewTag(it)
         }

--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -47,6 +47,10 @@ fun getDomain(urlString: String?): String {
     }
 }
 
+private fun getPath(urlString: String?): String {
+    return urlString?.toUri()?.path ?: ""
+}
+
 /**
  * Finds links, mentions, and hashtags in a piece of text and makes them clickable, associating
  * them with callbacks to notify when they're clicked.
@@ -101,7 +105,7 @@ fun setClickableText(
 fun getTagName(text: CharSequence, tags: List<HashTag>?, span: URLSpan): String? {
     return when (tags) {
         null -> text.subSequence(1, text.length).toString()
-        else -> tags.firstOrNull { it.url == span.url }?.name
+        else -> tags.firstOrNull { getPath(it.url) == getPath(span.url) }?.name
     }
 }
 

--- a/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
@@ -70,74 +70,27 @@ class LinkHelperTest {
     }
 
     @Test
-    fun whenSettingClickableTest_tagUrlsArePreserved() {
-        val builder = SpannableStringBuilder()
+    fun whenCheckingTags_tagNameIsComparedCaseInsensitively() {
         for (tag in tags) {
-            builder.append("#${tag.name}", URLSpan(tag.url), 0)
-            builder.append(" ")
-        }
-
-        var urlSpans = builder.getSpans(0, builder.length, URLSpan::class.java)
-        for (span in urlSpans) {
-            setClickableText(span, builder, emptyList(), tags, listener)
-        }
-
-        urlSpans = builder.getSpans(0, builder.length, URLSpan::class.java)
-        for (span in urlSpans) {
-            Assert.assertNotNull(tags.firstOrNull { it.url == span.url })
+            for (mutatedTagName in listOf(tag.name, tag.name.uppercase(), tag.name.lowercase())) {
+                val tagName = getTagName("#$mutatedTagName", tags)
+                Assert.assertNotNull(tagName)
+                Assert.assertNotNull(tags.firstOrNull { it.name == tagName })
+            }
         }
     }
 
     @Test
-    fun whenSettingClickableTest_nonTagUrlsAreNotConverted() {
-        val builder = SpannableStringBuilder()
-        val nonTagUrl = "http://example.com/"
+    fun hashedUrlSpans_withNoMatchingTag_areNotModified() {
         for (tag in tags) {
-            builder.append("#${tag.name}", URLSpan(nonTagUrl), 0)
-            builder.append(" ")
-            builder.append("#${tag.name} ")
-        }
-
-        var urlSpans = builder.getSpans(0, builder.length, URLSpan::class.java)
-        for (span in urlSpans) {
-            setClickableText(span, builder, emptyList(), tags, listener)
-        }
-
-        urlSpans = builder.getSpans(0, builder.length, URLSpan::class.java)
-        for (span in urlSpans) {
-            Assert.assertEquals(nonTagUrl, span.url)
+            Assert.assertNull(getTagName("#not${tag.name}", tags))
         }
     }
 
     @Test
     fun whenTagsAreNull_tagNameIsGeneratedFromText() {
-        SpannableStringBuilder().apply {
-            for (tag in tags) {
-                append("#${tag.name}", URLSpan(tag.url), 0)
-                append(" ")
-            }
-
-            getSpans(0, length, URLSpan::class.java).forEach {
-                Assert.assertNotNull(getTagName(subSequence(getSpanStart(it), getSpanEnd(it)), null, it))
-            }
-        }
-    }
-
-    @Test
-    fun whenSettingClickableTest_convertedLocalTagUrlsAreAccepted() {
-        SpannableStringBuilder().apply {
-            val remoteTags = mutableListOf<String>()
-            for (tag in tags) {
-                remoteTags.add(tag.url.replace("example.com", "instance.remote"))
-                append("#${tag.name}", URLSpan(remoteTags.last()), 0)
-                append(" ")
-            }
-
-            getSpans(0, length, URLSpan::class.java).forEach { span ->
-                val tagName = getTagName(subSequence(getSpanStart(span), getSpanEnd(span)), tags, span)
-                Assert.assertNotNull(tagName)
-                Assert.assertNotNull(tags.firstOrNull { tag -> tag.name == tagName })
-            }
+        for (tag in tags) {
+            Assert.assertEquals(tag.name, getTagName("#${tag.name}", null))
         }
     }
 

--- a/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
@@ -124,6 +124,24 @@ class LinkHelperTest {
     }
 
     @Test
+    fun whenSettingClickableTest_convertedLocalTagUrlsAreAccepted() {
+        SpannableStringBuilder().apply {
+            val remoteTags = mutableListOf<String>()
+            for (tag in tags) {
+                remoteTags.add(tag.url.replace("example.com", "instance.remote"))
+                append("#${tag.name}", URLSpan(remoteTags.last()), 0)
+                append(" ")
+            }
+
+            getSpans(0, length, URLSpan::class.java).forEach { span ->
+                val tagName = getTagName(subSequence(getSpanStart(span), getSpanEnd(span)), tags, span)
+                Assert.assertNotNull(tagName)
+                Assert.assertNotNull(tags.firstOrNull { tag -> tag.name == tagName })
+            }
+        }
+    }
+
+    @Test
     fun whenStringIsInvalidUri_emptyStringIsReturnedFromGetDomain() {
         listOf(
             null,


### PR DESCRIPTION
~~When the post originates on another server, the span url will be `https://remote.server.tags/meh` and the url associated with the tag object will be `https://local.server/tags/meh`, so clicking a hashtag in a post originating from another server will (currently on `develop`) open the remote server's tag url in a browser :neutral_face:~~

This was even more broken than I realized - the incoming url doesn't necessarily have *any* relation to the local url associated with the tag. The only thing that makes sense is to match on the name.