### PR TITLE
UnifiedPush: FEATURE_BYTES_MESSAGE distributors

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/PushNotificationHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/PushNotificationHelper.kt
@@ -89,7 +89,7 @@ private suspend fun enableUnifiedPushNotificationsForAccount(context: Context, a
         // Already registered, update the subscription to match notification settings
         updateUnifiedPushSubscription(context, api, accountManager, account)
     } else {
-        UnifiedPush.registerAppWithDialog(context, account.id.toString())
+        UnifiedPush.registerAppWithDialog(context, account.id.toString(), features = arrayListOf(UnifiedPush.FEATURE_BYTES_MESSAGE))
     }
 }
 


### PR DESCRIPTION
Only use distributors which are compatible with FEATURE_BYTES_MESSAGE. This is because Mastodon sends notifications that are arbitrary bytes, not UTF-8. This causes issues in older versions of UnifiedPush distributors and providers that don't support FEATURE_BYTES_MESSAGE, specifically Gotify w/ Postgres, see #2547 for more info.

I have tested this on my device.
Closes #2547