### PR TITLE
remove extra slash in OAuth authorize url

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -68,7 +68,7 @@ import retrofit2.http.Query
 interface MastodonApi {
 
     companion object {
-        const val ENDPOINT_AUTHORIZE = "/oauth/authorize"
+        const val ENDPOINT_AUTHORIZE = "oauth/authorize"
         const val DOMAIN_HEADER = "domain"
         const val PLACEHOLDER_DOMAIN = "dummy.placeholder"
     }


### PR DESCRIPTION
Mastodon instances ignore the extra slash so we did not notice.