### PR TITLE
Fix crash when saving redrafted media to drafts

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -53,7 +53,6 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.viewModelScope
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.transition.TransitionManager
@@ -969,7 +968,16 @@ class ComposeActivity :
 
     private fun saveDraftAndFinish(contentText: String, contentWarning: String) {
         lifecycleScope.launch {
+            val dialog = if (viewModel.shouldShowSaveDraftDialog()) {
+                ProgressDialog.show(
+                    this@ComposeActivity, null,
+                    getString(R.string.saving_draft), true, false
+                )
+            } else {
+                null
+            }
             viewModel.saveDraft(contentText, contentWarning)
+            dialog?.cancel()
             finishWithoutSlideOutAnimation()
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -53,6 +53,7 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.viewModelScope
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.transition.TransitionManager
@@ -967,8 +968,10 @@ class ComposeActivity :
     }
 
     private fun saveDraftAndFinish(contentText: String, contentWarning: String) {
-        viewModel.saveDraft(contentText, contentWarning)
-        finishWithoutSlideOutAnimation()
+        lifecycleScope.launch {
+            viewModel.saveDraft(contentText, contentWarning)
+            finishWithoutSlideOutAnimation()
+        }
     }
 
     override fun search(token: String): List<ComposeAutoCompleteAdapter.AutocompleteResult> {

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -220,8 +220,7 @@ class ComposeViewModel @Inject constructor(
         }
     }
 
-    fun saveDraft(content: String, contentWarning: String) {
-        viewModelScope.launch {
+    suspend fun saveDraft(content: String, contentWarning: String) {
             val mediaUris: MutableList<String> = mutableListOf()
             val mediaDescriptions: MutableList<String?> = mutableListOf()
             media.value.forEach { item ->
@@ -242,7 +241,6 @@ class ComposeViewModel @Inject constructor(
                 poll = poll.value,
                 failedToSend = false
             )
-        }
     }
 
     /**

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -220,27 +220,34 @@ class ComposeViewModel @Inject constructor(
         }
     }
 
-    suspend fun saveDraft(content: String, contentWarning: String) {
-            val mediaUris: MutableList<String> = mutableListOf()
-            val mediaDescriptions: MutableList<String?> = mutableListOf()
-            media.value.forEach { item ->
-                mediaUris.add(item.uri.toString())
-                mediaDescriptions.add(item.description)
-            }
+    fun shouldShowSaveDraftDialog(): Boolean {
+        // if any of the media files need to be downloaded first it could take a while, so show a loading dialog
+        return media.value.any { mediaValue ->
+            mediaValue.uri.scheme == "https"
+        }
+    }
 
-            draftHelper.saveDraft(
-                draftId = draftId,
-                accountId = accountManager.activeAccount?.id!!,
-                inReplyToId = inReplyToId,
-                content = content,
-                contentWarning = contentWarning,
-                sensitive = markMediaAsSensitive.value!!,
-                visibility = statusVisibility.value!!,
-                mediaUris = mediaUris,
-                mediaDescriptions = mediaDescriptions,
-                poll = poll.value,
-                failedToSend = false
-            )
+    suspend fun saveDraft(content: String, contentWarning: String) {
+        val mediaUris: MutableList<String> = mutableListOf()
+        val mediaDescriptions: MutableList<String?> = mutableListOf()
+        media.value.forEach { item ->
+            mediaUris.add(item.uri.toString())
+            mediaDescriptions.add(item.description)
+        }
+
+        draftHelper.saveDraft(
+            draftId = draftId,
+            accountId = accountManager.activeAccount?.id!!,
+            inReplyToId = inReplyToId,
+            content = content,
+            contentWarning = contentWarning,
+            sensitive = markMediaAsSensitive.value!!,
+            visibility = statusVisibility.value!!,
+            mediaUris = mediaUris,
+            mediaDescriptions = mediaDescriptions,
+            poll = poll.value,
+            failedToSend = false
+        )
     }
 
     /**

--- a/app/src/main/java/com/keylesspalace/tusky/components/drafts/DraftHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/drafts/DraftHelper.kt
@@ -30,6 +30,10 @@ import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.util.IOUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okio.buffer
+import okio.sink
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -38,6 +42,7 @@ import javax.inject.Inject
 
 class DraftHelper @Inject constructor(
     val context: Context,
+    val okHttpClient: OkHttpClient,
     db: AppDatabase
 ) {
 
@@ -72,10 +77,10 @@ class DraftHelper @Inject constructor(
         val uris = mediaUris.map { uriString ->
             uriString.toUri()
         }.map { uri ->
-            if (uri.isNotInFolder(draftDirectory)) {
-                uri.copyToFolder(draftDirectory)
-            } else {
+            if (uri.isInFolder(draftDirectory)) {
                 uri
+            } else {
+                uri.copyToFolder(draftDirectory)
             }
         }
 
@@ -114,6 +119,7 @@ class DraftHelper @Inject constructor(
         )
 
         draftDao.insertOrReplace(draft)
+        Log.d("DraftHelper", "saved draft to db")
     }
 
     suspend fun deleteDraftAndAttachments(draftId: Int) {
@@ -133,33 +139,50 @@ class DraftHelper @Inject constructor(
         }
     }
 
-    suspend fun deleteAttachments(draft: DraftEntity) {
-        withContext(Dispatchers.IO) {
-            draft.attachments.forEach { attachment ->
-                if (context.contentResolver.delete(attachment.uri, null, null) == 0) {
-                    Log.e("DraftHelper", "Did not delete file ${attachment.uriString}")
-                }
+    suspend fun deleteAttachments(draft: DraftEntity) = withContext(Dispatchers.IO) {
+        draft.attachments.forEach { attachment ->
+            if (context.contentResolver.delete(attachment.uri, null, null) == 0) {
+                Log.e("DraftHelper", "Did not delete file ${attachment.uriString}")
             }
         }
     }
 
-    private fun Uri.isNotInFolder(folder: File): Boolean {
+    private fun Uri.isInFolder(folder: File): Boolean {
         val filePath = path ?: return true
         return File(filePath).parentFile == folder
     }
 
     private fun Uri.copyToFolder(folder: File): Uri {
         val contentResolver = context.contentResolver
-
         val timeStamp: String = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
 
-        val mimeType = contentResolver.getType(this)
-        val map = MimeTypeMap.getSingleton()
-        val fileExtension = map.getExtensionFromMimeType(mimeType)
+        val fileExtension = if (scheme == "https") {
+            lastPathSegment?.substringAfterLast('.', "tmp")
+        } else {
+            val mimeType = contentResolver.getType(this)
+            val map = MimeTypeMap.getSingleton()
+            map.getExtensionFromMimeType(mimeType)
+        }
 
         val filename = String.format("Tusky_Draft_Media_%s.%s", timeStamp, fileExtension)
         val file = File(folder, filename)
-        IOUtils.copyToFile(contentResolver, this, file)
+
+        if (scheme == "https") {
+            val client = OkHttpClient()
+            val request = Request.Builder().url(toString()).build()
+
+            val response = client.newCall(request).execute()
+
+            val sink = file.sink().buffer()
+
+            response.body?.source()?.use { input ->
+                sink.use { output ->
+                    output.writeAll(input)
+                }
+            }
+        } else {
+            IOUtils.copyToFile(contentResolver, this, file)
+        }
         return FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".fileprovider", file)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -640,5 +640,6 @@
     <string name="action_unsubscribe_account">Unsubscribe</string>
 
     <string name="tusky_compose_post_quicksetting_label">Compose Post</string>
+    <string name="saving_draft">Saving draft...</string>
 
 </resources>


### PR DESCRIPTION
This is not ideal, but hey it is better than crashing.

It eats error, so users media may be lost, but copying local media does as well.

closes #2499