### PR TITLE
rewrite InstanceDao queries to drop unused columns

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/db/InstanceDao.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/InstanceDao.kt
@@ -19,6 +19,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.RewriteQueriesToDropUnusedColumns
 
 @Dao
 interface InstanceDao {
@@ -29,9 +30,11 @@ interface InstanceDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE, entity = InstanceEntity::class)
     suspend fun insertOrReplace(emojis: EmojisEntity)
 
+    @RewriteQueriesToDropUnusedColumns
     @Query("SELECT * FROM InstanceEntity WHERE instance = :instance LIMIT 1")
     suspend fun getInstanceInfo(instance: String): InstanceInfoEntity?
 
+    @RewriteQueriesToDropUnusedColumns
     @Query("SELECT * FROM InstanceEntity WHERE instance = :instance LIMIT 1")
     suspend fun getEmojiInfo(instance: String): EmojisEntity?
 }


### PR DESCRIPTION
This gets rid of the build warning and it should be slightly more efficient because unused columns are not loaded into memory (and the column holding the emojis can be huge)