### PR TITLE
Improve handling of shared media

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -236,26 +236,25 @@ class ComposeActivity :
                             }
                         }
                     }
-                } else if (type == "text/plain" && intent.action == Intent.ACTION_SEND) {
+                }
 
-                    val subject = intent.getStringExtra(Intent.EXTRA_SUBJECT)
-                    val text = intent.getStringExtra(Intent.EXTRA_TEXT).orEmpty()
-                    val shareBody = if (!subject.isNullOrBlank() && subject !in text) {
-                        subject + '\n' + text
-                    } else {
-                        text
-                    }
+                val subject = intent.getStringExtra(Intent.EXTRA_SUBJECT)
+                val text = intent.getStringExtra(Intent.EXTRA_TEXT).orEmpty()
+                val shareBody = if (!subject.isNullOrBlank() && subject !in text) {
+                    subject + '\n' + text
+                } else {
+                    text
+                }
 
-                    if (shareBody.isNotBlank()) {
-                        val start = binding.composeEditField.selectionStart.coerceAtLeast(0)
-                        val end = binding.composeEditField.selectionEnd.coerceAtLeast(0)
-                        val left = min(start, end)
-                        val right = max(start, end)
-                        binding.composeEditField.text.replace(left, right, shareBody, 0, shareBody.length)
-                        // move edittext cursor to first when shareBody parsed
-                        binding.composeEditField.text.insert(0, "\n")
-                        binding.composeEditField.setSelection(0)
-                    }
+                if (shareBody.isNotBlank()) {
+                    val start = binding.composeEditField.selectionStart.coerceAtLeast(0)
+                    val end = binding.composeEditField.selectionEnd.coerceAtLeast(0)
+                    val left = min(start, end)
+                    val right = max(start, end)
+                    binding.composeEditField.text.replace(left, right, shareBody, 0, shareBody.length)
+                    // move edittext cursor to first when shareBody parsed
+                    binding.composeEditField.text.insert(0, "\n")
+                    binding.composeEditField.setSelection(0)
                 }
             }
         }

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
@@ -122,9 +122,9 @@ class MediaUploader @Inject constructor(
                             throw CouldNotOpenFileException()
                         }
                         val inputFile = File(path)
