### PR TITLE
fix timeline refresh indicator finishing before updates are visible

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
@@ -172,7 +172,7 @@ class TimelineFragment :
         setupRecyclerView()
 
         adapter.addLoadStateListener { loadState ->
-            if (loadState.refresh != LoadState.Loading) {
+            if (loadState.refresh != LoadState.Loading && loadState.source.refresh != LoadState.Loading) {
                 binding.swipeRefreshLayout.isRefreshing = false
             }
 


### PR DESCRIPTION
The refresh indicator was hidden a split second before the new statuses were visible, which was annoying because one thinks that there is nothing new but then the timeline jumps. The problem was the indicator was already hidden when network loading was finished. With this change it will wait until database loading is finished as well.