### PR TITLE
fix SearchActivity transition animations

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
@@ -84,6 +84,10 @@ class SearchActivity : BottomSheetActivity(), HasAndroidInjector {
         return true
     }
 
+    override fun finish() {
+        super.finishWithoutSlideOutAnimation()
+    }
+
     private fun getPageTitle(position: Int): CharSequence {
         return when (position) {
             0 -> getString(R.string.title_posts)

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchFragment.kt
@@ -111,9 +111,13 @@ abstract class SearchFragment<T : Any> :
         }
     }
 
-    override fun onViewAccount(id: String) = startActivity(AccountActivity.getIntent(requireContext(), id))
+    override fun onViewAccount(id: String) {
+        bottomSheetActivity?.startActivityWithSlideInAnimation(AccountActivity.getIntent(requireContext(), id))
+    }
 
-    override fun onViewTag(tag: String) = startActivity(StatusListActivity.newHashtagIntent(requireContext(), tag))
+    override fun onViewTag(tag: String) {
+        bottomSheetActivity?.startActivityWithSlideInAnimation(StatusListActivity.newHashtagIntent(requireContext(), tag))
+    }
 
     override fun onViewUrl(url: String) {
         bottomSheetActivity?.viewUrl(url)

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchStatusesFragment.kt
@@ -219,7 +219,7 @@ class SearchStatusesFragment : SearchFragment<StatusViewData.Concrete>(), Status
                 replyingStatusContent = status.content.toString()
             )
         )
-        startActivity(intent)
+        bottomSheetActivity?.startActivityWithSlideInAnimation(intent)
     }
 
     private fun more(status: Status, view: View, position: Int) {

--- a/app/src/main/java/com/keylesspalace/tusky/interfaces/StatusActionListener.java
+++ b/app/src/main/java/com/keylesspalace/tusky/interfaces/StatusActionListener.java
@@ -38,7 +38,7 @@ public interface StatusActionListener extends LinkListener {
     void onOpenReblog(int position);
     void onExpandedChange(boolean expanded, int position);
     void onContentHiddenChange(boolean isShowing, int position);
-    void  onLoadMore(int position);
+    void onLoadMore(int position);
 
     /**
      * Called when the status {@link android.widget.ToggleButton} responsible for collapsing long


### PR DESCRIPTION
- SearchActivity is started without slide-in, so it should also finish without slide-out (or should it be the other way around?)
- ViewThread/Account/Tag activity are finished with slide-out, so they should also be started with slide-in