### PR TITLE
Add display of handle when using multiple accounts

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -834,6 +834,9 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
         header.clear()
         header.profiles = profiles
         header.setActiveProfile(accountManager.activeAccount!!.id)
+        binding.mainToolbar.subtitle = if (accountManager.accounts.size > 1) {
+            accountManager.activeAccount!!.fullName
+        } else null
     }
 
     override fun getActionButton() = binding.composeButton

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -236,6 +236,17 @@ class ComposeActivity :
         val composeOptions: ComposeOptions? = intent.getParcelableExtra(COMPOSE_OPTIONS_EXTRA)
 
         viewModel.setup(composeOptions)
+
+        if (accountManager.accounts.size > 1) {
+            binding.composeUsernameView.text = getString(
+                R.string.compose_active_account_description,
+                activeAccount.fullName
+            )
+            binding.composeUsernameView.show()
+        } else {
+            binding.composeUsernameView.hide()
+        }
+
         setupReplyViews(composeOptions?.replyingStatusAuthor, composeOptions?.replyingStatusContent)
         val statusContent = composeOptions?.content
         if (!statusContent.isNullOrEmpty()) {

--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -72,6 +72,19 @@
             android:orientation="vertical">
 
             <TextView
+                android:id="@+id/composeUsernameView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginBottom="0dp"
+                android:textSize="?attr/status_text_small"
+                android:textStyle="bold"
+                android:visibility="gone"
+                tools:text="Posting as @username@domain"
+                tools:visibility="visible" />
+
+            <TextView
                 android:id="@+id/composeReplyView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -401,7 +401,7 @@
     <string name="action_add_to_list">Add account to the list</string>
     <string name="action_remove_from_list">Remove account from the list</string>
 
-    <string name="compose_active_account_description">Posting with account %1$s</string>
+    <string name="compose_active_account_description">Posting as %1$s</string>
 
     <string name="error_failed_set_caption">Failed to set caption</string>
     <plurals name="hint_describe_for_visually_impaired">


### PR DESCRIPTION
- Shown on the main toolbar (subtitle)
- Shown just above the "replying to" message (even if not replying)

I made this feature for users who frequently post across multiple accounts with the same avatar. Currently there isn't an easy way to know which timeline you're on from the main view without sliding the sidebar open, and when posting (rather important) it's impossible to know who you're posting as, unless you have a unique avatar.

I am hoping these changes are minor enough that they should be OK. Please let me know if any tweaks would improve this.

Note that these altered visuals are only present when more than one account is present in the list.

I decided to change the text of `compose_active_account_description` instead of adding a new entry, because the text seems to only be used for accessibility and it seems like it would be OK to make use of it in this way. Also at least the German translation seems to match the new text, so seems there is some inconsistency anyway.

When replying:
![Screenshot_20220912_235329](https://user-images.githubusercontent.com/287339/189836259-2952ea39-b313-4cbe-be85-1aec237ec2d4.png)

On the top toolbar (for all tabs):
![Screenshot_20220912_235412](https://user-images.githubusercontent.com/287339/189836379-7726204b-4fd9-47d1-b6b6-65e06c32bf9d.png)

When creating a new post:
![Screenshot_20220912_235446](https://user-images.githubusercontent.com/287339/189836462-e5a6ee27-c9e4-48b9-89d8-fab378c5ca51.png)
