### PR TITLE
#2752: enable to copy the profile bio and its account fields

### DIFF
--- a/app/src/main/res/layout/activity_account.xml
+++ b/app/src/main/res/layout/activity_account.xml
@@ -223,6 +223,7 @@
                         android:lineSpacingMultiplier="1.1"
                         android:paddingTop="2dp"
                         android:textColor="?android:textColorTertiary"
+                        android:textIsSelectable="true"
                         android:textSize="?attr/status_text_medium"
                         app:layout_constraintTop_toBottomOf="@id/saveNoteInfo"
                         tools:text="This is a test description. Descriptions can be quite looooong." />

--- a/app/src/main/res/layout/item_account_field.xml
+++ b/app/src/main/res/layout/item_account_field.xml
@@ -29,6 +29,7 @@
         android:drawablePadding="6dp"
         android:gravity="center"
         android:lineSpacingMultiplier="1.1"
+        android:textIsSelectable="true"
         android:textSize="?attr/status_text_medium"
         app:layout_constrainedWidth="true"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
Fixes #2752 

By enabling selection on text fields for `accountFieldValues` and `accountNote`

![Screenshot_20221106_063931](https://user-images.githubusercontent.com/841681/200178462-78c002e1-0293-4c72-b10f-f6c61cf171ac.png)
