### PR TITLE
Fix Timeline not loading

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
@@ -30,7 +30,6 @@ import com.keylesspalace.tusky.db.TimelineStatusEntity
 import com.keylesspalace.tusky.db.TimelineStatusWithAccount
 import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.network.MastodonApi
-import com.keylesspalace.tusky.util.dec
 import kotlinx.coroutines.rx3.await
 import retrofit2.HttpException
 
@@ -103,8 +102,12 @@ class CachedTimelineRemoteMediator(
                 val overlappedStatuses = replaceStatusRange(statuses, state)
 
                 if (loadType == LoadType.REFRESH && overlappedStatuses == 0 && statuses.isNotEmpty() && !dbEmpty) {
+                    /* This overrides the last of the newly loaded statuses with a placeholder
+                       to guarantee the placeholder has an id that exists on the server as not all
+                       servers handle client generated ids as expected
+                     */
                     timelineDao.insertStatus(
-                        Placeholder(statuses.last().id.dec(), loading = false).toEntity(activeAccount.id)
+                        Placeholder(statuses.last().id, loading = false).toEntity(activeAccount.id)
                     )
                 }
             }

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -22,7 +22,6 @@ import androidx.paging.RemoteMediator
 import com.keylesspalace.tusky.components.timeline.util.ifExpected
 import com.keylesspalace.tusky.db.AccountManager
 import com.keylesspalace.tusky.util.HttpHeaderLink
-import com.keylesspalace.tusky.util.dec
 import com.keylesspalace.tusky.util.toViewData
 import com.keylesspalace.tusky.viewdata.StatusViewData
 import retrofit2.HttpException
