### PR TITLE
Added support for status translation with lingva.ml

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesFragment.kt
@@ -22,14 +22,7 @@ import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.db.AccountManager
 import com.keylesspalace.tusky.di.Injectable
 import com.keylesspalace.tusky.entity.Notification
-import com.keylesspalace.tusky.settings.AppTheme
-import com.keylesspalace.tusky.settings.PrefKeys
-import com.keylesspalace.tusky.settings.emojiPreference
-import com.keylesspalace.tusky.settings.listPreference
-import com.keylesspalace.tusky.settings.makePreferenceScreen
-import com.keylesspalace.tusky.settings.preference
-import com.keylesspalace.tusky.settings.preferenceCategory
-import com.keylesspalace.tusky.settings.switchPreference
+import com.keylesspalace.tusky.settings.*
 import com.keylesspalace.tusky.util.ThemeUtils
 import com.keylesspalace.tusky.util.deserialize
 import com.keylesspalace.tusky.util.getNonNullString
@@ -178,6 +171,15 @@ class PreferencesFragment : PreferenceFragmentCompat(), Injectable {
                     key = PrefKeys.ENABLE_SWIPE_FOR_TABS
                     setTitle(R.string.pref_title_enable_swipe_for_tabs)
                     isSingleLineTitle = false
+                }
+            }
+
+            preferenceCategory(R.string.pref_title_translation_settings) {
+                editTextPreference {
+                    setDefaultValue("lingva.ml")
+                    key = PrefKeys.LINGVA_INSTANCE
+                    setTitle(R.string.pref_title_lingva_instance)
+                    isSingleLineTitle = true
                 }
             }
 

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
@@ -259,7 +259,7 @@ public abstract class SFragment extends Fragment implements Injectable {
                 case R.id.status_translate_lingva: {
                     Status statusToTranslate = status;
                     String stringToTranslate = StatusParsingHelper.parseAsMastodonHtml(statusToTranslate.getContent()).toString();
-                    String stringToTranslateEncoded = stringToTranslate.replaceAll("\\s", "%20");
+                    String stringToTranslateEncoded = stringToTranslate.replaceAll("\n", "%0A").replaceAll("\r", "%0A").replaceAll("\\s", "%20");
 
                     SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
                     String lingvaInstance = prefs.getString(PrefKeys.LINGVA_INSTANCE, "lingva.ml");

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
@@ -23,6 +23,7 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Environment;
@@ -40,6 +41,7 @@ import androidx.core.app.ActivityOptionsCompat;
 import androidx.core.view.ViewCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Lifecycle;
+import androidx.preference.PreferenceManager;
 
 import com.keylesspalace.tusky.BaseActivity;
 import com.keylesspalace.tusky.BottomSheetActivity;
@@ -56,6 +58,7 @@ import com.keylesspalace.tusky.di.Injectable;
 import com.keylesspalace.tusky.entity.Attachment;
 import com.keylesspalace.tusky.entity.Status;
 import com.keylesspalace.tusky.network.MastodonApi;
+import com.keylesspalace.tusky.settings.PrefKeys;
 import com.keylesspalace.tusky.usecase.TimelineCases;
 import com.keylesspalace.tusky.util.LinkHelper;
 import com.keylesspalace.tusky.util.StatusParsingHelper;
@@ -258,9 +261,12 @@ public abstract class SFragment extends Fragment implements Injectable {
                     String stringToTranslate = StatusParsingHelper.parseAsMastodonHtml(statusToTranslate.getContent()).toString();
                     String stringToTranslateEncoded = stringToTranslate.replaceAll("\\s", "%20");
 
+                    SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
+                    String lingvaInstance = prefs.getString(PrefKeys.LINGVA_INSTANCE, "lingva.ml");
+
                     String lang = Locale.getDefault().getLanguage();
 
-                    LinkHelper.openLink(requireContext(), "https://lingva.ml/auto/" + lang + "/" + stringToTranslateEncoded);
+                    LinkHelper.openLink(requireContext(), "https://" + lingvaInstance + "/auto/" + lang + "/" + stringToTranslateEncoded);
                     return true;
                 }
                 case R.id.status_open_as: {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
@@ -62,8 +62,10 @@ import com.keylesspalace.tusky.util.StatusParsingHelper;
 import com.keylesspalace.tusky.view.MuteAccountDialog;
 import com.keylesspalace.tusky.viewdata.AttachmentViewData;
 
+import java.io.UnsupportedEncodingException;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -249,6 +251,16 @@ public abstract class SFragment extends Fragment implements Injectable {
                             getActivity().getSystemService(Context.CLIPBOARD_SERVICE);
                     ClipData clip = ClipData.newPlainText(null, statusUrl);
                     clipboard.setPrimaryClip(clip);
+                    return true;
+                }
+                case R.id.status_translate_lingva: {
+                    Status statusToTranslate = status;
+                    String stringToTranslate = StatusParsingHelper.parseAsMastodonHtml(statusToTranslate.getContent()).toString();
+                    String stringToTranslateEncoded = stringToTranslate.replaceAll("\\s", "%20");
+
+                    String lang = Locale.getDefault().getLanguage();
+
+                    LinkHelper.openLink(requireContext(), "https://lingva.ml/auto/" + lang + "/" + stringToTranslateEncoded);
                     return true;
                 }
                 case R.id.status_open_as: {

--- a/app/src/main/java/com/keylesspalace/tusky/settings/SettingsConstants.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/settings/SettingsConstants.kt
@@ -34,6 +34,8 @@ object PrefKeys {
     const val ENABLE_SWIPE_FOR_TABS = "enableSwipeForTabs"
     const val ANIMATE_CUSTOM_EMOJIS = "animateCustomEmojis"
 
+    const val LINGVA_INSTANCE = "lingvaInstance"
+
     const val CUSTOM_TABS = "customTabs"
     const val WELLBEING_LIMITED_NOTIFICATIONS = "wellbeingModeLimitedNotifications"
     const val WELLBEING_HIDE_STATS_POSTS = "wellbeingHideStatsPosts"

--- a/app/src/main/res/menu/status_more.xml
+++ b/app/src/main/res/menu/status_more.xml
@@ -16,6 +16,9 @@
         android:id="@+id/status_copy_link"
         android:title="@string/action_copy_link" />
     <item
+        android:id="@+id/status_translate_lingva"
+        android:title="@string/action_translate_lingva" />
+    <item
         android:id="@+id/status_open_as"
         android:title="@string/action_open_as" />
     <item

--- a/app/src/main/res/menu/status_more_for_user.xml
+++ b/app/src/main/res/menu/status_more_for_user.xml
@@ -16,6 +16,9 @@
         android:id="@+id/status_copy_link"
         android:title="@string/action_copy_link" />
     <item
+        android:id="@+id/status_translate_lingva"
+        android:title="@string/action_translate_lingva" />
+    <item
         android:id="@+id/status_open_as"
         android:title="@string/action_open_as" />
     <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,6 +162,7 @@
     <string name="download_image">Downloading %1$s</string>
 
     <string name="action_copy_link">Copy the link</string>
+    <string name="action_translate_lingva">Translate with Lingva</string>
     <string name="action_open_as">Open as %s</string>
     <string name="action_share_as">Share as …</string>
     <string name="download_media">Download media</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -252,6 +252,9 @@
     <string name="app_theme_auto">Automatic at sunset</string>
     <string name="app_theme_system">Use System Design</string>
 
+    <string name="pref_title_translation_settings">Translation</string>
+    <string name="pref_title_lingva_instance">Lingva instance</string>
+
     <string name="pref_title_browser_settings">Browser</string>
     <string name="pref_title_custom_tabs">Use Chrome Custom Tabs</string>
     <string name="pref_title_hide_follow_button">Hide compose button while scrolling</string>


### PR DESCRIPTION
An option is missing in the settings to let the user choose his Lingva instance.