### PR TITLE
Update FilemojiCompat to version 3.2.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,7 +101,7 @@ ext.glideVersion = '4.13.1'
 ext.daggerVersion = '2.42'
 ext.materialdrawerVersion = '8.4.5'
 ext.emoji2_version = '1.1.0'
-ext.filemojicompat_version = '3.2.4'
+ext.filemojicompat_version = '3.2.5'
 
 // if libraries are changed here, they should also be changed in LicenseActivity
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,7 +101,7 @@ ext.glideVersion = '4.13.1'
 ext.daggerVersion = '2.42'
 ext.materialdrawerVersion = '8.4.5'
 ext.emoji2_version = '1.1.0'
-ext.filemojicompat_version = '3.2.3'
+ext.filemojicompat_version = '3.2.4'
 
 // if libraries are changed here, they should also be changed in LicenseActivity
 dependencies {


### PR DESCRIPTION
- Updated dependencies (esp. okhttp which apparently had a vulnerability in the previous version)
- Inclusion of Microsoft's newly open-sourced [Fluent emoji pack](https://github.com/microsoft/fluentui-emoji) (for now only in the flat version which is also used as the Windows 11 emoji pack)