### PR TITLE
Don't display bot badge in account selection dialog

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/AccountSelectionAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/AccountSelectionAdapter.kt
@@ -44,6 +44,7 @@ class AccountSelectionAdapter(context: Context) : ArrayAdapter<AccountEntity>(co
 
             binding.username.text = account.fullName
             binding.displayName.text = account.displayName.emojify(account.emojis, binding.displayName, animateEmojis)
+            binding.avatarBadge.visibility = View.GONE // We never want to display the bot badge here
 
             val avatarRadius = context.resources.getDimensionPixelSize(R.dimen.avatar_radius_42dp)
             val animateAvatar = pm.getBoolean("animateGifAvatars", false)


### PR DESCRIPTION
Steps to reproduce:
- Add multiple accounts to Tusky
- Share something to Tusky from another app
- Observe the account selection list

Expected result: Only bot accounts are badged as bots
Actual result: All accounts are badged as bots

In the place where we create this dialog, we don't have any information about whether the account is a bot (because it's only on `TimelineAccount` and not `AccountEntity`). However, it's not useful information here anyway, so let's never show the badge.