### PR TITLE
Fix hiding/showing preview cards for sensitive statuses

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -1046,6 +1046,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                 actionable.getPoll() == null &&
                 card != null &&
                 !TextUtils.isEmpty(card.getUrl()) &&
+                (!actionable.getSensitive() || status.isExpanded()) &&
                 (!status.isCollapsible() || !status.isCollapsed())) {
             cardView.setVisibility(View.VISIBLE);
             cardTitle.setText(card.getTitle());

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
@@ -103,20 +103,26 @@ class StatusDetailedViewHolder extends StatusBaseViewHolder {
                                 @NonNull final StatusActionListener listener,
                                 @NonNull StatusDisplayOptions statusDisplayOptions,
                                 @Nullable Object payloads) {
-        super.setupWithStatus(status, listener, statusDisplayOptions, payloads);
-        setupCard(status, CardViewMode.FULL_WIDTH, statusDisplayOptions, listener); // Always show card for detailed status
+        // We never collapse statuses in the detail view
+        StatusViewData.Concrete uncollapsedStatus = (status.isCollapsible() && status.isCollapsed()) ?
+            status.copyWIthCollapsed(false) :
+            status;
+
+        super.setupWithStatus(uncollapsedStatus, listener, statusDisplayOptions, payloads);
+        setupCard(uncollapsedStatus, CardViewMode.FULL_WIDTH, statusDisplayOptions, listener); // Always show card for detailed status
         if (payloads == null) {
+            Status actionable = uncollapsedStatus.getActionable();
 
             if (!statusDisplayOptions.hideStats()) {
-                setReblogAndFavCount(status.getActionable().getReblogsCount(),
-                        status.getActionable().getFavouritesCount(), listener);
+                setReblogAndFavCount(actionable.getReblogsCount(),
+                        actionable.getFavouritesCount(), listener);
             } else {
                 hideQuantitativeStats();
             }
 
-            setApplication(status.getActionable().getApplication());
+            setApplication(actionable.getApplication());
 
-            setStatusVisibility(status.getActionable().getVisibility());
+            setStatusVisibility(actionable.getVisibility());
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
@@ -105,7 +105,7 @@ class StatusDetailedViewHolder extends StatusBaseViewHolder {
                                 @Nullable Object payloads) {
         // We never collapse statuses in the detail view
         StatusViewData.Concrete uncollapsedStatus = (status.isCollapsible() && status.isCollapsed()) ?
-            status.copyWIthCollapsed(false) :
+            status.copyWithCollapsed(false) :
             status;
 
         super.setupWithStatus(uncollapsedStatus, listener, statusDisplayOptions, payloads);

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -538,7 +538,7 @@ public class NotificationsFragment extends SFragment implements
 
     @Override
     public void onContentCollapsedChange(boolean isCollapsed, int position) {
-        updateViewDataAt(position, (vd) -> vd.copyWIthCollapsed(isCollapsed));
+        updateViewDataAt(position, (vd) -> vd.copyWithCollapsed(isCollapsed));
         ;
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -387,7 +387,7 @@ public final class ViewThreadFragment extends SFragment implements
     public void onContentCollapsedChange(boolean isCollapsed, int position) {
         adapter.setItem(
                 position,
-                statuses.getPairedItem(position).copyWIthCollapsed(isCollapsed),
+                statuses.getPairedItem(position).copyWithCollapsed(isCollapsed),
                 true
         );
     }

--- a/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.kt
@@ -106,7 +106,7 @@ sealed class StatusViewData {
         }
 
         /** Helper for Java */
-        fun copyWIthCollapsed(isCollapsed: Boolean): Concrete {
+        fun copyWithCollapsed(isCollapsed: Boolean): Concrete {
             return copy(isCollapsed = isCollapsed)
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.kt
@@ -47,8 +47,8 @@ sealed class StatusViewData {
             get() = status.id
 
         /**
-         * Specifies whether the content of this post is allowed to be collapsed or if it should show
-         * all content regardless.
+         * Specifies whether the content of this post is long enough to be automatically
+         * collapsed or if it should show all content regardless.
          *
          * @return Whether the post is collapsible or never collapsed.
          */


### PR DESCRIPTION
Fixes #2565 

Verified:
- Non-cwed statuses (timeline)
- Non-cwed statuses (detail view)
- CWed statuses (timeline)
- CWed statuses (detail view)
- NonCWed autocollapsing status (timeline)
- NonCWed autocollapsing status (detail view)
- CWed autocollapsing status (timeline)
- CWed autocollapsing status (detail view)