-                        val suffix = "." + inputFile.name.substringAfterLast('.', "tmp")
-                        mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(suffix.drop(1))
-                        val file = File.createTempFile("randomTemp1", suffix, context.cacheDir)
+                        val suffix = inputFile.name.substringAfterLast('.', "tmp")
+                        mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(suffix)
+                        val file = File.createTempFile("randomTemp1", ".$suffix", context.cacheDir)
                         val input = FileInputStream(inputFile)
 
                         FileOutputStream(file.absoluteFile).use { out ->

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
@@ -121,7 +121,12 @@ class MediaUploader @Inject constructor(
                             Log.w(TAG, "empty uri path $uri")
                             throw CouldNotOpenFileException()
                         }
-                        val suffix = path.substring(path.lastIndexOf("."))
+                        val dotIndex = path.lastIndexOf(".")
+                        val suffix = if (dotIndex == -1) {
+                            ".tmp"
+                        } else {
+                            path.substring(dotIndex)
+                        }
                         mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(suffix.drop(1))
                         val file = File.createTempFile("randomTemp1", suffix, context.cacheDir)
                         val input = FileInputStream(File(path))
@@ -147,7 +152,7 @@ class MediaUploader @Inject constructor(
             }
             if (mediaSize == MEDIA_SIZE_UNKNOWN) {
                 Log.w(TAG, "Could not determine file size of upload")
-                throw CouldNotOpenFileException()
+                throw MediaTypeException()
             }
 
             if (mimeType != null) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
@@ -121,15 +121,11 @@ class MediaUploader @Inject constructor(
                             Log.w(TAG, "empty uri path $uri")
                             throw CouldNotOpenFileException()
                         }
-                        val dotIndex = path.lastIndexOf(".")
-                        val suffix = if (dotIndex == -1) {
-                            ".tmp"
-                        } else {
-                            path.substring(dotIndex)
-                        }
+                        val inputFile = File(path)
+                        val suffix = "." + inputFile.name.substringAfterLast('.', "tmp")
                         mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(suffix.drop(1))
                         val file = File.createTempFile("randomTemp1", suffix, context.cacheDir)
-                        val input = FileInputStream(File(path))
+                        val input = FileInputStream(inputFile)
 
                         FileOutputStream(file.absoluteFile).use { out ->
                             input.copyTo(out)

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
@@ -15,6 +15,7 @@
 
 package com.keylesspalace.tusky.components.compose
 
+import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
 import android.os.Environment
@@ -37,6 +38,7 @@ import io.reactivex.rxjava3.schedulers.Schedulers
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import java.io.File
+import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
 import java.util.Date
@@ -83,35 +85,68 @@ class MediaUploader @Inject constructor(
 
     fun prepareMedia(inUri: Uri): Single<PreparedMedia> {
         return Single.fromCallable {
-            var mediaSize = getMediaSize(contentResolver, inUri)
+            var mediaSize = MEDIA_SIZE_UNKNOWN
             var uri = inUri
-            val mimeType = contentResolver.getType(uri)
-
-            val suffix = "." + MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType ?: "tmp")
+            var mimeType: String? = null
 
             try {
-                contentResolver.openInputStream(inUri).use { input ->
-                    if (input == null) {
-                        Log.w(TAG, "Media input is null")
-                        uri = inUri
-                        return@use
+                when (inUri.scheme) {
+                    ContentResolver.SCHEME_CONTENT -> {
+
+                        mimeType = contentResolver.getType(uri)
+
+                        val suffix = "." + MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType ?: "tmp")
+
+                        contentResolver.openInputStream(inUri).use { input ->
+                            if (input == null) {
+                                Log.w(TAG, "Media input is null")
+                                uri = inUri
+                                return@use
+                            }
+                            val file = File.createTempFile("randomTemp1", suffix, context.cacheDir)
+                            FileOutputStream(file.absoluteFile).use { out ->
+                                input.copyTo(out)
+                                uri = FileProvider.getUriForFile(
+                                    context,
+                                    BuildConfig.APPLICATION_ID + ".fileprovider",
+                                    file
+                                )
+                                mediaSize = getMediaSize(contentResolver, uri)
+                            }
+                        }
                     }
-                    val file = File.createTempFile("randomTemp1", suffix, context.cacheDir)
-                    FileOutputStream(file.absoluteFile).use { out ->
-                        input.copyTo(out)
-                        uri = FileProvider.getUriForFile(
-                            context,
-                            BuildConfig.APPLICATION_ID + ".fileprovider",
-                            file
-                        )
-                        mediaSize = getMediaSize(contentResolver, uri)
+                    ContentResolver.SCHEME_FILE -> {
+                        val path = uri.path
+                        if (path == null) {
+                            Log.w(TAG, "empty uri path $uri")
+                            throw CouldNotOpenFileException()
+                        }
+                        val suffix = path.substring(path.lastIndexOf("."))
+                        mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(suffix.drop(1))
+                        val file = File.createTempFile("randomTemp1", suffix, context.cacheDir)
+                        val input = FileInputStream(File(path))
+
+                        FileOutputStream(file.absoluteFile).use { out ->
+                            input.copyTo(out)
+                            uri = FileProvider.getUriForFile(
+                                context,
+                                BuildConfig.APPLICATION_ID + ".fileprovider",
+                                file
+                            )
+                            mediaSize = getMediaSize(contentResolver, uri)
+                        }
+                    }
+                    else -> {
+                        Log.w(TAG, "Unknown uri scheme $uri")
+                        throw CouldNotOpenFileException()
                     }
                 }
             } catch (e: IOException) {
                 Log.w(TAG, e)
-                uri = inUri
+                throw CouldNotOpenFileException()
             }
             if (mediaSize == MEDIA_SIZE_UNKNOWN) {
+                Log.w(TAG, "Could not determine file size of upload")
                 throw CouldNotOpenFileException()
             }
 
@@ -138,6 +173,7 @@ class MediaUploader @Inject constructor(
                     }
                 }
             } else {
+                Log.w(TAG, "Could not determine mime type of upload")
                 throw MediaTypeException()
             }
         }


### PR DESCRIPTION
While investigating #2232 I noticed that other apps, e.g. Nextcloud could open the shared image, but Tusky could not.
Fortunately Nextcloud is open source and the thing is that `file://` uris need to be handled differently (with file api), only `content://` works with ContentResolver.
(Providing `file://` uris is bad, outdated practice, but we can't control other apps so we should support them as well)

Also, not only plain text shares can contain a subject so I removed the check.

closes #2232