### PR TITLE
fix "nothing here" flickering when starting Tusky

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
@@ -182,7 +182,7 @@ class TimelineFragment :
             if (adapter.itemCount == 0) {
                 when (loadState.refresh) {
                     is LoadState.NotLoading -> {
-                        if (loadState.append is LoadState.NotLoading) {
+                        if (loadState.append is LoadState.NotLoading && loadState.source.refresh is LoadState.NotLoading) {
                             binding.statusView.show()
                             binding.statusView.setup(R.drawable.elephant_friend_empty, R.string.message_empty, null)
                         }


### PR DESCRIPTION
When opening the app and having the first tab set to the home timeline, sometimes the "Nothing here" elephant friend is visible for a split second before the progress bar appears. This fixes the problem.