### PR TITLE
Revert removal of Federated timeline from defaults

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/TabData.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/TabData.kt
@@ -100,6 +100,7 @@ fun defaultTabs(): List<TabData> {
         createTabDataFromId(HOME),
         createTabDataFromId(NOTIFICATIONS),
         createTabDataFromId(LOCAL),
+        createTabDataFromId(FEDERATED),
         createTabDataFromId(DIRECT)
     )
 }


### PR DESCRIPTION
Due to the removal, people have begun to stop using tusky and or finding another app to use that has a federated timeline. And adding the federated timeline back is extremely difficult and frustrating for uses.

This reverts the removal of the federated timeline, by adding it back to the defaults, resulting in a 5 button navigation bar.