### PR TITLE
change media download location to Download directory

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
@@ -205,10 +205,7 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
 
         val downloadManager = getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
         val request = DownloadManager.Request(Uri.parse(url))
-        request.setDestinationInExternalPublicDir(
-            Environment.DIRECTORY_PICTURES,
-            getString(R.string.app_name) + "/" + filename
-        )
+        request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, filename)
         downloadManager.enqueue(request)
     }
 


### PR DESCRIPTION
Apparently Android deletes all downloads that are not saved into the Downloads folder after a week. So lets use `DIRECTORY_DOWNLOADS` instead of `DIRECTORY_PICTURES`.

Note: When choosing "Download all media" on a status, we already save to Downloads.

close https://github.com/tuskyapp/Tusky/issues/2262
closes https://github.com/tuskyapp/Tusky/issues/1804