### PR TITLE
Remove debug logging of keypresses

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -1101,7 +1101,6 @@ class ComposeActivity :
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
-        Log.d(TAG, event.toString())
         if (event.action == KeyEvent.ACTION_DOWN) {
             if (event.isCtrlPressed) {
                 if (keyCode == KeyEvent.KEYCODE_ENTER) {


### PR DESCRIPTION
While only present in a Log.d call, which should be stripped out of release builds, this feels like an unnecessary privacy risk.