### PR TITLE
Fix filters in timelines in a simple way

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -249,6 +249,10 @@ class NetworkTimelineViewModel @Inject constructor(
         currentSource?.invalidate()
     }
 
+    override fun invalidate() {
+        currentSource?.invalidate()
+    }
+
     @Throws(IOException::class, HttpException::class)
     suspend fun fetchStatusesForKind(
         fromId: String?,

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
@@ -172,6 +172,9 @@ abstract class TimelineViewModel(
 
     abstract fun fullReload()
 
+    /** Triggered when currently displayed data must be reloaded. */
+    protected abstract fun invalidate()
+
     protected fun shouldFilterStatus(statusViewData: StatusViewData): Boolean {
         val status = statusViewData.asStatusOrNull()?.status ?: return false
         return status.inReplyToId != null && filterRemoveReplies ||
@@ -287,6 +290,9 @@ abstract class TimelineViewModel(
                     filterContextMatchesKind(kind, it.context)
                 }
             )
+            // After the filters are loaded we need to reload displayed content to apply them.
+            // It can happen during the usage or at startup, when we get statuses before filters.
+            invalidate()
         }
     }
 


### PR DESCRIPTION
Loading of statuses and loading of filters is an "intended" race:
we want to display statuses first, especially if they are cached.
Unfortunately we do not cache filters themselves so when we load cached
statuses we do not apply filters.

One part of the solution is to re-filter the statuses once we fetch the
filters. This commit implements it. Caching of filters is not included
yet.

fixes #2546