### PR TITLE
Leave the "edit scheduled status" button enabled after clicking

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledStatusAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledStatusAdapter.kt
@@ -16,7 +16,6 @@
 package com.keylesspalace.tusky.components.scheduled
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil

--- a/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledStatusAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledStatusAdapter.kt
@@ -54,7 +54,6 @@ class ScheduledStatusAdapter(
             holder.binding.delete.isEnabled = true
             holder.binding.text.text = item.params.text
             holder.binding.edit.setOnClickListener { v: View ->
-                v.isEnabled = false
                 listener.edit(item)
             }
             holder.binding.delete.setOnClickListener {

--- a/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledStatusAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledStatusAdapter.kt
@@ -53,7 +53,7 @@ class ScheduledStatusAdapter(
             holder.binding.edit.isEnabled = true
             holder.binding.delete.isEnabled = true
             holder.binding.text.text = item.params.text
-            holder.binding.edit.setOnClickListener { v: View ->
+            holder.binding.edit.setOnClickListener {
                 listener.edit(item)
             }
             holder.binding.delete.setOnClickListener {


### PR DESCRIPTION
If the user submits an edit to the scheduled status then this one will be deleted, the paging source will notice, the adapter will be notified in the normal way, and this binding will be reused.

Or the user backs out of the edit, and this adapter entry is still valid and should remain clickable.

Fixes https://github.com/tuskyapp/Tusky/issues/2705