### PR TITLE
Add support for following hashtags

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/StatusListActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/StatusListActivity.kt
@@ -94,7 +94,7 @@ class StatusListActivity : BottomSheetActivity(), HasAndroidInjector {
                         unfollowTagItem?.setOnMenuItemClickListener { unfollowTag() }
                     },
                     {
-                        Log.w("Failed to query tag #$tag", it)
+                        Log.w(TAG, "Failed to query tag #$tag", it)
                     }
                 )
             }
@@ -114,7 +114,8 @@ class StatusListActivity : BottomSheetActivity(), HasAndroidInjector {
                         unfollowTagItem?.isVisible = true
                     },
                     {
-                        Toast.makeText(context, "Error following #$tag", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(context, getString(R.string.error_following_hashtag_format, tag), Toast.LENGTH_SHORT).show()
+                        Log.e(TAG, "Failed to follow #$tag", it)
                     }
                 )
             }
@@ -134,7 +135,8 @@ class StatusListActivity : BottomSheetActivity(), HasAndroidInjector {
                         unfollowTagItem?.isVisible = false
                     },
                     {
-                        Toast.makeText(context, "Error unfollowing #$tag", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(context, getString(R.string.error_unfollowing_hashtag_format, tag), Toast.LENGTH_SHORT).show()
+                        Log.e(TAG, "Failed to unfollow #$tag", it)
                     }
                 )
             }
