### PR TITLE
wrapper class for API that sanitizes unicode domain names

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/di/NetworkModule.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/di/NetworkModule.kt
@@ -27,6 +27,7 @@ import com.keylesspalace.tusky.json.Rfc3339DateJsonAdapter
 import com.keylesspalace.tusky.network.InstanceSwitchAuthInterceptor
 import com.keylesspalace.tusky.network.MastodonApi
 import com.keylesspalace.tusky.network.MediaUploadApi
+import com.keylesspalace.tusky.network.UnicodeSafeMastodonApi
 import com.keylesspalace.tusky.util.getNonNullString
 import dagger.Module
 import dagger.Provides
@@ -117,7 +118,10 @@ class NetworkModule {
 
     @Provides
     @Singleton
-    fun providesApi(retrofit: Retrofit): MastodonApi = retrofit.create()
+    fun providesApi(retrofit: Retrofit): MastodonApi {
+        val api = retrofit.create<MastodonApi>()
+        return UnicodeSafeMastodonApi(api)
+    }
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/keylesspalace/tusky/network/UnicodeSafeMastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/UnicodeSafeMastodonApi.kt
@@ -1,0 +1,142 @@
+/* Copyright 2022 kylegoetz
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>. */
+
+package com.keylesspalace.tusky.network
+
+import at.connyduck.calladapter.networkresult.NetworkResult
+import com.keylesspalace.tusky.entity.AccessToken
+import com.keylesspalace.tusky.entity.Account
+import com.keylesspalace.tusky.entity.AppCredentials
+import com.keylesspalace.tusky.entity.Instance
+import com.keylesspalace.tusky.entity.Marker
+import com.keylesspalace.tusky.entity.NewStatus
+import com.keylesspalace.tusky.entity.Notification
+import com.keylesspalace.tusky.entity.NotificationSubscribeResult
+import com.keylesspalace.tusky.entity.Status
+import io.reactivex.rxjava3.core.Single
+import okhttp3.ResponseBody
+import java.net.IDN
+
+class UnicodeSafeMastodonApi(private val api: MastodonApi) : MastodonApi by api {
+    override suspend fun getInstance(domain: String?): NetworkResult<Instance> {
+        return api.getInstance(domain?.let(IDN::toASCII))
+    }
+
+    override fun markersWithAuth(
+        auth: String,
+        domain: String,
+        timelines: List<String>
+    ): Single<Map<String, Marker>> {
+        return api.markersWithAuth(auth, IDN.toASCII(domain), timelines)
+    }
+
+    override fun notificationsWithAuth(
+        auth: String,
+        domain: String,
+        sinceId: String?
+    ): Single<List<Notification>> {
+        return api.notificationsWithAuth(auth, IDN.toASCII(domain), sinceId)
+    }
+
+    override suspend fun createStatus(
+        auth: String,
+        domain: String,
+        idempotencyKey: String,
+        status: NewStatus
+    ): NetworkResult<Status> {
+        return api.createStatus(auth, IDN.toASCII(domain), idempotencyKey, status)
+    }
+
+    override suspend fun accountVerifyCredentials(
+        domain: String?,
+        auth: String?
+    ): NetworkResult<Account> {
+        return api.accountVerifyCredentials(domain?.let(IDN::toASCII), auth)
+    }
+
+    override suspend fun authenticateApp(
+        domain: String,
+        clientName: String,
+        redirectUris: String,
+        scopes: String,
+        website: String
+    ): NetworkResult<AppCredentials> {
+        return api.authenticateApp(
+            IDN.toASCII(domain),
+            clientName,
+            redirectUris,
+            scopes,
+            website
+        )
+    }
+
+    override suspend fun fetchOAuthToken(
+        domain: String,
+        clientId: String,
+        clientSecret: String,
+        redirectUri: String,
+        code: String,
+        grantType: String
+    ): NetworkResult<AccessToken> {
+        return api.fetchOAuthToken(
+            IDN.toASCII(domain),
+            clientId,
+            clientSecret,
+            redirectUri,
+            code,
+            grantType
+        )
+    }
+
+    override suspend fun subscribePushNotifications(
+        auth: String,
+        domain: String,
+        endPoint: String,
+        keysP256DH: String,
+        keysAuth: String,
+        data: Map<String, Boolean>
+    ): NetworkResult<NotificationSubscribeResult> {
+        return api.subscribePushNotifications(
+            auth,
+            IDN.toASCII(domain),
+            endPoint,
+            keysP256DH,
+            keysAuth,
+            data
+        )
+    }
+
+    override suspend fun updatePushNotificationSubscription(
+        auth: String,
+        domain: String,
+        data: Map<String, Boolean>
+    ): NetworkResult<NotificationSubscribeResult> {
+        return api.updatePushNotificationSubscription(
+            auth,
+            IDN.toASCII(domain),
+            data
+        )
+    }
+
+    override suspend fun unsubscribePushNotifications(
+        auth: String,
+        domain: String
+    ): NetworkResult<ResponseBody> {
+        return api.unsubscribePushNotifications(
+            auth,
+            IDN.toASCII(domain)
+        )
+    }
+}

--- a/app/src/test/java/com/keylesspalace/tusky/network/UnicodeSafeMastodonApiTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/network/UnicodeSafeMastodonApiTest.kt
@@ -1,0 +1,85 @@
+import com.keylesspalace.tusky.network.MastodonApi
+import com.keylesspalace.tusky.network.UnicodeSafeMastodonApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyBlocking
+import java.net.IDN
+
+private const val UNICODE_DOMAIN = "これはペンです"
+
+class UnicodeSafeMastodonApiTest {
+    private val asciiDomain = IDN.toASCII(UNICODE_DOMAIN)
+    private lateinit var mockApi: MastodonApi
+    private lateinit var api: UnicodeSafeMastodonApi
+
+    @Before
+    fun setup() {
+        mockApi = mock()
+        api = UnicodeSafeMastodonApi(mockApi)
+    }
+
+    @Test
+    fun `should call getInstance with ASCII domain instead of Unicode`() {
+        runBlocking { api.getInstance(UNICODE_DOMAIN) }
+        verifyBlocking(mockApi) { getInstance(asciiDomain) }
+    }
+
+    @Test
+    fun `should call markersWithAuth with ASCII domain`() {
+        runBlocking { api.markersWithAuth("", UNICODE_DOMAIN, emptyList()) }
+        verifyBlocking(mockApi) { markersWithAuth("", asciiDomain, emptyList()) }
+    }
+
+    @Test
+    fun `should call notificationsWithAuth with ASCII domain`() {
+        runBlocking { api.notificationsWithAuth("", UNICODE_DOMAIN, "") }
+        verifyBlocking(mockApi) { notificationsWithAuth("", asciiDomain, "") }
+    }
+
+    @Test
+    fun `calls createStatus with ASCII domain`() {
+        runBlocking { api.createStatus("", UNICODE_DOMAIN, "", mock()) }
+        verifyBlocking(mockApi) { createStatus(anyString(), eq(asciiDomain), anyString(), any()) }
+    }
+
+    @Test
+    fun `calls accountVerifyCredentials with ASCII domain`() {
+        runBlocking { api.accountVerifyCredentials(UNICODE_DOMAIN, "") }
+        verifyBlocking(mockApi) { accountVerifyCredentials(asciiDomain, "") }
+    }
+
+    @Test
+    fun `calls authenticateApp with ASCII domain`() {
+        runBlocking { api.authenticateApp(UNICODE_DOMAIN, "", "", "", "") }
+        verifyBlocking(mockApi) { authenticateApp(asciiDomain, "", "", "", "") }
+    }
+
+    @Test
+    fun `calls fetchOAuthToken with ASCII domain`() {
+        runBlocking { api.fetchOAuthToken(UNICODE_DOMAIN, "", "", "", "", "") }
+        verifyBlocking(mockApi) { fetchOAuthToken(asciiDomain, "", "", "", "", "") }
+    }
+
+    @Test
+    fun `calls subscribePushNotifications with ASCII domain`() {
+        runBlocking { api.subscribePushNotifications("", UNICODE_DOMAIN, "", "", "", emptyMap()) }
+        verifyBlocking(mockApi) { subscribePushNotifications("", asciiDomain, "", "", "", emptyMap()) }
+    }
+
+    @Test
+    fun `calls updatePushNotificationSubscription with ASCII domain`() {
+        runBlocking { api.updatePushNotificationSubscription("", UNICODE_DOMAIN, emptyMap()) }
+        verifyBlocking(mockApi) { updatePushNotificationSubscription("", asciiDomain, emptyMap()) }
+    }
+
+    @Test
+    fun `calls unsubscribePushNotifications with ASCII domain`() {
+        runBlocking { api.unsubscribePushNotifications("", UNICODE_DOMAIN) }
+        verifyBlocking(mockApi) { unsubscribePushNotifications("", asciiDomain) }
+    }
+}


### PR DESCRIPTION
fixes #2873 

Originally I wrote an interceptor that would convert unicode domains to ascii domains with the user's input being deemed the normalized form, but the code would still error out because OkHttp does not support unicode headers either, and the app sets the domain header.

So I wrote an implementation of `MastadonApi` that uses the Retrofit-generated version for most API calls but the ones that use the DOMAIN header convert Unicode to ASCII and then directly call the Retrofit-generated version with no other changes. This implementation is what gets injected by Dagger.

- [x] lint passes
- [x] new unit tests written
- [x] all unit tests pass 