### PR TITLE
Fix `markupHiddenUrls` destructs original CharSequence

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -69,7 +69,7 @@ fun setClickableText(view: TextView, content: CharSequence, mentions: List<Menti
 
 @VisibleForTesting
 fun markupHiddenUrls(context: Context, content: CharSequence): SpannableStringBuilder {
-    val spannableContent = SpannableStringBuilder.valueOf(content)
+    val spannableContent = SpannableStringBuilder(content)
     val originalSpans = spannableContent.getSpans(0, content.length, URLSpan::class.java)
     val obscuredLinkSpans = originalSpans.filter {
         val text = spannableContent.subSequence(spannableContent.getSpanStart(it), spannableContent.getSpanEnd(it))

--- a/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
@@ -165,10 +165,12 @@ class LinkHelperTest {
         val maliciousUrl = "https://$maliciousDomain/to/go"
         val content = SpannableStringBuilder()
         content.append(displayedContent, URLSpan(maliciousUrl), 0)
+        val oldContent = content.toString()
         Assert.assertEquals(
             context.getString(R.string.url_domain_notifier, displayedContent, maliciousDomain),
             markupHiddenUrls(context, content).toString()
         )
+        Assert.assertEquals(oldContent, content.toString())
     }
 
     @Test


### PR DESCRIPTION
It seems like URLs could be marked up repeatedly. See screenshot below.

# Steps to reproduce

1. Display a post with URL markup
2. Hide the post by scrolling up or down
3. Display the post again by scrolling
4. Repeat 2 and 3

# Cause of the bug

`SpannableBuilder.valueOf` does not create new instance when passed `CharSequence` is an instance of `SpannableBuilder`.
`markupHiddenUrls` is called every time `StatusBaseViewHolder.setupWithStatus` called, and updates status object.

# Screenshots

Example post from my misskey account: https://misskey.io/notes/97hkq07foc

![before](https://media.odakyu.app/media_attachments/files/109/331/258/607/064/662/original/c01831f387b0d315.png) ![after](https://media.odakyu.app/media_attachments/files/109/331/259/487/730/318/original/b7c7bd39c3160e57.png)