### PR TITLE
Don't markup urls where the display text is exactly the domain

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -57,7 +57,7 @@ fun getDomain(urlString: String?): String {
  * @param listener to notify about particular spans that are clicked
  */
 fun setClickableText(view: TextView, content: CharSequence, mentions: List<Mention>, tags: List<HashTag>?, listener: LinkListener) {
-    val spannableContent = markupHiddenUrls(view.context, content, mentions, tags, listener)
+    val spannableContent = markupHiddenUrls(view.context, content)
 
     view.text = spannableContent.apply {
         getSpans(0, content.length, URLSpan::class.java).forEach {
@@ -68,7 +68,7 @@ fun setClickableText(view: TextView, content: CharSequence, mentions: List<Menti
 }
 
 @VisibleForTesting
-fun markupHiddenUrls(context: Context, content: CharSequence, mentions: List<Mention>, tags: List<HashTag>?, listener: LinkListener): SpannableStringBuilder {
+fun markupHiddenUrls(context: Context, content: CharSequence): SpannableStringBuilder {
     val spannableContent = SpannableStringBuilder.valueOf(content)
     val originalSpans = spannableContent.getSpans(0, content.length, URLSpan::class.java)
     val obscuredLinkSpans = originalSpans.filter {

--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -74,9 +74,20 @@ fun markupHiddenUrls(context: Context, content: CharSequence, mentions: List<Men
     val obscuredLinkSpans = originalSpans.filter {
         val text = spannableContent.subSequence(spannableContent.getSpanStart(it), spannableContent.getSpanEnd(it))
         val firstCharacter = text[0]
-        firstCharacter != '#' &&
-            firstCharacter != '@' &&
-            getDomain(text.toString()) != getDomain(it.url)
+        return@filter if (firstCharacter == '#' || firstCharacter == '@') {
+            false
+        } else {
+            var textDomain = getDomain(text.toString())
+            if (textDomain.isBlank()) {
+                // Allow "some.domain" or "www.some.domain" without a domain notifier
+                textDomain = if (text.startsWith("www.")) {
+                    text.substring(4)
+                } else {
+                    text.toString()
+                }
+            }
+            getDomain(it.url) != textDomain
+        }
     }
 
     for (span in obscuredLinkSpans) {

--- a/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
@@ -193,6 +193,20 @@ class LinkHelperTest {
     }
 
     @Test
+    fun nonUriTextExactlyMatchingDomainIsNotMarkedUp() {
+        val domain = "some.place"
+        val content = SpannableStringBuilder()
+            .append(domain, URLSpan("https://some.place/"), 0)
+            .append(domain, URLSpan("https://some.place"), 0)
+            .append(domain, URLSpan("https://www.some.place"), 0)
+            .append("www.$domain", URLSpan("https://some.place"), 0)
+            .append("www.$domain", URLSpan("https://some.place/"), 0)
+
+        val markedUpContent = markupHiddenUrls(context, content, listOf(), listOf(), listener)
+        Assert.assertFalse(markedUpContent.contains("🔗"))
+    }
+
+    @Test
     fun validMentionsAreNotMarkedUp() {
         val builder = SpannableStringBuilder()
         for (mention in mentions) {

--- a/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
@@ -165,7 +165,10 @@ class LinkHelperTest {
         val maliciousUrl = "https://$maliciousDomain/to/go"
         val content = SpannableStringBuilder()
         content.append(displayedContent, URLSpan(maliciousUrl), 0)
-        Assert.assertEquals(context.getString(R.string.url_domain_notifier, displayedContent, maliciousDomain), markupHiddenUrls(context, content, listOf(), listOf(), listener).toString())
+        Assert.assertEquals(
+            context.getString(R.string.url_domain_notifier, displayedContent, maliciousDomain),
+            markupHiddenUrls(context, content).toString()
+        )
     }
 
     @Test
@@ -175,10 +178,14 @@ class LinkHelperTest {
         val maliciousUrl = "https://$maliciousDomain/to/go"
         val content = SpannableStringBuilder()
         content.append(displayedContent, URLSpan(maliciousUrl), 0)
-        Assert.assertEquals(context.getString(R.string.url_domain_notifier, displayedContent, maliciousDomain), markupHiddenUrls(context, content, listOf(), listOf(), listener).toString())
+        Assert.assertEquals(
+            context.getString(R.string.url_domain_notifier, displayedContent, maliciousDomain),
+            markupHiddenUrls(context, content).toString()
+        )
     }
 
-    @Test fun multipleHiddenDomainsAreMarkedUp() {
+    @Test
+    fun multipleHiddenDomainsAreMarkedUp() {
         val domains = listOf("one.place", "another.place", "athird.place")
         val displayedContent = "link"
         val content = SpannableStringBuilder()
@@ -186,7 +193,7 @@ class LinkHelperTest {
             content.append(displayedContent, URLSpan("https://$domain/foo/bar"), 0)
         }
 
-        val markedUpContent = markupHiddenUrls(context, content, listOf(), listOf(), listener)
+        val markedUpContent = markupHiddenUrls(context, content)
         for (domain in domains) {
             Assert.assertTrue(markedUpContent.contains(context.getString(R.string.url_domain_notifier, displayedContent, domain)))
         }
@@ -202,7 +209,7 @@ class LinkHelperTest {
             .append("www.$domain", URLSpan("https://some.place"), 0)
             .append("www.$domain", URLSpan("https://some.place/"), 0)
 
-        val markedUpContent = markupHiddenUrls(context, content, listOf(), listOf(), listener)
+        val markedUpContent = markupHiddenUrls(context, content)
         Assert.assertFalse(markedUpContent.contains("🔗"))
     }
 
@@ -214,7 +221,7 @@ class LinkHelperTest {
             builder.append(" ")
         }
 
-        val markedUpContent = markupHiddenUrls(context, builder, mentions, tags, listener)
+        val markedUpContent = markupHiddenUrls(context, builder)
         for (mention in mentions) {
             Assert.assertFalse(markedUpContent.contains("${getDomain(mention.url)})"))
         }
@@ -228,7 +235,7 @@ class LinkHelperTest {
             builder.append(" ")
         }
 
-        val markedUpContent = markupHiddenUrls(context, builder, listOf(), tags, listener)
+        val markedUpContent = markupHiddenUrls(context, builder)
         for (mention in mentions) {
             Assert.assertFalse(markedUpContent.contains("${getDomain(mention.url)})"))
         }
@@ -242,7 +249,7 @@ class LinkHelperTest {
             builder.append(" ")
         }
 
-        val markedUpContent = markupHiddenUrls(context, builder, mentions, tags, listener)
+        val markedUpContent = markupHiddenUrls(context, builder)
         for (tag in tags) {
             Assert.assertFalse(markedUpContent.contains("${getDomain(tag.url)})"))
         }
@@ -256,7 +263,7 @@ class LinkHelperTest {
             builder.append(" ")
         }
 
-        val markedUpContent = markupHiddenUrls(context, builder, mentions, listOf(), listener)
+        val markedUpContent = markupHiddenUrls(context, builder)
         for (tag in tags) {
             Assert.assertFalse(markedUpContent.contains("${getDomain(tag.url)})"))
         }


### PR DESCRIPTION
Prior to this, if the markup were like `<a href="https://itch.io/">itch.io</a>`, it would render as `itch.io (🔗 itch.io)`