### PR TITLE
Fix auto play when swiping between attachments

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
@@ -23,7 +23,12 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.text.method.ScrollingMovementMethod
-import android.view.*
+import android.view.GestureDetector
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
 import android.widget.MediaController
 import androidx.core.view.GestureDetectorCompat
 import com.keylesspalace.tusky.ViewMediaActivity

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
@@ -23,12 +23,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.text.method.ScrollingMovementMethod
-import android.view.GestureDetector
-import android.view.KeyEvent
-import android.view.LayoutInflater
-import android.view.MotionEvent
-import android.view.View
-import android.view.ViewGroup
+import android.view.*
 import android.widget.MediaController
 import androidx.core.view.GestureDetectorCompat
 import com.keylesspalace.tusky.ViewMediaActivity
@@ -66,19 +61,21 @@ class ViewVideoFragment : ViewMediaFragment() {
         videoActionsListener = context as VideoActionsListener
     }
 
-    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
-        // Start/pause/resume video playback as fragment is shown/hidden
-        super.setUserVisibleHint(isVisibleToUser)
-        if (_binding == null) {
-            return
-        }
+    override fun onResume() {
+        super.onResume()
 
-        if (isVisibleToUser) {
+        if (_binding != null) {
             if (mediaActivity.isToolbarVisible) {
                 handler.postDelayed(hideToolbar, TOOLBAR_HIDE_DELAY_MS)
             }
             binding.videoView.start()
-        } else {
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+
+        if (_binding != null) {
             handler.removeCallbacks(hideToolbar)
             binding.videoView.pause()
             mediaController.hide()
@@ -161,9 +158,6 @@ class ViewVideoFragment : ViewMediaFragment() {
 
             binding.progressBar.hide()
             mp.isLooping = true
-            if (requireArguments().getBoolean(ARG_START_POSTPONED_TRANSITION)) {
-                binding.videoView.start()
-            }
         }
 
         if (requireArguments().getBoolean(ARG_START_POSTPONED_TRANSITION)) {


### PR DESCRIPTION
Fixes an issue where attachment doesn't autoplay when swiping left/right from initial attachment.

 `setUserVisibleHint` is deprecated and it looks like `ViewPager2` does not call `setUserVisibleHint` when swiping between pages.

Testing:
 - Open a toot with multiple videos or gifs: https://peoplemaking.games/@lacruzo/109537282222626550
 - Swipe away from initial video and ensure attachment autoplays

Fixes #3066