### PR TITLE
Retain instance state in compose activity

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -281,7 +281,6 @@ class ComposeActivity :
             }
 
             it.getString(SCHEDULED_TIME_KEY)?.let { time ->
-                binding.composeScheduleView.setDateTime(time)
                 viewModel.updateScheduledAt(time)
             }
         }

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -235,8 +235,6 @@ class ComposeActivity :
         setupButtons()
         subscribeToUpdates(mediaAdapter)
 
-        photoUploadUri = savedInstanceState?.getParcelable(PHOTO_UPLOAD_URI_KEY)
-
         /* If the composer is started up as a reply to another post, override the "starting" state
          * based on what the intent from the reply request passes. */
 
@@ -269,6 +267,24 @@ class ComposeActivity :
         setupContentWarningField(composeOptions?.contentWarning)
         setupPollView()
         applyShareIntent(intent, savedInstanceState)
+
+        /* Finally, overwrite state with data from saved instance state. */
+        savedInstanceState?.let {
+            photoUploadUri = it.getParcelable(PHOTO_UPLOAD_URI_KEY)
+
+            (it.getSerializable(VISIBILITY_KEY) as Status.Visibility).apply {
+                setStatusVisibility(this)
+            }
+
+            it.getBoolean(CONTENT_WARNING_VISIBLE_KEY).apply {
+                viewModel.contentWarningChanged(this)
+            }
+
+            it.getString(SCHEDULED_TIME_KEY)?.let { time ->
+                binding.composeScheduleView.setDateTime(time)
+                viewModel.updateScheduledAt(time)
+            }
+        }
 
         binding.composeEditField.post {
             binding.composeEditField.requestFocus()
@@ -625,6 +641,9 @@ class ComposeActivity :
 
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putParcelable(PHOTO_UPLOAD_URI_KEY, photoUploadUri)
+        outState.putSerializable(VISIBILITY_KEY, viewModel.statusVisibility.value)
+        outState.putBoolean(CONTENT_WARNING_VISIBLE_KEY, viewModel.showContentWarning.value)
+        outState.putString(SCHEDULED_TIME_KEY, viewModel.scheduledAt.value)
         super.onSaveInstanceState(outState)
     }
 
@@ -1208,6 +1227,9 @@ class ComposeActivity :
         private const val NOTIFICATION_ID_EXTRA = "NOTIFICATION_ID"
         private const val ACCOUNT_ID_EXTRA = "ACCOUNT_ID"
         private const val PHOTO_UPLOAD_URI_KEY = "PHOTO_UPLOAD_URI"
+        private const val VISIBILITY_KEY = "VISIBILITY"
+        private const val SCHEDULED_TIME_KEY = "SCHEDULE"
+        private const val CONTENT_WARNING_VISIBLE_KEY = "CONTENT_WARNING_VISIBLE"
 
         /**
          * @param options ComposeOptions to configure the ComposeActivity


### PR DESCRIPTION
This PR improves the restoration behavior of `ComposeActivity` for the case that it is killed by the Android system and later restored from instance state.

Some information, like post content, is retained correctly by the Android system. Certain information is however currently lost during kill&restore:
* post visibility
* schedule time
* visibility of content warning field (however, not the content warning text itself)

To test:

1. Open developer settings, scroll to "Apps", toggle "Don't keep activities".
2. Open Tusky, compose a new post.
3. Expand content warning field, set a visibility that is different from the default, and a schedule time.
4. Open the app switcher (this kills `ComposeActivity`) and open it again.

Without this PR:

5. Observe that the CW field is collapsed (even though the text is still hidden inside), the default visibility is back and the schedule time has been removed.

With this PR:

5. The information is restored correctly and you can finish composing your post ;)