### PR TITLE
Add UI for image-attachment "focus"

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -26,6 +26,7 @@ import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
+import android.graphics.PointF
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -68,6 +69,7 @@ import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.adapter.EmojiAdapter
 import com.keylesspalace.tusky.adapter.OnEmojiSelectedListener
 import com.keylesspalace.tusky.components.compose.dialog.makeCaptionDialog
+import com.keylesspalace.tusky.components.compose.dialog.makeFocusDialog
 import com.keylesspalace.tusky.components.compose.dialog.showAddPollDialog
 import com.keylesspalace.tusky.components.compose.view.ComposeOptionsListener
 import com.keylesspalace.tusky.components.compose.view.ComposeScheduleView
@@ -214,6 +216,11 @@ class ComposeActivity :
             onAddCaption = { item ->
                 makeCaptionDialog(item.description, item.uri) { newDescription ->
                     viewModel.updateDescription(item.localId, newDescription)
+                }
+            },
+            onAddFocus = { item ->
+                makeFocusDialog(item.focus, item.uri) { newFocus ->
+                    viewModel.updateFocus(item.localId, newFocus)
                 }
             },
             onEditImage = this::editImageInQueue,
@@ -1065,7 +1072,8 @@ class ComposeActivity :
         val mediaSize: Long,
         val uploadPercent: Int = 0,
         val id: String? = null,
