### PR TITLE
Ability to crop/trim videos attached to posts via intent [draft]

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -19,6 +19,7 @@ import android.Manifest
 import android.app.Activity
 import android.app.NotificationManager
 import android.app.ProgressDialog
+import android.content.ActivityNotFoundException
 import android.content.ClipData
 import android.content.Context
 import android.content.Intent
@@ -37,6 +38,7 @@ import android.view.KeyEvent
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.MimeTypeMap
 import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.PopupMenu
@@ -184,7 +186,7 @@ class ComposeActivity :
         viewModel.cropImageItemOld = null
     }
 
-    // Function to catch the response
+    // Function to catch the response from editMediaInQueue, intent case
     // Warning: Comment out this function or it will swallow the image picker result!!
     val MEDIA_EDIT_REQUESTCODE = 0x1001
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -192,10 +194,11 @@ class ComposeActivity :
             MEDIA_EDIT_REQUESTCODE -> {
                 if (resultCode == Activity.RESULT_OK && data != null) {
                     Log.d(TAG, "User Response received: $data")
-                }else{
+                } else {
                     Log.d(TAG,"User Response is empty")
                 }
             }
+            else -> super.onActivityResult(requestCode, resultCode, data)
         }
     }
 
@@ -917,18 +920,29 @@ class ComposeActivity :
     }
 
     private fun editMediaInQueue(item: QueuedMedia) {
-        val editInternally = item.type == ComposeActivity.QueuedMedia.Type.IMAGE
-        if (editInternally) {
-            // If input image is lossless, output image should be lossless.
-            // Currently the only supported lossless format is png.
-            val mimeType: String? = contentResolver.getType(item.uri)
-            val isPng: Boolean = mimeType != null && mimeType.endsWith("/png")
-            val context = getApplicationContext()
-            val tempFile = createNewImageFile(context, if (isPng) ".png" else ".jpg")
+        // First create a temp-file content url to store the edited media in, then decide what to put in it
+        val isImage = item.type == ComposeActivity.QueuedMedia.Type.IMAGE
+        val mimeType: String? = contentResolver.getType(item.uri)
 
-            // "Authority" must be the same as the android:authorities string in AndroidManifest.xml
-            val uriNew = FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".fileprovider", tempFile)
+        // If input is a lossless image, output image should be lossless.
+        // Currently the only supported lossless format is png.
+        val isPng: Boolean = isImage && mimeType != null && mimeType.endsWith("/png")
+        val context = getApplicationContext()
+        val tempFile = createNewImageFile(context,
+            if (isPng) { ".png" }
+            else if (isImage) { ".jpg" }
+            else {
+                val extension = if (mimeType != null) MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType) else null
+                if (extension != null) "." + extension
+                else "" // FIXME: Would be better to error? Without a mime type the intent won't form right
+            }
+        )
 
