### PR TITLE
2857 precise tabbing

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -589,7 +589,8 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
 
         val adapter = MainPagerAdapter(tabs, this)
         binding.viewPager.adapter = adapter
-        TabLayoutMediator(activeTabLayout, binding.viewPager) { _: TabLayout.Tab?, _: Int -> }.attach()
+        val smoothScroll = false; // avoid other timelines being loaded needlessly
+        TabLayoutMediator(activeTabLayout, binding.viewPager, true, smoothScroll) { _: TabLayout.Tab?, _: Int -> }.attach()
         activeTabLayout.removeAllTabs()
         for (i in tabs.indices) {
             val tab = activeTabLayout.newTab()


### PR DESCRIPTION
Masks the problem of one timeline (tagline) potentially replacing the contents of another.
https://github.com/tuskyapp/Tusky/issues/2857

And also avoids loading timeline content that is actually not displayed (i. e. needless network traffic).