### PR TITLE
#2072: hide add reaction when limit is reached

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/announcements/AnnouncementAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/announcements/AnnouncementAdapter.kt
@@ -75,7 +75,7 @@ class AnnouncementAdapter(
         }
 
         // hide button if announcement badge limit is already reached
-        addReactionChip.visible(item.reactions.size >= 8)
+        addReactionChip.visible(item.reactions.size < 8)
 
         item.reactions.forEachIndexed { i, reaction ->
             (

--- a/app/src/main/java/com/keylesspalace/tusky/components/announcements/AnnouncementAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/announcements/AnnouncementAdapter.kt
@@ -34,6 +34,7 @@ import com.keylesspalace.tusky.util.EmojiSpan
 import com.keylesspalace.tusky.util.emojify
 import com.keylesspalace.tusky.util.parseAsMastodonHtml
 import com.keylesspalace.tusky.util.setClickableText
+import com.keylesspalace.tusky.util.visible
 import java.lang.ref.WeakReference
 
 interface AnnouncementActionListener : LinkListener {
@@ -74,11 +75,7 @@ class AnnouncementAdapter(
         }
 
         // hide button if announcement badge limit is already reached
-        if (item.reactions.size >= 8) {
-            addReactionChip.visibility = View.GONE
-        } else {
-            addReactionChip.visibility = View.VISIBLE
-        }
+        addReactionChip.visible(item.reactions.size >= 8)
 
         item.reactions.forEachIndexed { i, reaction ->
             (

--- a/app/src/main/java/com/keylesspalace/tusky/components/announcements/AnnouncementAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/announcements/AnnouncementAdapter.kt
@@ -73,6 +73,13 @@ class AnnouncementAdapter(
             return
         }
 
+        // hide button if announcement badge limit is already reached
+        if (item.reactions.size >= 8) {
+            addReactionChip.visibility = View.GONE
+        } else {
+            addReactionChip.visibility = View.VISIBLE
+        }
+
         item.reactions.forEachIndexed { i, reaction ->
             (
                 chips.getChildAt(i)?.takeUnless { it.id == R.id.addReactionChip } as Chip?


### PR DESCRIPTION
fixes: #2072

hide/show add reaction chip based on the reaction count

[device-2022-11-06-183243.webm](https://user-images.githubusercontent.com/841681/200185881-ffe1cb1d-2832-47e5-a99b-14af62d9c362.webm)
