### PR TITLE
Fix some network timeline bugs

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -234,7 +234,9 @@ class NetworkTimelineViewModel @Inject constructor(
 
     override fun fullReload() {
         statusData.clear()
+        nextKey = null
         currentSource?.invalidate()
+        // FIXME: auto reload needed
     }
 
     suspend fun fetchStatusesForKind(

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -34,6 +34,7 @@ import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.network.FilterModel
 import com.keylesspalace.tusky.network.MastodonApi
 import com.keylesspalace.tusky.network.TimelineCases
+import com.keylesspalace.tusky.util.dec
 import com.keylesspalace.tusky.util.getDomain
 import com.keylesspalace.tusky.util.inc
 import com.keylesspalace.tusky.util.toViewData
@@ -133,6 +134,10 @@ class NetworkTimelineViewModel @Inject constructor(
     override fun loadMore(placeholderId: String) {
         viewModelScope.launch {
             try {
+                val placeholderIndex =
+                    statusData.indexOfFirst { it is StatusViewData.Placeholder && it.id == placeholderId }
+                statusData[placeholderIndex] = StatusViewData.Placeholder(placeholderId, isLoading = true)
+
                 val statusResponse = fetchStatusesForKind(
                     fromId = placeholderId.inc(),
                     uptoId = null,
@@ -145,28 +150,46 @@ class NetworkTimelineViewModel @Inject constructor(
                     return@launch
                 }
 
+                statusData.removeAt(placeholderIndex)
+
                 val activeAccount = accountManager.activeAccount!!
-
                 val data = statuses.map { status ->
-                    val oldStatus = statusData.find { s ->
-                        s.asStatusOrNull()?.id == status.id
-                    }?.asStatusOrNull()
-
-                    val contentShowing = oldStatus?.isShowingContent ?: activeAccount.alwaysShowSensitiveMedia || !status.actionableStatus.sensitive
-                    val expanded = oldStatus?.isExpanded ?: activeAccount.alwaysOpenSpoiler
-                    val contentCollapsed = oldStatus?.isCollapsed ?: true
-
                     status.toViewData(
-                        isShowingContent = contentShowing,
-                        isExpanded = expanded,
-                        isCollapsed = contentCollapsed
+                        isShowingContent = activeAccount.alwaysShowSensitiveMedia || !status.actionableStatus.sensitive,
+                        isExpanded = activeAccount.alwaysOpenSpoiler,
+                        isCollapsed = true
                     )
+                }.toMutableList()
+
+                if (statuses.isNotEmpty()) {
+                    val firstId = statuses.first().id.hashCode().toLong()
+                    val lastId = statuses.last().id.hashCode().toLong()
+                    val overlappedFrom = statusData.indexOfFirst { it.viewDataId <= firstId }
+                    val overlappedTo = statusData.indexOfFirst { it.viewDataId < lastId }
+
+                    if (overlappedFrom < overlappedTo) {
+                        repeat(overlappedTo - overlappedFrom) {
+                            statusData[overlappedFrom].asStatusOrNull()?.let { oldStatus ->
+                                val dataIndex = statuses.indexOfFirst { it.id == oldStatus.id }
+                                if (dataIndex == -1) {
+                                    return@let
+                                }
+                                data[dataIndex] = data[dataIndex]
+                                    .copy(
+                                        isShowingContent = oldStatus.isShowingContent,
+                                        isExpanded = oldStatus.isExpanded,
+                                        isCollapsed = oldStatus.isCollapsed,
+                                    )
+                            }
+
+                            statusData.removeAt(overlappedFrom)
+                        }
+                    } else {
+                        statusData.add(overlappedFrom, StatusViewData.Placeholder(statuses.last().id.dec(), isLoading = false))
+                    }
                 }
 
-                val index =
-                    statusData.indexOfFirst { it is StatusViewData.Placeholder && it.id == placeholderId }
-                statusData.removeAt(index)
-                statusData.addAll(index, data)
+                statusData.addAll(placeholderIndex, data)
 
                 currentSource?.invalidate()
             } catch (e: Exception) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -233,10 +233,9 @@ class NetworkTimelineViewModel @Inject constructor(
     }
 
     override fun fullReload() {
+        nextKey = statusData.firstOrNull { it is StatusViewData.Concrete }?.asStatusOrNull()?.id?.inc()
         statusData.clear()
-        nextKey = null
         currentSource?.invalidate()
-        // FIXME: auto reload needed
     }
 
     suspend fun fetchStatusesForKind(

--- a/app/src/main/java/com/keylesspalace/tusky/util/StringUtils.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/StringUtils.kt
@@ -78,6 +78,19 @@ fun String.isLessThan(other: String): Boolean {
     }
 }
 
+/**
+ * A <= B (strictly) by length and then by content.
+ * Examples:
+ * "abc" <= "bcd"
+ * "ab"  <= "abc"
+ * "cb"  <= "abc"
+ * "ab"  <= "ab"
+ * not: "abc" > "cb"
+ */
+fun String.isLessThanOrEqual(other: String): Boolean {
+    return this == other || isLessThan(other)
+}
+
 fun Spanned.trimTrailingWhitespace(): Spanned {
     var i = length
     do {

--- a/app/src/test/java/com/keylesspalace/tusky/StringUtilsTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/StringUtilsTest.kt
@@ -3,6 +3,7 @@ package com.keylesspalace.tusky
 import com.keylesspalace.tusky.util.dec
 import com.keylesspalace.tusky.util.inc
 import com.keylesspalace.tusky.util.isLessThan
+import com.keylesspalace.tusky.util.isLessThanOrEqual
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -22,6 +23,20 @@ class StringUtilsTest {
             "abc" to "abc"
         )
         notLessList.forEach { (l, r) -> assertFalse("not $l < $r", l.isLessThan(r)) }
+    }
+
+    @Test
+    fun isLessThanOrEqual() {
+        val lessList = listOf(
+            "abc" to "bcd",
+            "ab" to "abc",
+            "cb" to "abc",
+            "1" to "2",
+            "abc" to "abc",
+        )
+        lessList.forEach { (l, r) -> assertTrue("$l < $r", l.isLessThanOrEqual(r)) }
+        val notLessList = lessList.filterNot { (l, r) -> l == r }.map { (l, r) -> r to l }
+        notLessList.forEach { (l, r) -> assertFalse("not $l < $r", l.isLessThanOrEqual(r)) }
     }
 
     @Test


### PR DESCRIPTION
I found that `NetworkTimelineViewModel` has some incomplete methods so tried to fix them.
I referred `CachedTimelineViewModel` and carefully implemented for network timeline, but it might have some mistakes so please check my codes.

Mistakes I found:

* `loadMore` does not handles statuses overlaps
* `loadMore` does not inserts new placeholder after fetched statuses when the number of statuses in the gap is more than fetch limit.
* `fullReload` does not fully refresh timeline. Statuses they are already fetched are not included after refresh.