@@ -151,6 +153,7 @@ class StatusListActivity : BottomSheetActivity(), HasAndroidInjector {
         private const val EXTRA_LIST_ID = "id"
         private const val EXTRA_LIST_TITLE = "title"
         private const val EXTRA_HASHTAG = "tag"
+        const val TAG = "StatusListActivity"
 
         fun newFavouritesIntent(context: Context) =
             Intent(context, StatusListActivity::class.java).apply {

--- a/app/src/main/java/com/keylesspalace/tusky/StatusListActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/StatusListActivity.kt
@@ -21,10 +21,11 @@ import android.os.Bundle
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
-import android.widget.Toast
+import android.view.View
 import androidx.fragment.app.commit
 import androidx.lifecycle.lifecycleScope
 import at.connyduck.calladapter.networkresult.fold
+import com.google.android.material.snackbar.Snackbar
 import com.keylesspalace.tusky.components.timeline.TimelineFragment
 import com.keylesspalace.tusky.components.timeline.viewmodel.TimelineViewModel.Kind
 import com.keylesspalace.tusky.databinding.ActivityStatuslistBinding
@@ -106,7 +107,7 @@ class StatusListActivity : BottomSheetActivity(), HasAndroidInjector {
     private fun followTag(): Boolean {
         val tag = hashtag
         if (tag != null) {
-            val context = this
+            val context = findViewById<View>(R.id.action_follow_hashtag)
             lifecycleScope.launch {
                 mastodonApi.followTag(tag).fold(
                     {
@@ -114,7 +115,7 @@ class StatusListActivity : BottomSheetActivity(), HasAndroidInjector {
                         unfollowTagItem?.isVisible = true
                     },
                     {
-                        Toast.makeText(context, getString(R.string.error_following_hashtag_format, tag), Toast.LENGTH_SHORT).show()
+                        Snackbar.make(context, getString(R.string.error_following_hashtag_format, tag), Snackbar.LENGTH_SHORT).show()
                         Log.e(TAG, "Failed to follow #$tag", it)
                     }
                 )
@@ -127,7 +128,7 @@ class StatusListActivity : BottomSheetActivity(), HasAndroidInjector {
     private fun unfollowTag(): Boolean {
         val tag = hashtag
         if (tag != null) {
-            val context = this
+            val context = findViewById<View>(R.id.action_unfollow_hashtag)
             lifecycleScope.launch {
                 mastodonApi.unfollowTag(tag).fold(
                     {
@@ -135,7 +136,7 @@ class StatusListActivity : BottomSheetActivity(), HasAndroidInjector {
                         unfollowTagItem?.isVisible = false
                     },
                     {
-                        Toast.makeText(context, getString(R.string.error_unfollowing_hashtag_format, tag), Toast.LENGTH_SHORT).show()
+                        Snackbar.make(context, getString(R.string.error_unfollowing_hashtag_format, tag), Snackbar.LENGTH_SHORT).show()
                         Log.e(TAG, "Failed to unfollow #$tag", it)
                     }
                 )

--- a/app/src/main/java/com/keylesspalace/tusky/StatusListActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/StatusListActivity.kt
@@ -21,7 +21,6 @@ import android.os.Bundle
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
-import android.view.View
 import androidx.fragment.app.commit
 import androidx.lifecycle.lifecycleScope
 import at.connyduck.calladapter.networkresult.fold
@@ -29,6 +28,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.keylesspalace.tusky.components.timeline.TimelineFragment
 import com.keylesspalace.tusky.components.timeline.viewmodel.TimelineViewModel.Kind
 import com.keylesspalace.tusky.databinding.ActivityStatuslistBinding
+import com.keylesspalace.tusky.util.viewBinding
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
 import kotlinx.coroutines.launch
@@ -39,14 +39,14 @@ class StatusListActivity : BottomSheetActivity(), HasAndroidInjector {
     @Inject
     lateinit var dispatchingAndroidInjector: DispatchingAndroidInjector<Any>
 
-    lateinit var kind: Kind
-    var hashtag: String? = null
-    var followTagItem: MenuItem? = null
-    var unfollowTagItem: MenuItem? = null
+    private val binding: ActivityStatuslistBinding by viewBinding(ActivityStatuslistBinding::inflate)
+    private lateinit var kind: Kind
+    private var hashtag: String? = null
+    private var followTagItem: MenuItem? = null
+    private var unfollowTagItem: MenuItem? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val binding = ActivityStatuslistBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
         setSupportActionBar(binding.includedToolbar.toolbar)
@@ -107,7 +107,6 @@ class StatusListActivity : BottomSheetActivity(), HasAndroidInjector {
     private fun followTag(): Boolean {
         val tag = hashtag
         if (tag != null) {
-            val context = findViewById<View>(R.id.action_follow_hashtag)
             lifecycleScope.launch {
                 mastodonApi.followTag(tag).fold(
                     {
@@ -115,7 +114,7 @@ class StatusListActivity : BottomSheetActivity(), HasAndroidInjector {
                         unfollowTagItem?.isVisible = true
                     },
                     {
-                        Snackbar.make(context, getString(R.string.error_following_hashtag_format, tag), Snackbar.LENGTH_SHORT).show()
+                        Snackbar.make(binding.root, getString(R.string.error_following_hashtag_format, tag), Snackbar.LENGTH_SHORT).show()
                         Log.e(TAG, "Failed to follow #$tag", it)
                     }
                 )
@@ -128,7 +127,6 @@ class StatusListActivity : BottomSheetActivity(), HasAndroidInjector {
     private fun unfollowTag(): Boolean {
         val tag = hashtag
         if (tag != null) {
-            val context = findViewById<View>(R.id.action_unfollow_hashtag)
             lifecycleScope.launch {
                 mastodonApi.unfollowTag(tag).fold(
                     {
@@ -136,7 +134,7 @@ class StatusListActivity : BottomSheetActivity(), HasAndroidInjector {
                         unfollowTagItem?.isVisible = false
                     },
                     {
-                        Snackbar.make(context, getString(R.string.error_unfollowing_hashtag_format, tag), Snackbar.LENGTH_SHORT).show()
+                        Snackbar.make(binding.root, getString(R.string.error_unfollowing_hashtag_format, tag), Snackbar.LENGTH_SHORT).show()
                         Log.e(TAG, "Failed to unfollow #$tag", it)
                     }
                 )

--- a/app/src/main/java/com/keylesspalace/tusky/entity/HashTag.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/HashTag.kt
@@ -1,3 +1,3 @@
 package com.keylesspalace.tusky.entity
 
-data class HashTag(val name: String, val url: String)
+data class HashTag(val name: String, val url: String, val following: Boolean? = null)

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -659,11 +659,11 @@ interface MastodonApi {
     ): NetworkResult<ResponseBody>
 
     @GET("api/v1/tags/{name}")
-    fun tag(@Path("name") name: String): Single<HashTag>
+    suspend fun tag(@Path("name") name: String): NetworkResult<HashTag>
 
     @POST("api/v1/tags/{name}/follow")
-    fun followTag(@Path("name") name: String): Single<HashTag>
+    suspend fun followTag(@Path("name") name: String): NetworkResult<HashTag>
 
     @POST("api/v1/tags/{name}/unfollow")
-    fun unfollowTag(@Path("name") name: String): Single<HashTag>
+    suspend fun unfollowTag(@Path("name") name: String): NetworkResult<HashTag>
 }

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -25,6 +25,7 @@ import com.keylesspalace.tusky.entity.Conversation
 import com.keylesspalace.tusky.entity.DeletedStatus
 import com.keylesspalace.tusky.entity.Emoji
 import com.keylesspalace.tusky.entity.Filter
+import com.keylesspalace.tusky.entity.HashTag
 import com.keylesspalace.tusky.entity.Instance
 import com.keylesspalace.tusky.entity.Marker
 import com.keylesspalace.tusky.entity.MastoList
@@ -656,4 +657,13 @@ interface MastodonApi {
         @Header("Authorization") auth: String,
         @Header(DOMAIN_HEADER) domain: String,
     ): NetworkResult<ResponseBody>
+
+    @GET("api/v1/tags/{name}")
+    fun tag(@Path("name") name: String): Single<HashTag>
+
+    @POST("api/v1/tags/{name}/follow")
+    fun followTag(@Path("name") name: String): Single<HashTag>
+
+    @POST("api/v1/tags/{name}/unfollow")
+    fun unfollowTag(@Path("name") name: String): Single<HashTag>
 }

--- a/app/src/main/res/drawable/ic_person_remove_24dp.xml
+++ b/app/src/main/res/drawable/ic_person_remove_24dp.xml
@@ -1,0 +1,8 @@
+<!-- drawable/account_remove.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#000" android:pathData="M15,14C17.67,14 23,15.33 23,18V20H7V18C7,15.33 12.33,14 15,14M15,12A4,4 0 0,1 11,8A4,4 0 0,1 15,4A4,4 0 0,1 19,8A4,4 0 0,1 15,12M5,9.59L7.12,7.46L8.54,8.88L6.41,11L8.54,13.12L7.12,14.54L5,12.41L2.88,14.54L1.46,13.12L3.59,11L1.46,8.88L2.88,7.46L5,9.59Z" />
+</vector>

--- a/app/src/main/res/menu/view_hashtag_toolbar.xml
+++ b/app/src/main/res/menu/view_hashtag_toolbar.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_follow_hashtag"
+        android:title="@string/action_follow"
+        app:showAsAction="ifRoom"
+        android:icon="@drawable/ic_person_add_24dp" />
+
+    <item
+        android:id="@+id/action_unfollow_hashtag"
+        android:title="@string/action_unfollow"
+        app:showAsAction="ifRoom"
+        android:icon="@drawable/ic_cancel_24dp" />
+
+
+</menu>

--- a/app/src/main/res/menu/view_hashtag_toolbar.xml
+++ b/app/src/main/res/menu/view_hashtag_toolbar.xml
@@ -13,7 +13,7 @@
         android:id="@+id/action_unfollow_hashtag"
         android:title="@string/action_unfollow"
         app:showAsAction="ifRoom"
-        android:icon="@drawable/ic_cancel_24dp" />
+        android:icon="@drawable/ic_person_remove_24dp" />
 
 
 </menu>

--- a/app/src/main/res/menu/view_hashtag_toolbar.xml
+++ b/app/src/main/res/menu/view_hashtag_toolbar.xml
@@ -7,12 +7,14 @@
         android:id="@+id/action_follow_hashtag"
         android:title="@string/action_follow"
         app:showAsAction="ifRoom"
+        app:iconTint="?attr/colorOnSurface"
         android:icon="@drawable/ic_person_add_24dp" />
 
     <item
         android:id="@+id/action_unfollow_hashtag"
         android:title="@string/action_unfollow"
         app:showAsAction="ifRoom"
+        app:iconTint="?attr/colorOnSurface"
         android:icon="@drawable/ic_person_remove_24dp" />
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,8 @@
     <string name="error_media_upload_image_or_video">Images and videos cannot both be attached to the same post.</string>
     <string name="error_media_upload_sending">The upload failed.</string>
     <string name="error_sender_account_gone">Error sending post.</string>
+    <string name="error_following_hashtag_format">Error following #%s</string>
+    <string name="error_unfollowing_hashtag_format">Error unfollowing #%s</string>
 
     <string name="title_login">Login</string>
     <string name="title_home">Home</string>


### PR DESCRIPTION
Addresses #2637

Adds a follow/unfollow toolbar item to the hashtag list activity when instance responds to the new api, and gracefully does nothing when an instance doesn't support it yet.

Tested with:
- glitch.taks.garden (supported)
- mastodon.gamedev.place (unsupported)