### PR TITLE
Ensure the "Apply" button is always visible

### DIFF
--- a/app/src/main/res/layout/notifications_filter.xml
+++ b/app/src/main/res/layout/notifications_filter.xml
@@ -6,12 +6,14 @@
     <ListView
         android:id="@+id/listView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="0dp"
+        android:layout_weight="1" />
     <Button
         android:id="@+id/buttonApply"
         style="@style/TuskyButton.TextButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_weight="0"
         android:text="@string/filter_apply"
         android:textSize="?attr/status_text_medium" />
 </LinearLayout>


### PR DESCRIPTION
On smaller devices the notification filter listview may be longer than the screen height, and pushes the "Apply" button out of sight.

Fix this by:

- Set the height of the listview to 0dp and its layout_weight to 1
- Set the layout_weight of the button to 0

This ensures the button always appears (because the listview height is 0dp) and the listview then expands to fill any remaining space (because the layout_weight is 1).

Fixes https://github.com/tuskyapp/Tusky/issues/2985