### PR TITLE
Switch to an unambiguous date format in Absolute Time mode

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/AbsoluteTimeFormatter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/AbsoluteTimeFormatter.kt
@@ -23,7 +23,7 @@ import java.util.TimeZone
 
 class AbsoluteTimeFormatter @JvmOverloads constructor(private val tz: TimeZone = TimeZone.getDefault()) {
     private val sameDaySdf = SimpleDateFormat("HH:mm", Locale.getDefault()).apply { this.timeZone = tz }
-    private val sameYearSdf = SimpleDateFormat("MM-dd HH:mm", Locale.getDefault()).apply { this.timeZone = tz }
+    private val sameYearSdf = SimpleDateFormat("dd MMM, HH:mm", Locale.getDefault()).apply { this.timeZone = tz }
     private val otherYearSdf = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).apply { this.timeZone = tz }
     private val otherYearCompleteSdf = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).apply { this.timeZone = tz }
 

--- a/app/src/test/java/com/keylesspalace/tusky/util/AbsoluteTimeFormatterTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/util/AbsoluteTimeFormatterTest.kt
@@ -27,11 +27,11 @@ class AbsoluteTimeFormatterTest {
     @Test
     fun `same year formatting`() {
         val nextDay = Date.from(Instant.parse("2022-04-12T00:10:00.00Z"))
-        assertEquals("04-12 00:10", formatter.format(nextDay, true, now))
-        assertEquals("04-12 00:10", formatter.format(nextDay, false, now))
+        assertEquals("12 Apr, 00:10", formatter.format(nextDay, true, now))
+        assertEquals("12 Apr, 00:10", formatter.format(nextDay, false, now))
         val endOfYear = Date.from(Instant.parse("2022-12-31T23:59:00.00Z"))
-        assertEquals("12-31 23:59", formatter.format(endOfYear, true, now))
-        assertEquals("12-31 23:59", formatter.format(endOfYear, false, now))
+        assertEquals("31 Dec, 23:59", formatter.format(endOfYear, true, now))
+        assertEquals("31 Dec, 23:59", formatter.format(endOfYear, false, now))
     }
 
     @Test


### PR DESCRIPTION
Noticed when scrolling notifs that the short date format is ambiguous as to whether it is DD/MM or MM/DD (figured it is the latter), but that's unintuitive to users where that's not the standard date format. This change uses MMM instead of MM to make it more clear (e.g. 10 Nov. vs. 11/10).