### PR TITLE
Fix timeline jumping to top when activity is recreated

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelinePagingAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelinePagingAdapter.kt
@@ -41,6 +41,10 @@ class TimelinePagingAdapter(
             )
         }
 
+    init {
+        stateRestorationPolicy = StateRestorationPolicy.PREVENT_WHEN_EMPTY
+    }
+
     override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {
             VIEW_TYPE_STATUS -> {


### PR DESCRIPTION
On some low memory devices, when you navigate away from the MainActivity, it gets destroyed and then recreated when you return to it, with the timeline jumping to top.
(You can easily get the same behavior on any device by setting "don't keep sctivities" in the developer options of the device)

This fix only works on the home timeline, because other timelines are not cached and cannot restore any position (yet - there might be a more complicated way to get it fixed in every timeline)
