### PR TITLE
Ability to crop images attached to posts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -175,7 +175,7 @@ dependencies {
     implementation "com.mikepenz:materialdrawer-iconics:$materialdrawerVersion"
     implementation 'com.mikepenz:google-material-typeface:4.0.0.2-kotlin@aar'
 
-    implementation "com.github.CanHub:Android-Image-Cropper:4.1.0"
+    implementation "com.github.CanHub:Android-Image-Cropper:4.2.1"
 
     implementation "de.c1710:filemojicompat-ui:$filemojicompat_version"
     implementation "de.c1710:filemojicompat:$filemojicompat_version"

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -29,6 +29,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
+import android.provider.MediaStore
 import android.util.Log
 import android.view.KeyEvent
 import android.view.MenuItem
@@ -56,6 +57,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.transition.TransitionManager
+import com.canhub.cropper.CropImageContract
+import com.canhub.cropper.options
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.snackbar.Snackbar
 import com.keylesspalace.tusky.BaseActivity
@@ -186,6 +189,7 @@ class ComposeActivity :
                     viewModel.updateDescription(item.localId, newDescription)
                 }
             },
+            onEditImage = this::editImageInQueue,
             onRemove = this::removeMediaFromQueue
         )
         binding.composeMediaPreviewBar.layoutManager =
@@ -865,6 +869,26 @@ class ComposeActivity :
         )
         binding.addPollTextActionTextView.setTextColor(textColor)
         binding.addPollTextActionTextView.compoundDrawablesRelative[0].colorFilter = PorterDuffColorFilter(textColor, PorterDuff.Mode.SRC_IN)
+    }
+
+    private val cropImage = registerForActivityResult(CropImageContract()) { result ->
+        if (result.isSuccessful) {
+            Log.w("CROPTEST","SUCCESS")
+        } else {
+            Log.w("CROPTEST","FAIL")
+        }
+    }
+
+    private fun editImageInQueue(item: QueuedMedia) {
+        cropImage.launch(
+            options(uri=item.uri) {
+                //setRequestedSize(AVATAR_SIZE, AVATAR_SIZE)
+                //setAspectRatio(AVATAR_SIZE, AVATAR_SIZE)
+                //setImageSource(includeGallery = true, includeCamera = false)
+                setOutputUri(item.uri)
+                //setOutputCompressFormat(Bitmap.CompressFormat.PNG)
+            }
+        )
     }
 
     private fun removeMediaFromQueue(item: QueuedMedia) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -902,8 +902,8 @@ class ComposeActivity :
     private fun editImageInQueue(item: QueuedMedia) {
         // If input image is lossless, output image should be lossless.
         // Currently the only supported lossless format is png.
-        val mimeType:String? = contentResolver.getType(item.uri)
-        val isPng:Boolean = mimeType != null && mimeType.endsWith("/png")
+        val mimeType: String? = contentResolver.getType(item.uri)
+        val isPng: Boolean = mimeType != null && mimeType.endsWith("/png")
         val context = getApplicationContext()
         val tempFile = createNewImageFile(context, if (isPng) ".png" else ".jpg")
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -910,10 +910,10 @@ class ComposeActivity :
         cropImageFileNew = tempFile
         cropImageUriNew = uriNew
         cropImage.launch(
-            options(uri=item.uri) {
+            options(uri = item.uri) {
                 setOutputUri(uriNew)
                 // TODO: Should compress format be set or will there be a sensible default?
-                //setOutputCompressFormat(Bitmap.CompressFormat.PNG)
+                // setOutputCompressFormat(Bitmap.CompressFormat.PNG)
             }
         )
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -56,6 +56,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.transition.TransitionManager
+import com.canhub.cropper.CropImage
 import com.canhub.cropper.CropImageContract
 import com.canhub.cropper.options
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -894,9 +895,11 @@ class ComposeActivity :
                     }
                 }
             }
+        } else if (result == CropImage.CancelledResult) {
+            Log.w("ComposeActivity", "Edit image cancelled by user")
         } else {
-            // TODO: In else case check result.getError() to see if this was a voluntary cancel, display error if involuntary
-            Log.w("ComposeActivity", "Edit image aborted: " + result.error)
+            Log.w("ComposeActivity", "Edit image failed: " + result.error)
+            displayTransientError(R.string.error_media_edit_failed)
         }
         cropImageItemOld = null
         cropImageUriNew = null

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -873,13 +873,11 @@ class ComposeActivity :
         binding.addPollTextActionTextView.compoundDrawablesRelative[0].colorFilter = PorterDuffColorFilter(textColor, PorterDuff.Mode.SRC_IN)
     }
 
