### PR TITLE
Use specific term "image" in error UI, not "attachment"

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -177,7 +177,7 @@ class ComposeActivity :
             Log.w("ComposeActivity", "Edit image cancelled by user")
         } else {
             Log.w("ComposeActivity", "Edit image failed: " + result.error)
-            displayTransientError(R.string.error_media_edit_failed)
+            displayTransientError(R.string.error_image_edit_failed)
         }
         viewModel.cropImageItemOld = null
     }

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -534,7 +534,6 @@
     <string name="dialog_push_notification_migration">تاسکی برای استفاده از آگاهی‌های ارسالی با UnifiedPush نیاز به اجازهٔ اشتراک آگاهی‌ها روی کارساز ماستودنتان دارد. این کار نیازمند ورود دوباره برای تغییر حوزه‌های OAuth اعطایی به تاسکی است. استفاده از گزینهٔ ورود دوباره در این‌جا یا در ترجیحات حساب، تمامی انباره‌ها و پیش‌نویس‌های محلیتان را نگه خواهد داشت.</string>
     <string name="error_could_not_load_login_page">نتوانست صفحهٔ ورود را بار کند.</string>
     <string name="pref_title_notification_filter_sign_ups">کسی ثبت‌نام کرد</string>
-    <string name="error_media_edit_failed">پیوست نتوانست ویرایش شود.</string>
     <string name="notification_update_name">ویرایش‌های فرسته</string>
     <string name="action_edit_image">ویرایش تصویر</string>
     <string name="notification_update_format">%s فرسته‌اش را ویراست</string>

--- a/app/src/main/res/values-gd/strings.xml
+++ b/app/src/main/res/values-gd/strings.xml
@@ -562,6 +562,5 @@
     <string name="tips_push_notification_migration">Clàraich a-steach às ùr leis a h-uile cunntas a chur na taice ri brathan putaidh an comas.</string>
     <string name="title_migration_relogin">Clàraich a-steach às ùr airson brathan putaidh</string>
     <string name="status_count_one_plus">1+</string>
-    <string name="error_media_edit_failed">Cha deach le deasachadh a’ cheanglachain.</string>
     <string name="action_edit_image">Deasaich an dealbh</string>
 </resources>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -536,6 +536,5 @@
     <string name="error_could_not_load_login_page">Non se puido cargar a páxina de inicio.</string>
     <string name="saving_draft">Gardando borrador…</string>
     <string name="status_count_one_plus">1+</string>
-    <string name="error_media_edit_failed">Non se puido editar o anexo.</string>
     <string name="action_edit_image">Editar imaxe</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -542,7 +542,6 @@
     <string name="status_count_one_plus">1+</string>
     <string name="error_could_not_load_login_page">Nem tudtuk betölteni a bejelentkező oldalt.</string>
     <string name="saving_draft">Vázlat mentése…</string>
-    <string name="error_media_edit_failed">A csatolmány nem szerkeszthető.</string>
     <string name="dialog_push_notification_migration">Ahhoz, hogy használhass leküldési értesítéseket a UnifiedPush szolgáltatással, a Tusky-nak fel kell iratkoznia az értesítésekre a Mastodon szervereden. Ehhez új bejelentkezésre van szükség, hogy a Tusky számára kiosztott OAuth jogosultságok megváltozzanak. Az újbóli bejelentkezés funkció használata itt vagy a Fiókbeállításoknál meg fogja őrizni a helyi piszkozataidat és a cache tartalmát.</string>
     <string name="dialog_push_notification_migration_other_accounts">Újra bejelentkeztél a fiókodba, hogy feliratkoztasd a Tusky-t a leküldési értesítések használatára. Ugyanakkor vannak még fiókjaid, melyek még nem lettek így migrálva. Válts át rájuk és jelentkezz be újra mindegyikben, hogy ezekben is engedélyezd a UnifiedPush értesítések támogatását.</string>
     <string name="action_edit_image">Kép szerkesztése</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -532,7 +532,6 @@
     <string name="title_login">Skrá inn</string>
     <string name="status_count_one_plus">1+</string>
     <string name="error_could_not_load_login_page">Gat ekki lesið innskráningarsíðuna.</string>