@@ -93,7 +92,7 @@ class NetworkTimelineRemoteMediator(
                 viewModel.statusData.addAll(0, data)
 
                 if (insertPlaceholder) {
-                    viewModel.statusData.add(statuses.size, StatusViewData.Placeholder(statuses.last().id.dec(), false))
+                    viewModel.statusData.add(statuses.size - 1, StatusViewData.Placeholder(statuses.last().id, false))
                 }
             } else {
                 val linkHeader = statusResponse.headers()["Link"]

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -92,7 +92,7 @@ class NetworkTimelineRemoteMediator(
                 viewModel.statusData.addAll(0, data)
 
                 if (insertPlaceholder) {
-                    viewModel.statusData.add(statuses.size - 1, StatusViewData.Placeholder(statuses.last().id, false))
+                    viewModel.statusData[statuses.size - 1] = StatusViewData.Placeholder(statuses.last().id, false)
                 }
             } else {
                 val linkHeader = statusResponse.headers()["Link"]

--- a/app/src/main/java/com/keylesspalace/tusky/db/TimelineDao.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/TimelineDao.kt
@@ -186,6 +186,15 @@ AND timelineUserId = :accountId
     @Query("SELECT serverId FROM TimelineStatusEntity WHERE timelineUserId = :accountId AND authorServerId IS NULL ORDER BY LENGTH(serverId) DESC, serverId DESC LIMIT 1")
     abstract suspend fun getTopPlaceholderId(accountId: Long): String?
 
+    /**
+     * Returns the id directly above [serverId], or null if [serverId] is the id of the top status
+     */
+    @Query("SELECT serverId FROM TimelineStatusEntity WHERE timelineUserId = :accountId AND (LENGTH(:serverId) < LENGTH(serverId) OR (LENGTH(:serverId) = LENGTH(serverId) AND :serverId < serverId)) ORDER BY LENGTH(serverId) ASC, serverId ASC LIMIT 1")
+    abstract suspend fun getIdAbove(accountId: Long, serverId: String): String?
+
+    /**
+     * Returns the id of the next placeholder after [serverId]
+     */
     @Query("SELECT serverId FROM TimelineStatusEntity WHERE timelineUserId = :accountId AND authorServerId IS NULL AND (LENGTH(:serverId) > LENGTH(serverId) OR (LENGTH(:serverId) = LENGTH(serverId) AND :serverId > serverId)) ORDER BY LENGTH(serverId) DESC, serverId DESC LIMIT 1")
     abstract suspend fun getNextPlaceholderIdAfter(accountId: Long, serverId: String): String?
 }

--- a/app/src/main/java/com/keylesspalace/tusky/util/StringUtils.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/StringUtils.kt
@@ -16,51 +16,6 @@ fun randomAlphanumericString(count: Int): String {
     return String(chars)
 }
 
-// We sort statuses by ID. Something we need to invent some ID for placeholder.
-
-/**
- * "Increment" string so that during sorting it's bigger than [this]. Inverse operation to [dec].
- */
-fun String.inc(): String {
-    val builder = this.toCharArray()
-    var i = builder.lastIndex
-
-    while (i >= 0) {
-        if (builder[i] < 'z') {
-            builder[i] = builder[i].inc()
-            return String(builder)
-        } else {
-            builder[i] = '0'
-        }
-        i--
-    }
-    return String(
-        CharArray(builder.size + 1) { index ->
-            if (index == 0) '0' else builder[index - 1]
-        }
-    )
-}
-
-/**
- * "Decrement" string so that during sorting it's smaller than [this]. Inverse operation to [inc].
- */
-fun String.dec(): String {
-    if (this.isEmpty()) return this
-
-    val builder = this.toCharArray()
-    var i = builder.lastIndex
-    while (i >= 0) {
-        if (builder[i] > '0') {
-            builder[i] = builder[i].dec()
-            return String(builder)
-        } else {
-            builder[i] = 'z'
-        }
-        i--
-    }
-    return String(builder.copyOfRange(1, builder.size))
-}
-
 /**
  * A < B (strictly) by length and then by content.
  * Examples:

--- a/app/src/test/java/com/keylesspalace/tusky/StringUtilsTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/StringUtilsTest.kt
@@ -1,10 +1,7 @@
 package com.keylesspalace.tusky
 
-import com.keylesspalace.tusky.util.dec
-import com.keylesspalace.tusky.util.inc
 import com.keylesspalace.tusky.util.isLessThan
 import com.keylesspalace.tusky.util.isLessThanOrEqual
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -37,42 +34,5 @@ class StringUtilsTest {
         lessList.forEach { (l, r) -> assertTrue("$l < $r", l.isLessThanOrEqual(r)) }
         val notLessList = lessList.filterNot { (l, r) -> l == r }.map { (l, r) -> r to l }
         notLessList.forEach { (l, r) -> assertFalse("not $l < $r", l.isLessThanOrEqual(r)) }
-    }
-
-    @Test
-    fun inc() {
-        listOf(
-            "10786565059022968z" to "107865650590229690",
-            "122" to "123",
-            "12A" to "12B",
-            "11z" to "120",
-            "0zz" to "100",
-            "zz" to "000",
-            "4zzbz" to "4zzc0",
-            "" to "0",
-            "1" to "2",
-            "0" to "1",
-            "AGdxwSQqT3pW4xrLJA" to "AGdxwSQqT3pW4xrLJB",
-            "AGdfqi1HnlBFVl0tkz" to "AGdfqi1HnlBFVl0tl0"
-        ).forEach { (l, r) -> assertEquals("$l + 1 = $r", r, l.inc()) }
-    }
-
-    @Test
-    fun dec() {
-        listOf(
-            "" to "",
-            "107865650590229690" to "10786565059022968z",
-            "123" to "122",
-            "12B" to "12A",
-            "120" to "11z",
-            "100" to "0zz",
-            "000" to "zz",
-            "4zzc0" to "4zzbz",
-            "0" to "",
-            "2" to "1",
-            "1" to "0",
-            "AGdxwSQqT3pW4xrLJB" to "AGdxwSQqT3pW4xrLJA",
-            "AGdfqi1HnlBFVl0tl0" to "AGdfqi1HnlBFVl0tkz"
-        ).forEach { (l, r) -> assertEquals("$l - 1 = $r", r, l.dec()) }
     }
 }

--- a/app/src/test/java/com/keylesspalace/tusky/components/timeline/CachedTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/timeline/CachedTimelineRemoteMediatorTest.kt
@@ -194,9 +194,8 @@ class CachedTimelineRemoteMediatorTest {
             listOf(
                 mockStatusEntityWithAccount("8"),
                 mockStatusEntityWithAccount("7"),
-                mockStatusEntityWithAccount("5"),
                 TimelineStatusWithAccount().apply {
-                    status = Placeholder("4", loading = false).toEntity(1)
+                    status = Placeholder("5", loading = false).toEntity(1)
                 },
                 mockStatusEntityWithAccount("3"),
                 mockStatusEntityWithAccount("2"),

--- a/app/src/test/java/com/keylesspalace/tusky/components/timeline/NetworkTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/timeline/NetworkTimelineRemoteMediatorTest.kt
@@ -217,8 +217,7 @@ class NetworkTimelineRemoteMediatorTest {
         val newStatusData = mutableListOf(
             mockStatusViewData("10"),
             mockStatusViewData("9"),
-            mockStatusViewData("7"),
-            StatusViewData.Placeholder("6", false),
+            StatusViewData.Placeholder("7", false),
             mockStatusViewData("3"),
             mockStatusViewData("2"),
             mockStatusViewData("1"),


### PR DESCRIPTION
Getting rid of all client generated ids as they only cause trouble.
From now on, we don't display the last loaded status and use its id for the placeholder. This way we can safely send placeholder ids into the api.

Requires a db cache cleanup to make sure no old placeholder ids are cached anymore. I'm using this opportunity to make tags in the db non-null, fyi @Tak 

fixes https://github.com/tuskyapp/Tusky/issues/2382