### PR TITLE
Make bare domain detection more robust in link markup logic

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -72,19 +72,15 @@ fun markupHiddenUrls(context: Context, content: CharSequence): SpannableStringBu
     val spannableContent = SpannableStringBuilder.valueOf(content)
     val originalSpans = spannableContent.getSpans(0, content.length, URLSpan::class.java)
     val obscuredLinkSpans = originalSpans.filter {
-        val text = spannableContent.subSequence(spannableContent.getSpanStart(it), spannableContent.getSpanEnd(it))
-        val firstCharacter = text[0]
+        val start = spannableContent.getSpanStart(it)
+        val firstCharacter = content[start]
         return@filter if (firstCharacter == '#' || firstCharacter == '@') {
             false
         } else {
-            var textDomain = getDomain(text.toString())
+            val text = spannableContent.subSequence(start, spannableContent.getSpanEnd(it)).toString()
+            var textDomain = getDomain(text)
             if (textDomain.isBlank()) {
-                // Allow "some.domain" or "www.some.domain" without a domain notifier
-                textDomain = if (text.startsWith("www.")) {
-                    text.substring(4)
-                } else {
-                    text.toString()
-                }
+                textDomain = getDomain("https://$text")
             }
             getDomain(it.url) != textDomain
         }

--- a/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
@@ -203,11 +203,14 @@ class LinkHelperTest {
     fun nonUriTextExactlyMatchingDomainIsNotMarkedUp() {
         val domain = "some.place"
         val content = SpannableStringBuilder()
-            .append(domain, URLSpan("https://some.place/"), 0)
-            .append(domain, URLSpan("https://some.place"), 0)
-            .append(domain, URLSpan("https://www.some.place"), 0)
-            .append("www.$domain", URLSpan("https://some.place"), 0)
-            .append("www.$domain", URLSpan("https://some.place/"), 0)
+            .append(domain, URLSpan("https://$domain/"), 0)
+            .append(domain, URLSpan("https://$domain"), 0)
+            .append(domain, URLSpan("https://www.$domain"), 0)
+            .append("www.$domain", URLSpan("https://$domain"), 0)
+            .append("www.$domain", URLSpan("https://$domain/"), 0)
+            .append("$domain/", URLSpan("https://$domain/"), 0)
+            .append("$domain/", URLSpan("https://$domain"), 0)
+            .append("$domain/", URLSpan("https://www.$domain"), 0)
 
         val markedUpContent = markupHiddenUrls(context, content)
         Assert.assertFalse(markedUpContent.contains("🔗"))


### PR DESCRIPTION
This additionally prevents marking up the target domain of links when the display text is:
- `same.domain/`
- `same.domain/foo/bar`