### PR TITLE
[UX Improvement] Always show the toolbar, but hide section title

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesActivity.kt
@@ -138,7 +138,7 @@ class PreferencesActivity :
             }
             "statusTextSize", "absoluteTimeView", "showBotOverlay", "animateGifAvatars", "useBlurhash",
             "showSelfUsername", "showCardsInTimelines", "confirmReblogs", "confirmFavourites",
-            "enableSwipeForTabs", "mainNavPosition", PrefKeys.HIDE_TOP_TOOLBAR -> {
+            "enableSwipeForTabs", "mainNavPosition", PrefKeys.HIDE_TOP_TOOLBAR_TITLE -> {
                 restartActivitiesOnBackPressedCallback.isEnabled = true
             }
             "language" -> {

--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesFragment.kt
@@ -108,7 +108,7 @@ class PreferencesFragment : PreferenceFragmentCompat(), Injectable {
 
                 switchPreference {
                     setDefaultValue(false)
-                    key = PrefKeys.HIDE_TOP_TOOLBAR
+                    key = PrefKeys.HIDE_TOP_TOOLBAR_TITLE
                     setTitle(R.string.pref_title_hide_top_toolbar)
                 }
 

--- a/app/src/main/java/com/keylesspalace/tusky/settings/SettingsConstants.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/settings/SettingsConstants.kt
@@ -22,7 +22,7 @@ object PrefKeys {
     const val LANGUAGE = "language"
     const val STATUS_TEXT_SIZE = "statusTextSize"
     const val MAIN_NAV_POSITION = "mainNavPosition"
-    const val HIDE_TOP_TOOLBAR = "hideTopToolbar"
+    const val HIDE_TOP_TOOLBAR_TITLE = "hideTopToolbar"
     const val ABSOLUTE_TIME_VIEW = "absoluteTimeView"
     const val SHOW_BOT_OVERLAY = "showBotOverlay"
     const val ANIMATE_GIF_AVATARS = "animateGifAvatars"


### PR DESCRIPTION
Hi, Tusky! 👋 ❤️ 

Fixing an issue where enabling _**Hide the title of the top toolbar**_ in preferences would hide the entire toolbar. This would make it ~~impossible~~ DIFFICULT/CONFUSING to open the App's navigation drawer, therefore locking the user out of a significant portion of the app, including Preferences. The user would have to delete the App Cache for it to re-appear if they didn't know about long-pressing on the left side of the screen (which they probably don't).

Instead, let's set the toolbar title to the `app_name` string and avoid setting the title with the section names. This avoids putting the user in a bad UX state.

### Summary of changes
Improving intent of the _**Hide the title of the top toolbar**_ preference
- Rename PrefKeys constant `HIDE_TOP_TOOLBAR` to `HIDE_TOP_TOOLBAR_TITLE` 
- During MainActivity `onCreate`, set the title of the toolbar to `Tusky` from `R.string.app_name`
- When a tab is selected, only change the title of the toolbar to `TabData.title` if the `HIDE_TOP_TOOLBAR` preference is enabled. Otherwise, the title will remain `Tusky`
- Always showing the Search menu action on the toolbar, because we want to always show the toolbar!

### Comparison

| Before | After |
|----|----|
| <video src="https://user-images.githubusercontent.com/478342/200122525-358075e3-d85b-4cda-8c11-cc4226fe8648.mp4" width="400" /> | <video src="https://user-images.githubusercontent.com/478342/200122552-0869a462-83e9-4f0f-a97a-7650b6856211.mp4" width="400" /> |



