### PR TITLE
don't include dependency info in apk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,6 +90,10 @@ android {
     kotlinOptions {
         freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
     }
+    dependenciesInfo {
+        includeInApk false
+        includeInBundle false
+    }
 }
 
 // library versions are in PROJECT_ROOT/gradle/libs.versions.toml


### PR DESCRIPTION
Makes the apk a tiny bit smaller.