### PR TITLE
Fix unintended [mismatched] show-replies preference (with key force-reset)

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/TabFilterPreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/TabFilterPreferencesFragment.kt
@@ -39,7 +39,7 @@ class TabFilterPreferencesFragment : PreferenceFragmentCompat() {
                 checkBoxPreference {
                     setTitle(R.string.pref_title_show_replies)
                     key = PrefKeys.TAB_FILTER_HOME_REPLIES
-                    setDefaultValue(false)
+                    setDefaultValue(true)
                     isIconSpaceReserved = false
                 }
             }

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
@@ -81,6 +81,7 @@ abstract class TimelineViewModel(
         this.tags = tags
 
         if (kind == Kind.HOME) {
+            // Note the variable is "true if filter" but the underlying preference/settings text is "true if show"
             filterRemoveReplies =
                 !sharedPreferences.getBoolean(PrefKeys.TAB_FILTER_HOME_REPLIES, true)
             filterRemoveReblogs =

--- a/app/src/main/java/com/keylesspalace/tusky/settings/SettingsConstants.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/settings/SettingsConstants.kt
@@ -62,6 +62,6 @@ object PrefKeys {
     const val NOTIFICATION_FILTER_SIGN_UPS = "notificationFilterSignUps"
     const val NOTIFICATION_FILTER_UPDATES = "notificationFilterUpdates"
 
-    const val TAB_FILTER_HOME_REPLIES = "tabFilterHomeReplies"
+    const val TAB_FILTER_HOME_REPLIES = "tabFilterHomeReplies_v2" // This was changed once to reset an unintentionally set default.
     const val TAB_FILTER_HOME_BOOSTS = "tabFilterHomeBoosts"
 }


### PR DESCRIPTION
This is a variant of #2567 that changes the key to forcibly reset the key to true for everyone. This may be desirable because many of the people who had this key set to hide replies (including me, and at least two other people I talked to) were surprised to learn how the key was set and additionally did not know the key existed.