### PR TITLE
show push migration snackbar above floating action button

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -703,7 +703,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
         NotificationHelper.createNotificationChannelsForAccount(accountManager.activeAccount!!, this)
 
         // Setup push notifications
-        showMigrationNoticeIfNecessary(this, binding.root, accountManager)
+        showMigrationNoticeIfNecessary(this, binding.mainCoordinatorLayout, binding.composeButton, accountManager)
         if (NotificationHelper.areNotificationsEnabled(this, accountManager)) {
             lifecycleScope.launch {
                 enablePushNotificationsWithFallback(this@MainActivity, mastodonApi, accountManager)

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/PushNotificationHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/PushNotificationHelper.kt
@@ -51,7 +51,12 @@ private fun accountNeedsMigration(account: AccountEntity): Boolean =
 fun currentAccountNeedsMigration(accountManager: AccountManager): Boolean =
     accountManager.activeAccount?.let(::accountNeedsMigration) ?: false
 
-fun showMigrationNoticeIfNecessary(context: Context, parent: View, accountManager: AccountManager) {
+fun showMigrationNoticeIfNecessary(
+    context: Context,
+    parent: View,
+    anchorView: View?,
+    accountManager: AccountManager
+) {
     // No point showing anything if we cannot enable it
     if (!isUnifiedPushAvailable(context)) return
     if (!anyAccountNeedsMigration(accountManager)) return
@@ -59,10 +64,10 @@ fun showMigrationNoticeIfNecessary(context: Context, parent: View, accountManage
     val pm = PreferenceManager.getDefaultSharedPreferences(context)
     if (pm.getBoolean(KEY_MIGRATION_NOTICE_DISMISSED, false)) return
 
-    Snackbar.make(parent, R.string.tips_push_notification_migration, Snackbar.LENGTH_INDEFINITE).apply {
-        setAction(R.string.action_details) { showMigrationExplanationDialog(context, accountManager) }
-        show()
-    }
+    Snackbar.make(parent, R.string.tips_push_notification_migration, Snackbar.LENGTH_INDEFINITE)
+        .setAnchorView(anchorView)
+        .setAction(R.string.action_details) { showMigrationExplanationDialog(context, accountManager) }
+        .show()
 }
 
 private fun showMigrationExplanationDialog(context: Context, accountManager: AccountManager) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,6 +8,7 @@
     android:fitsSystemWindows="true">
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/mainCoordinatorLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context="com.keylesspalace.tusky.MainActivity">


### PR DESCRIPTION
As recommended by Material guidelines: https://material.io/components/snackbars#placement
<img src="https://user-images.githubusercontent.com/10157047/175339037-340fb79a-36e7-4606-a568-c8e740ca8921.png" width="360">

closes https://github.com/tuskyapp/Tusky/issues/2597