-        val description: String? = null
+        val description: String? = null,
+        val focus: PointF? = null // Range -1..1 y-up
     ) {
         enum class Type {
             IMAGE, VIDEO, AUDIO;

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -15,6 +15,7 @@
 
 package com.keylesspalace.tusky.components.compose
 
+import android.graphics.PointF
 import android.net.Uri
 import android.util.Log
 import androidx.core.net.toUri
@@ -337,11 +338,37 @@ class ComposeViewModel @Inject constructor(
 
         val updatedItem = newMediaList.find { it.localId == localId }
         if (updatedItem?.id != null) {
-            return api.updateMedia(updatedItem.id, description)
+            return api.updateMediaDescription(updatedItem.id, description)
                 .fold({
                     true
                 }, { throwable ->
                     Log.w(TAG, "failed to update media", throwable)
+                    false
+                })
+        }
+        return true
+    }
+
+    // TODO: Factor this and updateDescription into a single function?
+    suspend fun updateFocus(localId: Int, focus: PointF): Boolean {
+        val newMediaList = media.updateAndGet { mediaValue ->
+            mediaValue.map { mediaItem ->
+                if (mediaItem.localId == localId) {
+                    mediaItem.copy(focus = focus)
+                } else {
+                    mediaItem
+                }
+            }
+        }
+
+        val updatedItem = newMediaList.find { it.localId == localId }
+        if (updatedItem?.id != null) {
+            val focusString = "${focus.x},${focus.y}"
+            return api.updateMediaFocus(updatedItem.id, focusString)
+                .fold({
+                    true
+                }, { throwable ->
+                    Log.w(TAG, "failed to update media focus point", throwable)
                     false
                 })
         }

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaPreviewAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaPreviewAdapter.kt
@@ -32,6 +32,7 @@ import com.keylesspalace.tusky.components.compose.view.ProgressImageView
 class MediaPreviewAdapter(
     context: Context,
     private val onAddCaption: (ComposeActivity.QueuedMedia) -> Unit,
+    private val onAddFocus: (ComposeActivity.QueuedMedia) -> Unit,
     private val onEditImage: (ComposeActivity.QueuedMedia) -> Unit,
     private val onRemove: (ComposeActivity.QueuedMedia) -> Unit
 ) : RecyclerView.Adapter<MediaPreviewAdapter.PreviewViewHolder>() {
@@ -44,15 +45,19 @@ class MediaPreviewAdapter(
         val item = differ.currentList[position]
         val popup = PopupMenu(view.context, view)
         val addCaptionId = 1
-        val editImageId = 2
-        val removeId = 3
+        val addFocusId = 2
+        val editImageId = 3
+        val removeId = 4
         popup.menu.add(0, addCaptionId, 0, R.string.action_set_caption)
-        if (item.type == ComposeActivity.QueuedMedia.Type.IMAGE)
+        if (item.type == ComposeActivity.QueuedMedia.Type.IMAGE) {
+            popup.menu.add(0, addFocusId, 0, R.string.action_set_focus)
             popup.menu.add(0, editImageId, 0, R.string.action_edit_image)
+        }
         popup.menu.add(0, removeId, 0, R.string.action_remove)
         popup.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
                 addCaptionId -> onAddCaption(item)
+                addFocusId -> onAddFocus(item)
                 editImageId -> onEditImage(item)
                 removeId -> onRemove(item)
             }

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/FocusDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/FocusDialog.kt
@@ -1,0 +1,110 @@
+/* Copyright 2019 Tusky Contributors
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>. */
+
+package com.keylesspalace.tusky.components.compose.dialog
+
+import android.app.Activity
+import android.content.DialogInterface
+import android.graphics.PointF
+import android.graphics.drawable.Drawable
+import android.net.Uri
+import android.text.InputFilter
+import android.text.InputType
+import android.util.Log // ANDI SHOULD NOT CHECK THIS LINE IN TO GIT
+import android.view.WindowManager
+import android.widget.EditText
+import android.widget.ImageView;
+import android.widget.LinearLayout
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import at.connyduck.sparkbutton.helpers.Utils
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
+import com.bumptech.glide.request.target.CustomTarget
+import com.bumptech.glide.request.transition.Transition
+import com.github.chrisbanes.photoview.OnPhotoTapListener
+import com.github.chrisbanes.photoview.PhotoView
+import com.keylesspalace.tusky.R
+import kotlinx.coroutines.launch
+
+fun <T> T.makeFocusDialog(
+    existingFocus: PointF?,
+    previewUri: Uri,
+    onUpdateFocus: suspend (PointF) -> Boolean
+) where T : Activity, T : LifecycleOwner {
+    var focus = existingFocus ?: PointF(0.0f, 0.0f) // Default to center
+
+    val dialogLayout = LinearLayout(this)
+    val padding = Utils.dpToPx(this, 8)
+    dialogLayout.setPadding(padding, padding, padding, padding)
+
+    dialogLayout.orientation = LinearLayout.VERTICAL
+    val imageView = PhotoView(this).apply {
+        maximumScale = 6f
+        setOnPhotoTapListener(object : OnPhotoTapListener {
+            override fun onPhotoTap(view: ImageView, x:Float, y:Float) {
+                focus = PointF(x*2-1, 1-y*2) // PhotoView range is 0..1 Y-down but Mastodon API range is -1..1 Y-up
+            }
+        })
+    }
+
+    val margin = Utils.dpToPx(this, 4)
+    dialogLayout.addView(imageView)
+    (imageView.layoutParams as LinearLayout.LayoutParams).weight = 1f
+    imageView.layoutParams.height = 0
+    (imageView.layoutParams as LinearLayout.LayoutParams).setMargins(0, margin, 0, 0)
+
+    val okListener = { dialog: DialogInterface, _: Int ->
+        lifecycleScope.launch {
+            if (!onUpdateFocus(focus)) {
+                showFailedFocusMessage()
+            }
+        }
+        dialog.dismiss()
+    }
+
+    val dialog = AlertDialog.Builder(this)
+        .setView(dialogLayout)
+        .setPositiveButton(android.R.string.ok, okListener)
+        .setNegativeButton(android.R.string.cancel, null)
+        .create()
+
+    val window = dialog.window
+    window?.setSoftInputMode(
+        WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
+    )
+
+    dialog.show()
+
+    // Load the image and manually set it into the ImageView because it doesn't have a fixed  size.
+    Glide.with(this)
+        .load(previewUri)
+        .downsample(DownsampleStrategy.CENTER_INSIDE)
+        .into(object : CustomTarget<Drawable>(4096, 4096) {
+            override fun onLoadCleared(placeholder: Drawable?) {
+                imageView.setImageDrawable(placeholder)
+            }
+
+            override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) {
+                imageView.setImageDrawable(resource)
+            }
+        })
+}
+
+private fun Activity.showFailedFocusMessage() {
+    Toast.makeText(this, R.string.error_failed_set_focus, Toast.LENGTH_SHORT).show()
+}

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -143,9 +143,16 @@ interface MastodonApi {
 
     @FormUrlEncoded
     @PUT("api/v1/media/{mediaId}")
-    suspend fun updateMedia(
+    suspend fun updateMediaDescription(
         @Path("mediaId") mediaId: String,
         @Field("description") description: String
+    ): NetworkResult<Attachment>
+
+    @FormUrlEncoded
+    @PUT("api/v1/media/{mediaId}")
+    suspend fun updateMediaFocus(
+        @Path("mediaId") mediaId: String,
+        @Field("focus") focus: String
     ): NetworkResult<Attachment>
 
     @GET("api/v1/media/{mediaId}")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -402,10 +402,12 @@
     <string name="compose_active_account_description">Posting with account %1$s</string>
 
     <string name="error_failed_set_caption">Failed to set caption</string>
+    <string name="error_failed_set_focus">Failed to set focus</string>
     <plurals name="hint_describe_for_visually_impaired">
         <item quantity="other">Describe for visually impaired\n(%d character limit)</item>
     </plurals>
     <string name="action_set_caption">Set caption</string>
+    <string name="action_set_focus">Set focus</string>
     <string name="action_edit_image">Edit image</string>
     <string name="action_remove">Remove</string>
     <string name="lock_account_label">Lock account</string>


### PR DESCRIPTION
Choose "Set focus" in the attachment menu, tap once to select focus point, tap "OK". Has been [successfully tested](https://mastodon.social/@mcc_test_tusky/108655193725406904) with mastodon.social (image has two identical very tall image attachments, but in one the focus point is set near the top and in the other it is set near the bottom).

Currently very ugly, no visual feedback of where/whether you tapped and I think a naive user would be totally confused by what the dialog even does:

[<img src="https://user-images.githubusercontent.com/277318/179340919-7f0f185d-9f94-470a-9631-421de9a600b5.png" width="100">](https://user-images.githubusercontent.com/277318/179340919-7f0f185d-9f94-470a-9631-421de9a600b5.png)
 
But, it works, so should be a good starting point for a more complete attempt.

Things I think should change before submit:
- Thumbnails in compose view should refocus on focus point
- Some visual feedback of tap, a bullseye or something
- Currently if you tap outside the photo view (like slightly to the right or left) the tap does not register. That's very bad (may require replacing chrisbanes.photoview)
- I need to do more aggressive testing (changing focus points multiple times, changing caption before and after etc)

Things I'm 50% sure should change before submit:

- It would be nice if you could drag a finger to move around the focus point instead of only taps working (this may require replacing chrisbanes.photoview)
- Some text above the image would be good. Possibly either a full explanation of how focus points work or a link to one. It could be an unfamiliar concept.
- Some sort of preview would be nice. Ideally the preview would let you choose a couple different aspect ratios like 16:9 or 1:1. Maybe that could be saved for a followup PR.

Things I'm not sure about at all:
- What should the menu item say? Currently it's "Set focus". Would something like "Image focus" or "Set focus point" be better?
- TODO item in [ComposeViewModel.kt](https://github.com/tuskyapp/Tusky/compare/develop...mcclure:image-focus?expand=1#diff-979cd489c1b985730744fe1ffea7cfc58c035627b13189e21602de4942ccd474)
- Currently the pane is inset (like "set caption"), maybe it would be good if the pane were "full screen" (like the cropper)