### PR TITLE
Use the appcompat style for Toolbar. Fixes subtitle vertical cropping.

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -25,6 +25,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:contentInsetStartWithNavigation="0dp"
+                style="@style/Widget.AppCompat.Toolbar"
                 app:layout_scrollFlags="scroll|enterAlways"
                 app:navigationContentDescription="@string/action_open_drawer" />
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -22,10 +22,10 @@
 
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/mainToolbar"
+                style="@style/Widget.AppCompat.Toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:contentInsetStartWithNavigation="0dp"
-                style="@style/Widget.AppCompat.Toolbar"
                 app:layout_scrollFlags="scroll|enterAlways"
                 app:navigationContentDescription="@string/action_open_drawer" />
 


### PR DESCRIPTION
### Objective
* Fix the toolbar subtitle appearing slightly cropped (see #2712).

### Description
* It's an AppCompat.Toolbar, so applying the default theme appears to do the trick.

This is how it looks after the change:

![image](https://user-images.githubusercontent.com/15253/203383747-2a094e07-2f8a-415c-95cd-25d7726bfa07.png)
