### PR TITLE
Make CaptionDialog non-cancellable

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
@@ -89,6 +89,7 @@ fun <T> T.makeCaptionDialog(
         .setView(dialogLayout)
         .setPositiveButton(android.R.string.ok, okListener)
         .setNegativeButton(android.R.string.cancel, null)
+        .setCancelable(false)
         .create()
 
     val window = dialog.window


### PR DESCRIPTION
This prevents accidental closing of dialog by clicking
outside of the dialog.
