### PR TITLE
hide "take photo" button when no photo app is installed

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -30,6 +30,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
+import android.provider.MediaStore
 import android.util.Log
 import android.view.KeyEvent
 import android.view.MenuItem
@@ -509,6 +510,8 @@ class ComposeActivity :
 
         val pollIcon = IconicsDrawable(this, GoogleMaterial.Icon.gmd_poll).apply { colorInt = textColor; sizeDp = 18 }
         binding.addPollTextActionTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(pollIcon, null, null, null)
+
+        binding.actionPhotoTake.visible(Intent(MediaStore.ACTION_IMAGE_CAPTURE).resolveActivity(packageManager) != null)
 
         binding.actionPhotoTake.setOnClickListener { initiateCameraApp() }
         binding.actionPhotoPick.setOnClickListener { onMediaPick() }


### PR DESCRIPTION
This should prevent a rare crash I'm seeing in the Play console
```

Exception android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.media.action.IMAGE_CAPTURE flg=0x3 clip={text/uri-list hasLabel(0) {U(content)}} (has extras) }
  at android.app.Instrumentation.checkStartActivityResult (Instrumentation.java:2167)
  at android.app.Instrumentation.execStartActivity (Instrumentation.java:1811)
  at android.app.Activity.startActivityForResult (Activity.java:5470)
  at androidx.activity.ComponentActivity.startActivityForResult (ComponentActivity.java:728)
  at androidx.core.app.ActivityCompat$Api16Impl.startActivityForResult (ActivityCompat.java:809)
  at androidx.core.app.ActivityCompat.startActivityForResult (ActivityCompat.java:246)
  at androidx.activity.ComponentActivity$2.onLaunch (ComponentActivity.java:243)
  at androidx.activity.result.ActivityResultRegistry$2.launch (ActivityResultRegistry.java:175)
  at androidx.activity.result.ActivityResultRegistry$2.launch$bridge (ActivityResultRegistry.java:3)
  at androidx.activity.result.ActivityResultLauncher.launch (ActivityResultLauncher.java:47)
  at com.keylesspalace.tusky.components.compose.ComposeActivity.initiateCameraApp (ComposeActivity.java:1025)
  at com.keylesspalace.tusky.components.compose.ComposeActivity.setupButtons$lambda-28 (ComposeActivity.java:512)
  at com.keylesspalace.tusky.components.compose.ComposeActivity$$InternalSyntheticLambda$0$1bbd067fe2148c39cb1290742d7cbba1f802e3c7a2e9650d02646ca1f86abbc4$0.onClick$bridge (ComposeActivity.java:61)
  at android.view.View.performClick (View.java:7506)
  at android.view.View.performClickInternal (View.java:7483)
  at android.view.View.-$$Nest$mperformClickInternal (View.java)
  at android.view.View$PerformClick.run (View.java:29335)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:201)
  at android.os.Looper.loop (Looper.java:288)
  at android.app.ActivityThread.main (ActivityThread.java:7893)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:548)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:936)
```