### PR TITLE
fix empty timeline on initial load

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -267,8 +267,11 @@ class CachedTimelineViewModel @Inject constructor(
         }
     }
 
-    override fun invalidate() {
-        currentPagingSource?.invalidate()
+    override suspend fun invalidate() {
+        // invalidating when we don't have statuses yet can cause empty timelines because it cancels the network load
+        if (db.timelineDao().getStatusCount(accountManager.activeAccount!!.id) > 0) {
+            currentPagingSource?.invalidate()
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -249,7 +249,7 @@ class NetworkTimelineViewModel @Inject constructor(
         currentSource?.invalidate()
     }
 
-    override fun invalidate() {
+    override suspend fun invalidate() {
         currentSource?.invalidate()
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
@@ -174,7 +174,7 @@ abstract class TimelineViewModel(
     abstract fun fullReload()
 
     /** Triggered when currently displayed data must be reloaded. */
-    protected abstract fun invalidate()
+    protected abstract suspend fun invalidate()
 
     protected fun shouldFilterStatus(statusViewData: StatusViewData): Boolean {
         val status = statusViewData.asStatusOrNull()?.status ?: return false

--- a/app/src/main/java/com/keylesspalace/tusky/db/TimelineDao.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/TimelineDao.kt
@@ -197,4 +197,7 @@ AND timelineUserId = :accountId
      */
     @Query("SELECT serverId FROM TimelineStatusEntity WHERE timelineUserId = :accountId AND authorServerId IS NULL AND (LENGTH(:serverId) > LENGTH(serverId) OR (LENGTH(:serverId) = LENGTH(serverId) AND :serverId > serverId)) ORDER BY LENGTH(serverId) DESC, serverId DESC LIMIT 1")
     abstract suspend fun getNextPlaceholderIdAfter(accountId: Long, serverId: String): String?
+
+    @Query("SELECT COUNT(*) FROM TimelineStatusEntity WHERE timelineUserId = :accountId")
+    abstract suspend fun getStatusCount(accountId: Long): Int
 }


### PR DESCRIPTION
New approach for the same problem as https://github.com/tuskyapp/Tusky/pull/2573

In contrast to #2573 this does not delay any network calls, but there might still be race conditions were the timeline stays empty or filters are not applied immediately. It worked fine in may testing though.