### PR TITLE
replace Manifest package with Gradle namespace

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,7 @@ android {
     compileSdkVersion 33
     defaultConfig {
         applicationId APP_ID
+        namespace "com.keylesspalace.tusky"
         minSdkVersion 23
         targetSdkVersion 33
         versionCode 97

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.keylesspalace.tusky">
+    xmlns:tools="http://schemas.android.com/tools" >
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />


### PR DESCRIPTION
to get rid of this warning

```
package="com.keylesspalace.tusky" found in source AndroidManifest.xml: C:\Users\Conny Duck\AndroidApps\Tusky\app\src\main\AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
```