### PR TITLE
Left-align image alt text & make it selectable

### DIFF
--- a/app/src/main/res/layout/fragment_view_image.xml
+++ b/app/src/main/res/layout/fragment_view_image.xml
@@ -50,11 +50,11 @@
             <View
                 android:layout_width="24dp"
                 android:layout_height="3dp"
+                android:layout_gravity="center_horizontal"
                 android:layout_marginTop="10dp"
                 android:layout_marginBottom="10dp"
-                android:layout_gravity="center_horizontal"
-                android:importantForAccessibility="no"
-                android:background="@drawable/ic_drag_indicator_horiz_24dp" />
+                android:background="@drawable/ic_drag_indicator_horiz_24dp"
+                android:importantForAccessibility="no" />
 
             <androidx.core.widget.NestedScrollView
                 android:layout_width="match_parent"
@@ -69,8 +69,8 @@
                     android:paddingLeft="8dp"
                     android:paddingRight="8dp"
                     android:paddingBottom="8dp"
-                    android:textAlignment="center"
                     android:textColor="?android:textColorPrimary"
+                    android:textIsSelectable="true"
                     android:textSize="?attr/status_text_medium"
                     tools:text="Some media description which might get quite long so that it won't easily fit in one line" />
             </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
Fixes #2819, #2126

In my quick testing text selection here didn't conflict with dragging up and down. May also be worth adding a copy alt option to the menu options?