### PR TITLE
make date converter null safe

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/db/Converters.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/Converters.kt
@@ -126,13 +126,13 @@ class Converters @Inject constructor (
     }
 
     @TypeConverter
-    fun dateToLong(date: Date): Long {
-        return date.time
+    fun dateToLong(date: Date?): Long? {
+        return date?.time
     }
 
     @TypeConverter
-    fun longToDate(date: Long): Date {
-        return Date(date)
+    fun longToDate(date: Long?): Date? {
+        return date?.let { Date(it) }
     }
 
     @TypeConverter


### PR DESCRIPTION
This is needed to convert the "editedAt" attribute of ConversationStatusEntity, without it ConversationsFragment shows the sad elephant frend.
(regression from https://github.com/tuskyapp/Tusky/pull/2935)