### PR TITLE
Fix unintended [mismatched] show-replies preference

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/TabFilterPreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/TabFilterPreferencesFragment.kt
@@ -39,7 +39,7 @@ class TabFilterPreferencesFragment : PreferenceFragmentCompat() {
                 checkBoxPreference {
                     setTitle(R.string.pref_title_show_replies)
                     key = PrefKeys.TAB_FILTER_HOME_REPLIES
-                    setDefaultValue(false)
+                    setDefaultValue(true)
                     isIconSpaceReserved = false
                 }
             }

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
@@ -81,6 +81,7 @@ abstract class TimelineViewModel(
         this.tags = tags
 
         if (kind == Kind.HOME) {
+            // Note the variable is "true if filter" but the underlying preference/settings text is "true if show"
             filterRemoveReplies =
                 !sharedPreferences.getBoolean(PrefKeys.TAB_FILTER_HOME_REPLIES, true)
             filterRemoveReblogs =


### PR DESCRIPTION
Also add a comment to prevent confusion.

In my testing, this works with new app installs but **not** with existing app installs, I assume because they've already saved the default as an actual key. See second PR.