-    <string name="error_media_edit_failed">Ekki var hægt að breyta viðhenginu.</string>
     <string name="action_edit_image">Breyta mynd</string>
     <string name="saving_draft">Vista drög…</string>
     <string name="title_migration_relogin">Skráðu aftur inn fyrir ýti-tilkynningar</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -540,7 +540,6 @@
     <string name="notification_update_name">Modifiche ai post</string>
     <string name="notification_update_description">Notifiche di quando i post con cui hai interagito vengono modificati</string>
     <string name="error_could_not_load_login_page">Non è stato possibile caricare la pagina di login.</string>
-    <string name="error_media_edit_failed">L\'allegato non può essere modificato.</string>
     <string name="action_edit_image">Modifica immagine</string>
     <string name="saving_draft">Salvataggio bozza…</string>
     <string name="action_dismiss">Scartare</string>

--- a/app/src/main/res/values-no-rNB/strings.xml
+++ b/app/src/main/res/values-no-rNB/strings.xml
@@ -536,6 +536,5 @@
     <string name="dialog_push_notification_migration_other_accounts">Du har logget inn på nytt for å tillate Tusky til å sende pushvarsler, men du har fortsatt andre konti som ikke har fått den nødvendige tillatelsen. Bytt til dem og logg inn på nytt på samme måte for å skru på støtte for pushvarsler via UnifiedPush.</string>
     <string name="saving_draft">Lagrer kladd…</string>
     <string name="status_count_one_plus">1+</string>
-    <string name="error_media_edit_failed">Vedlegget kan ikke redigeres.</string>
     <string name="action_edit_image">Rediger bilde</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -559,5 +559,4 @@
     <string name="account_date_joined">Приєднується %1$s</string>
     <string name="action_edit_image">Редагувати зображення</string>
     <string name="status_count_one_plus">1+</string>
-    <string name="error_media_edit_failed">Неможливо редагувати вкладення.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -525,6 +525,5 @@
     <string name="dialog_push_notification_migration_other_accounts">Bạn đã đăng nhập lại vào tài khoản hiện tại của mình để cấp quyền thông báo đẩy cho Tusky. Tuy nhiên, bạn vẫn có các tài khoản khác chưa kích hoạt thông báo đẩy theo cách này. Chuyển sang chúng và đăng nhập từng cái một để cho phép hỗ trợ thông báo UnifiedPush.</string>
     <string name="dialog_push_notification_migration">Để sử dụng thông báo đẩy qua UnifiedPush, Tusky cần có quyền đăng ký thông báo trên máy chủ Mastodon của bạn. Bạn hãy thoát ra rồi đăng nhập lại để thay đổi phạm vi OAuth được cấp cho Tusky. Sử dụng đăng nhập lại ở đây hoặc trong cài đặt Tài khoản sẽ bảo toàn tất cả các tút nháp và bộ nhớ đệm trên điện thoại của bạn.</string>
     <string name="status_count_one_plus">1+</string>
-    <string name="error_media_edit_failed">Tập tin đính kèm không thể chỉnh sửa.</string>
     <string name="action_edit_image">Sửa ảnh</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -544,6 +544,5 @@
     <string name="tips_push_notification_migration">重新登录所有账户来启用推送通知支持。</string>
     <string name="dialog_push_notification_migration">为了通过 UnifiedPush 使用推送通知，Tusky 需要订阅你 Mastodon 服务器通知的权限。这需要重新登录来更改授予 Tusky 的 OAuth 作用域。使用此处或账户首选项中“重新登录”选项将保留你所有的本地草稿和缓存。</string>
     <string name="status_count_one_plus">1+</string>
-    <string name="error_media_edit_failed">无法编辑附件。</string>
     <string name="action_edit_image">编辑图片</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,7 +14,7 @@
     <string name="error_image_upload_size">The file must be less than 8MB.</string>
     <string name="error_video_upload_size">Video files must be less than 40MB.</string>
     <string name="error_audio_upload_size">Audio files must be less than 40MB.</string>
-    <string name="error_media_edit_failed">The attachment could not be edited.</string>
+    <string name="error_image_edit_failed">The image could not be edited.</string>
     <string name="error_media_upload_type">That type of file cannot be uploaded.</string>
     <string name="error_media_upload_opening">That file could not be opened.</string>
     <string name="error_media_upload_permission">Permission to read media is required.</string>


### PR DESCRIPTION
The new message for the crop feature, "The attachment could not be edited.", turned out to be awkward in some languages (French) where according to the translator it would be better to more specifically say "The image could not be edited." (as currently we can only edit images). Patch replaces `error_media_edit_failed` with a `error_image_edit_failed` and deletes the existing `error_media_edit_failed`s.