+        // "Authority" here must be the same as the android:authorities string in AndroidManifest.xml
+        val uriNew = FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".fileprovider", tempFile)
+
+        val editInternally = isImage
+        if (editInternally) { // We can use Android-Image-Cropper
             viewModel.cropImageItemOld = item
 
             cropImage.launch(
@@ -940,16 +954,21 @@ class ComposeActivity :
         } else { // Pawn off to a external editor
             val intent = Intent(Intent.ACTION_EDIT)
             intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-            intent.setDataAndType(item.uri, "image/*")         // Where will media be loaded from?
-            intent.putExtra(MediaStore.EXTRA_OUTPUT, item.uri) // Where will media be saved to?
+            intent.setDataAndType(item.uri, mimeType)         // Where will media be loaded from?
+            intent.putExtra(MediaStore.EXTRA_OUTPUT, uriNew) // Where will media be saved to?
 
-            val context = getApplicationContext()
+            // FIXME: This grants more permissions to more apps than are necessary
             val resInfoList = context.getPackageManager().queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
             for (resolveInfo in resInfoList) {
                 val packageName = resolveInfo.activityInfo.packageName;
-                context.grantUriPermission(packageName, item.uri, Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                context.grantUriPermission(packageName, uriNew, Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION);
             }
-            startActivityForResult(intent, MEDIA_EDIT_REQUESTCODE) //Intent.createChooser(intent)
+            try {
+                startActivityForResult(intent, MEDIA_EDIT_REQUESTCODE) // FIXME: Would using Intent.createChooser(intent) be better?
+            } catch (e: ActivityNotFoundException) {
+                // FIXME: Would be nice if error message could be specialized on (or flat out include) the mime type
+                displayTransientError(R.string.error_media_edit_intent_failed)
+            } 
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaPreviewAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaPreviewAdapter.kt
@@ -32,7 +32,7 @@ import com.keylesspalace.tusky.components.compose.view.ProgressImageView
 class MediaPreviewAdapter(
     context: Context,
     private val onAddCaption: (ComposeActivity.QueuedMedia) -> Unit,
-    private val onEditImage: (ComposeActivity.QueuedMedia) -> Unit,
+    private val onEditMedia: (ComposeActivity.QueuedMedia) -> Unit,
     private val onRemove: (ComposeActivity.QueuedMedia) -> Unit
 ) : RecyclerView.Adapter<MediaPreviewAdapter.PreviewViewHolder>() {
 
@@ -44,16 +44,16 @@ class MediaPreviewAdapter(
         val item = differ.currentList[position]
         val popup = PopupMenu(view.context, view)
         val addCaptionId = 1
-        val editImageId = 2
+        val editMediaId = 2
         val removeId = 3
+        val editMediaText = if (item.type == ComposeActivity.QueuedMedia.Type.IMAGE) R.string.action_edit_image else R.string.action_edit_media
         popup.menu.add(0, addCaptionId, 0, R.string.action_set_caption)
-        if (item.type == ComposeActivity.QueuedMedia.Type.IMAGE)
-            popup.menu.add(0, editImageId, 0, R.string.action_edit_image)
+        popup.menu.add(0, editMediaId, 0, editMediaText)
         popup.menu.add(0, removeId, 0, R.string.action_remove)
         popup.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
                 addCaptionId -> onAddCaption(item)
-                editImageId -> onEditImage(item)
+                editMediaId -> onEditMedia(item)
                 removeId -> onRemove(item)
             }
             true

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -406,6 +406,7 @@
     </plurals>
     <string name="action_set_caption">Set caption</string>
     <string name="action_edit_image">Edit image</string>
+    <string name="action_edit_media">Edit media</string>
     <string name="action_remove">Remove</string>
     <string name="lock_account_label">Lock account</string>
     <string name="lock_account_label_description">Requires you to manually approve followers</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="error_video_upload_size">Video files must be less than 40MB.</string>
     <string name="error_audio_upload_size">Audio files must be less than 40MB.</string>
     <string name="error_media_edit_failed">The attachment could not be edited.</string>
+    <string name="error_media_edit_intent_failed">No apps are installed that can edit this file type.</string>
     <string name="error_media_upload_type">That type of file cannot be uploaded.</string>
     <string name="error_media_upload_opening">That file could not be opened.</string>
     <string name="error_media_upload_permission">Permission to read media is required.</string>


### PR DESCRIPTION
I'm not sure about this, I think I might need help to get it working.

The idea was to have a code path that passes media off via implicit intent to an external program, and that would images would continue to be edited by Android-Image-Cropper but video and audio would instead invoke the intent path. If the intent path turned out to work well for video, I was going to propose a setting that would optionally allow the user to configure Tusky to handle images through intents also.

But, in my testing, the intent path works with images but *not* video. If you change `val editInternally = isImage` to `val editInternally = false`, the intent path will invoke even for images and it can pass off an image to an image editor (Photos, on my phone) and get a successful result; I know this because it prints
```
2022-05-22 23:53:04.542 32174-32174/com.keylesspalace.tusky_DEV D/ComposeActivity: User Response received: Intent { dat=content://com.keylesspalace.tusky_DEV.fileprovider/my_images/Android/data/com.keylesspalace.tusky_DEV/files/Pictures/Tusky_8XR95ZBCENS1_6584364492142417520.jpg typ=image/jpeg }
```
in logcat.

However, when I try to edit a *video* attachment with this code, startActivityForResult raises a ActivityNotFoundException saying there is no installed program that can edit video/mp4. Photos is definitely able to edit mp4 files, and I have a strange Sony program called Cinema Pro installed that I think can also edit video, though I do not know whether either of these programs correctly register themselves as intents that can edit mp4 video.

Either I haven't found the right program for editing videos, or something is wrong with the PR code.

The current code prints a nice error message in the failure case. In the success case it currently only logcats and drops the value on the floor (it would be straightforward to wire through the content URL in the result object to `addMediaToQueue`, but if the code can't edit videos there may not be a point).

There is an additional problem described below: