### PR TITLE
Fix image preview in share sheet

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
@@ -36,6 +36,7 @@ import android.view.MenuItem
 import android.view.View
 import android.webkit.MimeTypeMap
 import android.widget.Toast
+import androidx.core.app.ShareCompat
 import androidx.core.content.FileProvider
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
@@ -252,11 +253,11 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
     }
 
     private fun shareFile(file: File, mimeType: String?) {
-        val sendIntent = Intent()
-        sendIntent.action = Intent.ACTION_SEND
-        sendIntent.putExtra(Intent.EXTRA_STREAM, FileProvider.getUriForFile(applicationContext, "$APPLICATION_ID.fileprovider", file))
-        sendIntent.type = mimeType
-        startActivity(Intent.createChooser(sendIntent, resources.getText(R.string.send_media_to)))
+        ShareCompat.IntentBuilder(this)
+            .setType(mimeType)
+            .addStream(FileProvider.getUriForFile(applicationContext, "$APPLICATION_ID.fileprovider", file))
+            .setChooserTitle(R.string.send_media_to)
+            .startChooser()
     }
 
     private var isCreating: Boolean = false


### PR DESCRIPTION
`ShareCompat.IntentBuilder` handles all the subtleties involved with sharing content. With this change the share sheet will display a preview when sharing images (on Android versions that support this).

Before and after:
<img src="https://user-images.githubusercontent.com/218061/158497400-d27d3ce4-e63f-4e59-a80a-c65b260eae60.png" alt="tusky__share_image__missing_preview" width=300> <img src="https://user-images.githubusercontent.com/218061/158497422-552c8e9a-4b69-4a59-974c-d41688fba6ac.png" alt="tusky__share_image__with_preview" width=300>


See https://issuetracker.google.com/issues/173137936