### PR TITLE
Provide default text sizes in TuskyBaseTheme

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
@@ -82,7 +82,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
         setTaskDescription(new ActivityManager.TaskDescription(appName, appIcon, recentsBackgroundColor));
 
         int style = textStyle(preferences.getString("statusTextSize", "medium"));
-        getTheme().applyStyle(style, false);
+        getTheme().applyStyle(style, true);
 
         if(requiresLogin()) {
             redirectIfNotLoggedIn();

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -41,6 +41,13 @@
     <style name="TuskyDialogActivityTheme" parent="@style/TuskyTheme" />
 
     <style name="TuskyBaseTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <!-- Provide default text sizes. These are overwritten in BaseActivity, but
+             if they are missing then the Android Studio layout preview crashes
+             with java.lang.reflect.InvocationTargetException -->
+        <item name="status_text_small">14sp</item>
+        <item name="status_text_medium">16sp</item>
+        <item name="status_text_large">18sp</item>
+
         <item name="colorPrimary">@color/tusky_blue</item>
         <item name="colorOnPrimary">@color/white</item>
 


### PR DESCRIPTION
These aren't necessary for the app, and are overwritten with the actual style in `BaseActivity.onCreate()`.

But if they're missing the Android Studio layout preview renderer crashes.