### PR TITLE
Show target domains for non-mention/non-hashtag links where the target domain is not provided or differs from the domain in the text

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -83,7 +83,7 @@ fun markupHiddenUrls(context: Context, content: CharSequence, mentions: List<Men
         val start = spannableContent.getSpanStart(span)
         val end = spannableContent.getSpanEnd(span)
         val originalText = spannableContent.subSequence(start, end)
-        val replacementText = context.getString(R.string.url_domain_notifier).format(originalText, getDomain(span.url))
+        val replacementText = context.getString(R.string.url_domain_notifier, originalText, getDomain(span.url))
         spannableContent.replace(start, end, replacementText) // this also updates the span locations
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -74,8 +74,8 @@ fun markupHiddenUrls(context: Context, content: CharSequence, mentions: List<Men
     val obscuredLinkSpans = originalSpans.filter {
         val text = spannableContent.subSequence(spannableContent.getSpanStart(it), spannableContent.getSpanEnd(it))
         val firstCharacter = text[0]
-        (firstCharacter != '#' || getCustomSpanForTag(text, tags, it, listener) == null) &&
-            (firstCharacter != '@' || getCustomSpanForMention(mentions, it, listener) == null) &&
+        firstCharacter != '#' &&
+            firstCharacter != '@' &&
             getDomain(text.toString()) != getDomain(it.url)
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -57,12 +57,37 @@ fun getDomain(urlString: String?): String {
  * @param listener to notify about particular spans that are clicked
  */
 fun setClickableText(view: TextView, content: CharSequence, mentions: List<Mention>, tags: List<HashTag>?, listener: LinkListener) {
-    view.text = SpannableStringBuilder.valueOf(content).apply {
+    val spannableContent = markupHiddenUrls(view.context, content, mentions, tags, listener)
+
+    view.text = spannableContent.apply {
         getSpans(0, content.length, URLSpan::class.java).forEach {
             setClickableText(it, this, mentions, tags, listener)
         }
     }
     view.movementMethod = LinkMovementMethod.getInstance()
+}
+
+@VisibleForTesting
+fun markupHiddenUrls(context: Context, content: CharSequence, mentions: List<Mention>, tags: List<HashTag>?, listener: LinkListener): SpannableStringBuilder {
+    val spannableContent = SpannableStringBuilder.valueOf(content)
+    val originalSpans = spannableContent.getSpans(0, content.length, URLSpan::class.java)
+    val obscuredLinkSpans = originalSpans.filter {
+        val text = spannableContent.subSequence(spannableContent.getSpanStart(it), spannableContent.getSpanEnd(it))
+        val firstCharacter = text[0]
+        (firstCharacter != '#' || getCustomSpanForTag(text, tags, it, listener) == null) &&
+            (firstCharacter != '@' || getCustomSpanForMention(mentions, it, listener) == null) &&
+            getDomain(text.toString()) != getDomain(it.url)
+    }
+
+    for (span in obscuredLinkSpans) {
+        val start = spannableContent.getSpanStart(span)
+        val end = spannableContent.getSpanEnd(span)
+        val originalText = spannableContent.subSequence(start, end)
+        val replacementText = context.getString(R.string.url_domain_notifier).format(originalText, getDomain(span.url))
+        spannableContent.replace(start, end, replacementText) // this also updates the span locations
+    }
+
+    return spannableContent
 }
 
 @VisibleForTesting

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -658,7 +658,7 @@
     <string name="tips_push_notification_migration">Re-login all accounts to enable push notification support.</string>
     <string name="dialog_push_notification_migration">In order to use push notifications via UnifiedPush, Tusky needs permission to subscribe to notifications on your Mastodon server. This requires a re-login to change the OAuth scopes granted to Tusky. Using the re-login option here or in Account Preferences will preserve all of your local drafts and cache.</string>
     <string name="dialog_push_notification_migration_other_accounts">You have re-logged into your current account to grant push subscription permission to Tusky. However, you still have other accounts that have not been migrated this way. Switch to them and re-login one by one in order to enable UnifiedPush notifications support.</string>
-    <string name="url_domain_notifier">%s (%s)</string>
+    <string name="url_domain_notifier">%s (🔗 %s)</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -658,6 +658,7 @@
     <string name="tips_push_notification_migration">Re-login all accounts to enable push notification support.</string>
     <string name="dialog_push_notification_migration">In order to use push notifications via UnifiedPush, Tusky needs permission to subscribe to notifications on your Mastodon server. This requires a re-login to change the OAuth scopes granted to Tusky. Using the re-login option here or in Account Preferences will preserve all of your local drafts and cache.</string>
     <string name="dialog_push_notification_migration_other_accounts">You have re-logged into your current account to grant push subscription permission to Tusky. However, you still have other accounts that have not been migrated this way. Switch to them and re-login one by one in order to enable UnifiedPush notifications support.</string>
+    <string name="url_domain_notifier">%s (%s)</string>
 
 
 </resources>

--- a/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
@@ -196,7 +196,7 @@ class LinkHelperTest {
     }
 
     @Test
-    fun invalidMentionsAreMarkedUp() {
+    fun invalidMentionsAreNotMarkedUp() {
         val builder = SpannableStringBuilder()
         for (mention in mentions) {
             builder.append("@${mention.username}", URLSpan(mention.url), 0)
@@ -205,7 +205,7 @@ class LinkHelperTest {
 
         val markedUpContent = markupHiddenUrls(context, builder, listOf(), tags, listener)
         for (mention in mentions) {
-            Assert.assertTrue(markedUpContent.contains("${getDomain(mention.url)})"))
+            Assert.assertFalse(markedUpContent.contains("${getDomain(mention.url)})"))
         }
     }
 
@@ -224,7 +224,7 @@ class LinkHelperTest {
     }
 
     @Test
-    fun invalidTagsAreMarkedUp() {
+    fun invalidTagsAreNotMarkedUp() {
         val builder = SpannableStringBuilder()
         for (tag in tags) {
             builder.append("#${tag.name}", URLSpan(tag.url), 0)
@@ -233,7 +233,7 @@ class LinkHelperTest {
 
         val markedUpContent = markupHiddenUrls(context, builder, mentions, listOf(), listener)
         for (tag in tags) {
-            Assert.assertTrue(markedUpContent.contains("${getDomain(tag.url)})"))
+            Assert.assertFalse(markedUpContent.contains("${getDomain(tag.url)})"))
         }
     }
 }

--- a/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
@@ -1,8 +1,10 @@
 package com.keylesspalace.tusky.util
 
+import android.content.Context
 import android.text.SpannableStringBuilder
 import android.text.style.URLSpan
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.keylesspalace.tusky.entity.HashTag
 import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.interfaces.LinkListener
@@ -28,6 +30,9 @@ class LinkHelperTest {
         HashTag("Tusky", "https://example.com/Tags/Tusky"),
         HashTag("mastodev", "https://example.com/Tags/mastodev"),
     )
+
+    private val context: Context
+        get() = InstrumentationRegistry.getInstrumentation().targetContext
 
     @Test
     fun whenSettingClickableText_mentionUrlsArePreserved() {
@@ -138,6 +143,96 @@ class LinkHelperTest {
             "https://wwwexample.com/" to "wwwexample.com",
         ).forEach { (url, domain) ->
             Assert.assertEquals(domain, getDomain(url))
+        }
+    }
+
+    @Test
+    fun hiddenDomainsAreMarkedUp() {
+        val displayedContent = "This is a good place to go"
+        val maliciousDomain = "malicious.place"
+        val maliciousUrl = "https://$maliciousDomain/to/go"
+        val content = SpannableStringBuilder()
+        content.append(displayedContent, URLSpan(maliciousUrl), 0)
+        Assert.assertEquals("$displayedContent ($maliciousDomain)", markupHiddenUrls(context, content, listOf(), listOf(), listener).toString())
+    }
+
+    @Test
+    fun fraudulentDomainsAreMarkedUp() {
+        val displayedContent = "https://tusky.app/"
+        val maliciousDomain = "malicious.place"
+        val maliciousUrl = "https://$maliciousDomain/to/go"
+        val content = SpannableStringBuilder()
+        content.append(displayedContent, URLSpan(maliciousUrl), 0)
+        Assert.assertEquals("$displayedContent ($maliciousDomain)", markupHiddenUrls(context, content, listOf(), listOf(), listener).toString())
+    }
+
+    @Test fun multipleHiddenDomainsAreMarkedUp() {
+        val domains = listOf("one.place", "another.place", "athird.place")
+        val displayedContent = "link"
+        val content = SpannableStringBuilder()
+        for (domain in domains) {
+            content.append(displayedContent, URLSpan("https://$domain/foo/bar"), 0)
+        }
+
+        val markedUpContent = markupHiddenUrls(context, content, listOf(), listOf(), listener)
+        for (domain in domains) {
+            Assert.assertTrue(markedUpContent.contains("$displayedContent ($domain)"))
+        }
+    }
+
+    @Test
+    fun validMentionsAreNotMarkedUp() {
+        val builder = SpannableStringBuilder()
+        for (mention in mentions) {
+            builder.append("@${mention.username}", URLSpan(mention.url), 0)
+            builder.append(" ")
+        }
+
+        val markedUpContent = markupHiddenUrls(context, builder, mentions, tags, listener)
+        for (mention in mentions) {
+            Assert.assertFalse(markedUpContent.contains("(${getDomain(mention.url)})"))
+        }
+    }
+
+    @Test
+    fun invalidMentionsAreMarkedUp() {
+        val builder = SpannableStringBuilder()
+        for (mention in mentions) {
+            builder.append("@${mention.username}", URLSpan(mention.url), 0)
+            builder.append(" ")
+        }
+
+        val markedUpContent = markupHiddenUrls(context, builder, listOf(), tags, listener)
+        for (mention in mentions) {
+            Assert.assertTrue(markedUpContent.contains("(${getDomain(mention.url)})"))
+        }
+    }
+
+    @Test
+    fun validTagsAreNotMarkedUp() {
+        val builder = SpannableStringBuilder()
+        for (tag in tags) {
+            builder.append("#${tag.name}", URLSpan(tag.url), 0)
+            builder.append(" ")
+        }
+
+        val markedUpContent = markupHiddenUrls(context, builder, mentions, tags, listener)
+        for (tag in tags) {
+            Assert.assertFalse(markedUpContent.contains("(${getDomain(tag.url)})"))
+        }
+    }
+
+    @Test
+    fun invalidTagsAreMarkedUp() {
+        val builder = SpannableStringBuilder()
+        for (tag in tags) {
+            builder.append("#${tag.name}", URLSpan(tag.url), 0)
+            builder.append(" ")
+        }
+
+        val markedUpContent = markupHiddenUrls(context, builder, mentions, listOf(), listener)
+        for (tag in tags) {
+            Assert.assertTrue(markedUpContent.contains("(${getDomain(tag.url)})"))
         }
     }
 }

--- a/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
@@ -5,6 +5,7 @@ import android.text.SpannableStringBuilder
 import android.text.style.URLSpan
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.entity.HashTag
 import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.interfaces.LinkListener
@@ -153,7 +154,7 @@ class LinkHelperTest {
         val maliciousUrl = "https://$maliciousDomain/to/go"
         val content = SpannableStringBuilder()
         content.append(displayedContent, URLSpan(maliciousUrl), 0)
-        Assert.assertEquals("$displayedContent ($maliciousDomain)", markupHiddenUrls(context, content, listOf(), listOf(), listener).toString())
+        Assert.assertEquals(context.getString(R.string.url_domain_notifier, displayedContent, maliciousDomain), markupHiddenUrls(context, content, listOf(), listOf(), listener).toString())
     }
 
     @Test
@@ -163,7 +164,7 @@ class LinkHelperTest {
         val maliciousUrl = "https://$maliciousDomain/to/go"
         val content = SpannableStringBuilder()
         content.append(displayedContent, URLSpan(maliciousUrl), 0)
-        Assert.assertEquals("$displayedContent ($maliciousDomain)", markupHiddenUrls(context, content, listOf(), listOf(), listener).toString())
+        Assert.assertEquals(context.getString(R.string.url_domain_notifier, displayedContent, maliciousDomain), markupHiddenUrls(context, content, listOf(), listOf(), listener).toString())
     }
 
     @Test fun multipleHiddenDomainsAreMarkedUp() {
@@ -176,7 +177,7 @@ class LinkHelperTest {
 
         val markedUpContent = markupHiddenUrls(context, content, listOf(), listOf(), listener)
         for (domain in domains) {
-            Assert.assertTrue(markedUpContent.contains("$displayedContent ($domain)"))
+            Assert.assertTrue(markedUpContent.contains(context.getString(R.string.url_domain_notifier, displayedContent, domain)))
         }
     }
 
@@ -190,7 +191,7 @@ class LinkHelperTest {
 
         val markedUpContent = markupHiddenUrls(context, builder, mentions, tags, listener)
         for (mention in mentions) {
-            Assert.assertFalse(markedUpContent.contains("(${getDomain(mention.url)})"))
+            Assert.assertFalse(markedUpContent.contains("${getDomain(mention.url)})"))
         }
     }
 
@@ -204,7 +205,7 @@ class LinkHelperTest {
 
         val markedUpContent = markupHiddenUrls(context, builder, listOf(), tags, listener)
         for (mention in mentions) {
-            Assert.assertTrue(markedUpContent.contains("(${getDomain(mention.url)})"))
+            Assert.assertTrue(markedUpContent.contains("${getDomain(mention.url)})"))
         }
     }
 
@@ -218,7 +219,7 @@ class LinkHelperTest {
 
         val markedUpContent = markupHiddenUrls(context, builder, mentions, tags, listener)
         for (tag in tags) {
-            Assert.assertFalse(markedUpContent.contains("(${getDomain(tag.url)})"))
+            Assert.assertFalse(markedUpContent.contains("${getDomain(tag.url)})"))
         }
     }
 
@@ -232,7 +233,7 @@ class LinkHelperTest {
 
         val markedUpContent = markupHiddenUrls(context, builder, mentions, listOf(), listener)
         for (tag in tags) {
-            Assert.assertTrue(markedUpContent.contains("(${getDomain(tag.url)})"))
+            Assert.assertTrue(markedUpContent.contains("${getDomain(tag.url)})"))
         }
     }
 }


### PR DESCRIPTION
Addresses #2694

My *instinct* is to spend more time trying not to iterate the content multiple times, but maybe it's ok because many posts don't contain links/tags/mentions, and they only have a few when they do 🤷 

<img width="390" alt="Screen Shot 2022-09-13 at 10 07 17" src="https://user-images.githubusercontent.com/142250/189879689-af923f6f-ac97-4127-a2ef-4359d6bb71da.png">
