### PR TITLE
Fire observable to update timestamps directly on resume (#2554)

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
@@ -471,7 +471,7 @@ class TimelineFragment :
         val preferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
         val useAbsoluteTime = preferences.getBoolean(PrefKeys.ABSOLUTE_TIME_VIEW, false)
         if (!useAbsoluteTime) {
-            Observable.interval(1, TimeUnit.MINUTES)
+            Observable.interval(0, 1, TimeUnit.MINUTES)
                 .observeOn(AndroidSchedulers.mainThread())
                 .autoDispose(this, Lifecycle.Event.ON_PAUSE)
                 .subscribe {


### PR DESCRIPTION
An initial delay (0) can be specified.

Fixes https://github.com/tuskyapp/Tusky/issues/2554