### PR TITLE
Use NetworkResult in MediaUploadApi

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
@@ -23,6 +23,7 @@ import android.util.Log
 import android.webkit.MimeTypeMap
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
+import at.connyduck.calladapter.networkresult.getOrThrow
 import com.keylesspalace.tusky.BuildConfig
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.components.compose.ComposeActivity.QueuedMedia

--- a/app/src/main/java/com/keylesspalace/tusky/network/MediaUploadApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MediaUploadApi.kt
@@ -1,5 +1,6 @@
 package com.keylesspalace.tusky.network
 
+import at.connyduck.calladapter.networkresult.NetworkResult
 import com.keylesspalace.tusky.entity.MediaUploadResult
 import okhttp3.MultipartBody
 import retrofit2.http.Multipart
@@ -15,5 +16,5 @@ interface MediaUploadApi {
     suspend fun uploadMedia(
         @Part file: MultipartBody.Part,
         @Part description: MultipartBody.Part? = null
-    ): Result<MediaUploadResult>
+    ): NetworkResult<MediaUploadResult>
 }


### PR DESCRIPTION
This PR updates the MediaUploadApi logic to use Conny's `NetworkResult` instead of the previous `Result` that was being returned.

closes https://github.com/tuskyapp/Tusky/issues/2576