### PR TITLE
Make URLSpans with trailing URL not marked up

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -77,13 +77,16 @@ fun markupHiddenUrls(context: Context, content: CharSequence): SpannableStringBu
         return@filter if (firstCharacter == '#' || firstCharacter == '@') {
             false
         } else {
-            var textDomain = getDomain(text.toString())
+            val lastPart = text.toString().split(' ').lastOrNull() ?: ""
+            var textDomain = getDomain(lastPart)
             if (textDomain.isBlank()) {
                 // Allow "some.domain" or "www.some.domain" without a domain notifier
-                textDomain = if (text.startsWith("www.")) {
-                    text.substring(4)
-                } else {
-                    text.toString()
+                textDomain = lastPart
+                if (textDomain.startsWith("www.")) {
+                    textDomain = textDomain.substring(4)
+                }
+                if (textDomain.endsWith("/")) {
+                    textDomain = textDomain.substring(0, textDomain.length - 1)
                 }
             }
             getDomain(it.url) != textDomain

--- a/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
@@ -214,6 +214,41 @@ class LinkHelperTest {
     }
 
     @Test
+    fun spanEndsWithUrlIsNotMarkedUp() {
+        val content = SpannableStringBuilder()
+            .append("Some Place: some.place", URLSpan("https://some.place"), 0)
+            .append("Some Place: some.place/", URLSpan("https://some.place/"), 0)
+            .append("Some Place - https://some.place", URLSpan("https://some.place"), 0)
+            .append("Some Place | https://some.place/", URLSpan("https://some.place/"), 0)
+            .append("Some Place https://some.place/path", URLSpan("https://some.place/path"), 0)
+
+        val markedUpContent = markupHiddenUrls(context, content)
+        Assert.assertFalse(markedUpContent.contains("🔗"))
+    }
+
+    @Test
+    fun spanEndsWithFraudulentUrlIsMarkedUp() {
+        val content = SpannableStringBuilder()
+            .append("Another Place: another.place", URLSpan("https://some.place"), 0)
+            .append("Another Place: another.place/", URLSpan("https://some.place/"), 0)
+            .append("Another Place - https://another.place", URLSpan("https://some.place"), 0)
+            .append("Another Place | https://another.place/", URLSpan("https://some.place/"), 0)
+            .append("Another Place https://another.place/path", URLSpan("https://some.place/path"), 0)
+
+        val markedUpContent = markupHiddenUrls(context, content)
+        val asserts = listOf(
+            "Another Place: another.place",
+            "Another Place: another.place/",
+            "Another Place - https://another.place",
+            "Another Place | https://another.place/",
+            "Another Place https://another.place/path",
+        )
+        asserts.forEach {
+            Assert.assertTrue(markedUpContent.contains(context.getString(R.string.url_domain_notifier, it, "some.place")))
+        }
+    }
+
+    @Test
     fun validMentionsAreNotMarkedUp() {
         val builder = SpannableStringBuilder()
         for (mention in mentions) {


### PR DESCRIPTION
Some Misskey users use Markdown to share URLs with its title with URL. URL markup is too redundant for such URLs.

Examples of URLs with trailing URL:

* [GitHub | https://github.com/](https://github.com) (`[GitHub | https://github.com/](https://github.com)`)
* [GitHub - github.com](https://github.com) (`[GitHub | https://github.com/](https://github.com)`)
* [GitHub https://github.com](https://github.com) (`[GitHub | https://github.com/](https://github.com)`)

There are some variations for such representation, so I decided to cut texts with whitespace and take the last part of them.

Example post from my misskey account: https://misskey.io/notes/97hjya45lu

![Screenshot](https://media.odakyu.app/media_attachments/files/109/331/168/356/437/540/original/fb6ae71254d7b65d.png)