### PR TITLE
remove legacy notification channel cleanup

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/SplashActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/SplashActivity.kt
@@ -20,7 +20,6 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.keylesspalace.tusky.components.login.LoginActivity
-import com.keylesspalace.tusky.components.notifications.NotificationHelper
 import com.keylesspalace.tusky.db.AccountManager
 import com.keylesspalace.tusky.di.Injectable
 import javax.inject.Inject
@@ -34,12 +33,8 @@ class SplashActivity : AppCompatActivity(), Injectable {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        /** delete old notification channels */
-        NotificationHelper.deleteLegacyNotificationChannels(this, accountManager)
-
         /** Determine whether the user is currently logged in, and if so go ahead and load the
          *  timeline. Otherwise, start the activity_login screen. */
-
         val intent = if (accountManager.activeAccount != null) {
             Intent(this, MainActivity::class.java)
         } else {

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationHelper.java
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationHelper.java
@@ -458,24 +458,6 @@ public class NotificationHelper {
         }
     }
 
-    public static void deleteLegacyNotificationChannels(@NonNull Context context, @NonNull AccountManager accountManager) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-
-            NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-
-            // used until Tusky 1.4
-            notificationManager.deleteNotificationChannel(CHANNEL_MENTION);
-            notificationManager.deleteNotificationChannel(CHANNEL_FAVOURITE);
-            notificationManager.deleteNotificationChannel(CHANNEL_BOOST);
-            notificationManager.deleteNotificationChannel(CHANNEL_FOLLOW);
-
-            // used until Tusky 1.7
-            for(AccountEntity account: accountManager.getAllAccountsOrderedByActive()) {
-                notificationManager.deleteNotificationChannel(CHANNEL_FAVOURITE+" "+account.getIdentifier());
-            }
-        }
-    }
-
     public static boolean areNotificationsEnabled(@NonNull Context context, @NonNull AccountManager accountManager) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 


### PR DESCRIPTION
- Tusky 1.7 was released over 4 years ago so all users should have upgraded
- this was executed on every appstart which is super inefficient considering it just needed to run once
- (even if someone upgrades after this is removed, they will have some unused channels, so what)