### PR TITLE
update android animation glide plugin to 2.22.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -152,7 +152,7 @@ dependencies {
     implementation "com.github.bumptech.glide:okhttp3-integration:$glideVersion"
     kapt "com.github.bumptech.glide:compiler:$glideVersion"
 
-    implementation "com.github.penfeizhou.android.animation:glide-plugin:2.20.0"
+    implementation "com.github.penfeizhou.android.animation:glide-plugin:2.22.0"
 
     implementation "io.reactivex.rxjava3:rxjava:3.1.3"
     implementation "io.reactivex.rxjava3:rxandroid:3.0.0"


### PR DESCRIPTION
This fixes a crash with gifs some instances have as custom emoji, see https://github.com/penfeizhou/APNG4Android/issues/148