### PR TITLE
Improve UX when Login WebView fails to load the page

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/login/LoginActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/login/LoginActivity.kt
@@ -68,7 +68,9 @@ class LoginActivity : BaseActivity(), Injectable {
                 // Authorization failed. Put the error response where the user can read it and they
                 // can try again.
                 setLoading(false)
-                binding.domainTextInputLayout.error = getString(R.string.error_authorization_denied)
+                // Use error returned by the server or fall back to the generic message
+                binding.domainTextInputLayout.error =
+                    result.errorMessage.ifBlank { getString(R.string.error_authorization_denied) }
                 Log.e(
                     TAG,
                     "%s %s".format(

--- a/app/src/main/java/com/keylesspalace/tusky/components/login/LoginWebViewActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/login/LoginWebViewActivity.kt
@@ -117,7 +117,7 @@ class LoginWebViewActivity : BaseActivity(), Injectable {
                 error: WebResourceError
             ) {
                 Log.d("LoginWeb", "Failed to load ${data.url}: $error")
-                finishWithoutSlideOutAnimation()
+                sendResult(LoginResult.Err(getString(R.string.error_could_not_load_login_page)))
             }
 
             override fun shouldOverrideUrlLoading(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="error_authorization_unknown">An unidentified authorization error occurred.</string>
     <string name="error_authorization_denied">Authorization was denied.</string>
     <string name="error_retrieving_oauth_token">Failed getting a login token.</string>
+    <string name="error_could_not_load_login_page">Could not load the login page.</string>
     <string name="error_compose_character_limit">The post is too long!</string>
     <string name="error_image_upload_size">The file must be less than 8MB.</string>
     <string name="error_video_upload_size">Video files must be less than 40MB.</string>


### PR DESCRIPTION
Previously we simply closed the screen with the login WebView which
could cause confusion. Now we specify that page could not be loaded.

As a side effect it will also show the error message which the server
returns (if any).