### PR TITLE
fix compose field on landscape tablets

### DIFF
--- a/app/src/main/res/values-large-land/dimens.xml
+++ b/app/src/main/res/values-large-land/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="compose_activity_scrollview_height">180dp</dimen>
+</resources>


### PR DESCRIPTION
On tablets in landscape format the compose field would be too big (400dp) and be hidden behind the bottom bar when composing long texts. This fixes the problem.