### PR TITLE
Update FilemojiCompat to version 3.2.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,7 +101,7 @@ ext.glideVersion = '4.13.1'
 ext.daggerVersion = '2.42'
 ext.materialdrawerVersion = '8.4.5'
 ext.emoji2_version = '1.1.0'
-ext.filemojicompat_version = '3.2.2'
+ext.filemojicompat_version = '3.2.3'
 
 // if libraries are changed here, they should also be changed in LicenseActivity
 dependencies {


### PR DESCRIPTION
This update simply bumps the version code of Openmoji to 14.0 to allow updates for those who use it.

Waiting for the release to Maven Central to complete...