### PR TITLE
fix currently logged in profiles not being visible in main drawer when offline

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -621,6 +621,8 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
         binding.mainToolbar.setOnClickListener {
             (adapter.getFragment(activeTabLayout.selectedTabPosition) as? ReselectableFragment)?.onReselect()
         }
+
+        updateProfiles()
     }
 
     private fun handleProfileClick(profile: IProfile, current: Boolean): Boolean {


### PR DESCRIPTION
closes #2515 

I think this already worked once but got lost in some refactoring