-    // Use to pass state from cropImage caller to result function
-    private var cropImageItemOld: QueuedMedia? = null
-
+    // Contract kicked off by editImageInQueue; expects viewModel.cropImageItemOld set
     private val cropImage = registerForActivityResult(CropImageContract()) { result ->
         val uriNew = result.uriContent
         if (result.isSuccessful && uriNew != null) {
-            cropImageItemOld?.let { itemOld ->
+            viewModel.cropImageItemOld?.let { itemOld ->
                 val size = getMediaSize(getApplicationContext().getContentResolver(), uriNew)
 
                 lifecycleScope.launch {
@@ -898,7 +896,7 @@ class ComposeActivity :
             Log.w("ComposeActivity", "Edit image failed: " + result.error)
             displayTransientError(R.string.error_media_edit_failed)
         }
-        cropImageItemOld = null
+        viewModel.cropImageItemOld = null
     }
 
     private fun editImageInQueue(item: QueuedMedia) {
@@ -912,7 +910,7 @@ class ComposeActivity :
         // "Authority" must be the same as the android:authorities string in AndroidManifest.xml
         val uriNew = FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".fileprovider", tempFile)
 
-        cropImageItemOld = item
+        viewModel.cropImageItemOld = item
 
         cropImage.launch(
             options(uri = item.uri) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -143,7 +143,7 @@ class ComposeViewModel @Inject constructor(
             if (replaceItem != null) {
                 mediaToJob[replaceItem.localId]?.cancel()
                 mediaValue.map {
-                   if (it.localId == replaceItem.localId) mediaItem else it
+                    if (it.localId == replaceItem.localId) mediaItem else it
                 }
             } else { // Append
                 mediaValue + mediaItem

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -94,6 +94,9 @@ class ComposeViewModel @Inject constructor(
 
     private val isEditingScheduledToot get() = !scheduledTootId.isNullOrEmpty()
 
+    // Used in ComposeActivity to pass state to result function when cropImage contract inflight
+    var cropImageItemOld: QueuedMedia? = null
+
     init {
         viewModelScope.launch {
             emoji.postValue(instanceInfoRepo.getEmojis())

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaPreviewAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaPreviewAdapter.kt
@@ -32,6 +32,7 @@ import com.keylesspalace.tusky.components.compose.view.ProgressImageView
 class MediaPreviewAdapter(
     context: Context,
     private val onAddCaption: (ComposeActivity.QueuedMedia) -> Unit,
+    private val onEditImage: (ComposeActivity.QueuedMedia) -> Unit,
     private val onRemove: (ComposeActivity.QueuedMedia) -> Unit
 ) : RecyclerView.Adapter<MediaPreviewAdapter.PreviewViewHolder>() {
 
@@ -43,12 +44,16 @@ class MediaPreviewAdapter(
         val item = differ.currentList[position]
         val popup = PopupMenu(view.context, view)
         val addCaptionId = 1
-        val removeId = 2
+        val editImageId = 2
+        val removeId = 3
         popup.menu.add(0, addCaptionId, 0, R.string.action_set_caption)
+        if (item.type == ComposeActivity.QueuedMedia.Type.IMAGE)
+            popup.menu.add(0, editImageId, 0, R.string.action_edit_image)
         popup.menu.add(0, removeId, 0, R.string.action_remove)
         popup.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
                 addCaptionId -> onAddCaption(item)
+                editImageId -> onEditImage(item)
                 removeId -> onRemove(item)
             }
             true

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
@@ -54,14 +54,14 @@ sealed class UploadEvent {
     data class FinishedEvent(val mediaId: String) : UploadEvent()
 }
 
-fun createNewImageFile(context: Context): File {
+fun createNewImageFile(context: Context, suffix: String = ".jpg"): File {
     // Create an image file name
     val randomId = randomAlphanumericString(12)
     val imageFileName = "Tusky_${randomId}_"
     val storageDir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
     return File.createTempFile(
         imageFileName, /* prefix */
-        ".jpg", /* suffix */
+        suffix, /* suffix */
         storageDir /* directory */
     )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -401,6 +401,7 @@
         <item quantity="other">Describe for visually impaired\n(%d character limit)</item>
     </plurals>
     <string name="action_set_caption">Set caption</string>
+    <string name="action_edit_image">Edit image</string>
     <string name="action_remove">Remove</string>
     <string name="lock_account_label">Lock account</string>
     <string name="lock_account_label_description">Requires you to manually approve followers</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="error_image_upload_size">The file must be less than 8MB.</string>
     <string name="error_video_upload_size">Video files must be less than 40MB.</string>
     <string name="error_audio_upload_size">Audio files must be less than 40MB.</string>
+    <string name="error_media_edit_failed">The attachment could not be edited.</string>
     <string name="error_media_upload_type">That type of file cannot be uploaded.</string>
     <string name="error_media_upload_opening">That file could not be opened.</string>
     <string name="error_media_upload_permission">Permission to read media is required.</string>


### PR DESCRIPTION
It should be possible to crop images. There is a crop library already in place.

This is a work in progress. I have created a pull request so I can ask questions on the Matrix channel.

Current status: The menu item for the cropper is created, the local content URL is updated, but the server is not notified.