### PR TITLE
Share and copy menu items for account page

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
@@ -16,8 +16,6 @@
 package com.keylesspalace.tusky.components.account
 
 import android.animation.ArgbEvaluator
-import android.content.ClipData
-import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
@@ -868,7 +866,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
                 }
                 return true
             }
-            R.id.action_share_account_handle -> {
+            R.id.action_share_account_username -> {
                 // If the account isn't loaded yet, eat the input.
                 if (loadedAccount != null) {
                     val domain = getDomain(loadedAccount?.url)
@@ -878,27 +876,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
                     sendIntent.action = Intent.ACTION_SEND
                     sendIntent.putExtra(Intent.EXTRA_TEXT, username)
                     sendIntent.type = "text/plain"
-                    startActivity(Intent.createChooser(sendIntent, resources.getText(R.string.send_account_handle_to)))
-                }
-                return true
-            }
-            R.id.action_copy_account_link -> {
-                // If the account isn't loaded yet, eat the input.
-                if (loadedAccount != null) {
-                    val url = loadedAccount!!.url
-                    val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                    clipboard.setPrimaryClip(ClipData.newPlainText(null, url))
-                }
-                return true
-            }
-            R.id.action_copy_account_handle -> {
-                // If the account isn't loaded yet, eat the input.
-                if (loadedAccount != null) {
-                    val domain = getDomain(loadedAccount?.url)
-                    val localUsername = loadedAccount!!.username
-                    val username = "@$localUsername@$domain"
-                    val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                    clipboard.setPrimaryClip(ClipData.newPlainText(null, username))
+                    startActivity(Intent.createChooser(sendIntent, resources.getText(R.string.send_account_username_to)))
                 }
                 return true
             }

--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
@@ -28,7 +28,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.annotation.ColorInt
 import androidx.annotation.Px
@@ -417,7 +416,8 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
                     val fullUsername = loadedAccount!!.fullUsername
                     val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                     clipboard.setPrimaryClip(ClipData.newPlainText(null, fullUsername))
-                    Toast.makeText(this, getString(R.string.account_username_copied), Toast.LENGTH_LONG).show()
+                    Snackbar.make(binding.root, getString(R.string.account_username_copied), Snackbar.LENGTH_SHORT)
+                        .show()
                 }
                 true
             }

--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
@@ -935,6 +935,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
             return "@" + account.username
         } else {
             val localUsername = account.localUsername
+            // Note: !! here will crash if this pane is ever shown to a logged-out user. With AccountActivity this is believed to be impossible.
             val domain = accountManager.activeAccount!!.domain
             return "@$localUsername@$domain"
         }

--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
@@ -412,8 +412,8 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
         // Long press on username to copy it to clipboard
         for (view in listOf(binding.accountUsernameTextView, binding.accountDisplayNameTextView)) {
             view.setOnLongClickListener {
-                if (loadedAccount != null) {
-                    val fullUsername = getFullUsername(loadedAccount!!)
+                loadedAccount?.let { loadedAccount ->
+                    val fullUsername = getFullUsername(loadedAccount)
                     val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                     clipboard.setPrimaryClip(ClipData.newPlainText(null, fullUsername))
                     Snackbar.make(binding.root, getString(R.string.account_username_copied), Snackbar.LENGTH_SHORT)
@@ -728,9 +728,9 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
                 getString(R.string.action_mute)
             }
 
-            if (loadedAccount != null) {
+            loadedAccount?.let { loadedAccount ->
                 val muteDomain = menu.findItem(R.id.action_mute_domain)
-                domain = getDomain(loadedAccount?.url)
+                domain = getDomain(loadedAccount.url)
                 if (domain.isEmpty()) {
                     // If we can't get the domain, there's no way we can mute it anyway...
                     menu.removeItem(R.id.action_mute_domain)
@@ -853,18 +853,18 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
         when (item.itemId) {
             R.id.action_open_in_web -> {
                 // If the account isn't loaded yet, eat the input.
-                if (loadedAccount?.url != null) {
-                    openLink(loadedAccount!!.url)
+                loadedAccount?.let { loadedAccount ->
+                    openLink(loadedAccount.url)
                 }
                 return true
             }
             R.id.action_open_as -> {
-                if (loadedAccount != null) {
+                loadedAccount?.let { loadedAccount ->
                     showAccountChooserDialog(
                         item.title, false,
                         object : AccountSelectionListener {
                             override fun onAccountSelected(account: AccountEntity) {
-                                openAsAccount(loadedAccount!!.url, account)
+                                openAsAccount(loadedAccount.url, account)
                             }
                         }
                     )
@@ -872,8 +872,8 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
             }
             R.id.action_share_account_link -> {
                 // If the account isn't loaded yet, eat the input.
-                if (loadedAccount != null) {
-                    val url = loadedAccount!!.url
+                loadedAccount?.let { loadedAccount ->
+                    val url = loadedAccount.url
                     val sendIntent = Intent()
                     sendIntent.action = Intent.ACTION_SEND
                     sendIntent.putExtra(Intent.EXTRA_TEXT, url)
@@ -884,8 +884,8 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
             }
             R.id.action_share_account_username -> {
                 // If the account isn't loaded yet, eat the input.
-                if (loadedAccount != null) {
-                    val fullUsername = getFullUsername(loadedAccount!!)
+                loadedAccount?.let { loadedAccount ->
+                    val fullUsername = getFullUsername(loadedAccount)
                     val sendIntent = Intent()
                     sendIntent.action = Intent.ACTION_SEND
                     sendIntent.putExtra(Intent.EXTRA_TEXT, fullUsername)
@@ -915,8 +915,8 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
                 return true
             }
             R.id.action_report -> {
-                if (loadedAccount != null) {
-                    startActivity(ReportActivity.getIntent(this, viewModel.accountId, loadedAccount!!.username))
+                loadedAccount?.let { loadedAccount ->
+                    startActivity(ReportActivity.getIntent(this, viewModel.accountId, loadedAccount.username))
                 }
                 return true
             }
@@ -931,7 +931,6 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
     }
 
     private fun getFullUsername(account: Account): String {
-        val test = accountManager.activeAccount
         if (account.isRemote()) {
             return "@" + account.username
         } else {

--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
@@ -858,7 +858,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
             }
             R.id.action_share_account_link -> {
                 // If the account isn't loaded yet, eat the input.
-                if (loadedAccount?.url != null) {
+                if (loadedAccount != null) {
                     val url = loadedAccount!!.url
                     val sendIntent = Intent()
                     sendIntent.action = Intent.ACTION_SEND
@@ -870,8 +870,10 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
             }
             R.id.action_share_account_handle -> {
                 // If the account isn't loaded yet, eat the input.
-                if (loadedAccount?.username != null) {
-                    val username = "@" + loadedAccount!!.username
+                if (loadedAccount != null) {
+                    val domain = getDomain(loadedAccount?.url)
+                    val localUsername = loadedAccount!!.username
+                    val username = "@$localUsername@$domain"
                     val sendIntent = Intent()
                     sendIntent.action = Intent.ACTION_SEND
                     sendIntent.putExtra(Intent.EXTRA_TEXT, username)
@@ -882,7 +884,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
             }
             R.id.action_copy_account_link -> {
                 // If the account isn't loaded yet, eat the input.
-                if (loadedAccount?.url != null) {
+                if (loadedAccount != null) {
                     val url = loadedAccount!!.url
                     val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                     clipboard.setPrimaryClip(ClipData.newPlainText(null, url))
@@ -891,8 +893,10 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
             }
             R.id.action_copy_account_handle -> {
                 // If the account isn't loaded yet, eat the input.
-                if (loadedAccount?.username != null) {
-                    val username = "@" + loadedAccount!!.username
+                if (loadedAccount != null) {
+                    val domain = getDomain(loadedAccount?.url)
+                    val localUsername = loadedAccount!!.username
+                    val username = "@$localUsername@$domain"
                     val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                     clipboard.setPrimaryClip(ClipData.newPlainText(null, username))
                 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
@@ -413,7 +413,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
         for (view in listOf(binding.accountUsernameTextView, binding.accountDisplayNameTextView)) {
             view.setOnLongClickListener {
                 if (loadedAccount != null) {
-                    val fullUsername = loadedAccount!!.fullUsername
+                    val fullUsername = getFullUsername(loadedAccount!!)
                     val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                     clipboard.setPrimaryClip(ClipData.newPlainText(null, fullUsername))
                     Snackbar.make(binding.root, getString(R.string.account_username_copied), Snackbar.LENGTH_SHORT)
@@ -885,7 +885,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
             R.id.action_share_account_username -> {
                 // If the account isn't loaded yet, eat the input.
                 if (loadedAccount != null) {
-                    val fullUsername = loadedAccount!!.fullUsername
+                    val fullUsername = getFullUsername(loadedAccount!!)
                     val sendIntent = Intent()
                     sendIntent.action = Intent.ACTION_SEND
                     sendIntent.putExtra(Intent.EXTRA_TEXT, fullUsername)
@@ -928,6 +928,17 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
         return if (!viewModel.isSelf && !blocking) {
             binding.accountFloatingActionButton
         } else null
+    }
+
+    private fun getFullUsername(account: Account): String {
+        val test = accountManager.activeAccount
+        if (account.isRemote()) {
+            return "@" + account.username
+        } else {
+            val localUsername = account.localUsername
+            val domain = accountManager.activeAccount!!.domain
+            return "@$localUsername@$domain"
+        }
     }
 
     override fun androidInjector() = dispatchingAndroidInjector

--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
@@ -16,6 +16,8 @@
 package com.keylesspalace.tusky.components.account
 
 import android.animation.ArgbEvaluator
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
@@ -853,6 +855,48 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidI
                         }
                     )
                 }
+            }
+            R.id.action_share_account_link -> {
+                // If the account isn't loaded yet, eat the input.
+                if (loadedAccount?.url != null) {
+                    val url = loadedAccount!!.url
+                    val sendIntent = Intent()
+                    sendIntent.action = Intent.ACTION_SEND
+                    sendIntent.putExtra(Intent.EXTRA_TEXT, url)
+                    sendIntent.type = "text/plain"
+                    startActivity(Intent.createChooser(sendIntent, resources.getText(R.string.send_account_link_to)))
+                }
+                return true
+            }
+            R.id.action_share_account_handle -> {
+                // If the account isn't loaded yet, eat the input.
+                if (loadedAccount?.username != null) {
+                    val username = "@" + loadedAccount!!.username
+                    val sendIntent = Intent()
+                    sendIntent.action = Intent.ACTION_SEND
+                    sendIntent.putExtra(Intent.EXTRA_TEXT, username)
+                    sendIntent.type = "text/plain"
+                    startActivity(Intent.createChooser(sendIntent, resources.getText(R.string.send_account_handle_to)))
+                }
+                return true
+            }
+            R.id.action_copy_account_link -> {
+                // If the account isn't loaded yet, eat the input.
+                if (loadedAccount?.url != null) {
+                    val url = loadedAccount!!.url
+                    val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    clipboard.setPrimaryClip(ClipData.newPlainText(null, url))
+                }
+                return true
+            }
+            R.id.action_copy_account_handle -> {
+                // If the account isn't loaded yet, eat the input.
+                if (loadedAccount?.username != null) {
+                    val username = "@" + loadedAccount!!.username
+                    val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    clipboard.setPrimaryClip(ClipData.newPlainText(null, username))
+                }
+                return true
             }
             R.id.action_block -> {
                 toggleBlock()

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Account.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Account.kt
@@ -49,7 +49,7 @@ data class Account(
     val fullUsername: String
         get() {
             val domain = getDomain(this.url)
-            val localUsername = this.username
+            val localUsername = this.localUsername
             return "@$localUsername@$domain"
         }
 

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Account.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Account.kt
@@ -16,6 +16,7 @@
 package com.keylesspalace.tusky.entity
 
 import com.google.gson.annotations.SerializedName
+import com.keylesspalace.tusky.util.getDomain
 import java.util.Date
 
 data class Account(
@@ -44,6 +45,13 @@ data class Account(
         get() = if (displayName.isNullOrEmpty()) {
             localUsername
         } else displayName
+
+    val fullUsername: String
+        get() {
+            val domain = getDomain(this.url)
+            val localUsername = this.username
+            return "@$localUsername@$domain"
+        }
 
     fun isRemote(): Boolean = this.username != this.localUsername
 }

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Account.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Account.kt
@@ -46,13 +46,6 @@ data class Account(
             localUsername
         } else displayName
 
-    val fullUsername: String
-        get() {
-            val domain = getDomain(this.url)
-            val localUsername = this.localUsername
-            return "@$localUsername@$domain"
-        }
-
     fun isRemote(): Boolean = this.username != this.localUsername
 }
 

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Account.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Account.kt
@@ -16,7 +16,6 @@
 package com.keylesspalace.tusky.entity
 
 import com.google.gson.annotations.SerializedName
-import com.keylesspalace.tusky.util.getDomain
 import java.util.Date
 
 data class Account(

--- a/app/src/main/res/menu/account_toolbar.xml
+++ b/app/src/main/res/menu/account_toolbar.xml
@@ -18,18 +18,10 @@
                 android:id="@+id/action_share_account_link"
                 android:title="@string/action_share_account_link" />
             <item
-                android:id="@+id/action_share_account_handle"
-                android:title="@string/action_share_account_handle" />
+                android:id="@+id/action_share_account_username"
+                android:title="@string/action_share_account_username" />
         </menu>
     </item>
-
-    <item android:id="@+id/action_copy_account_link"
-        android:title="@string/action_copy_account_link"
-        app:showAsAction="never" />
-
-    <item android:id="@+id/action_copy_account_handle"
-        android:title="@string/action_copy_account_handle"
-        app:showAsAction="never" />
 
     <item android:id="@+id/action_mute"
         android:title="@string/action_mute"

--- a/app/src/main/res/menu/account_toolbar.xml
+++ b/app/src/main/res/menu/account_toolbar.xml
@@ -10,6 +10,27 @@
         android:title="@string/action_open_as"
         app:showAsAction="never" />
 
+    <item
+        android:id="@+id/action_account_share"
+        android:title="@string/action_share">
+        <menu>
+            <item
+                android:id="@+id/action_share_account_link"
+                android:title="@string/action_share_account_link" />
+            <item
+                android:id="@+id/action_share_account_handle"
+                android:title="@string/action_share_account_handle" />
+        </menu>
+    </item>
+
+    <item android:id="@+id/action_copy_account_link"
+        android:title="@string/action_copy_account_link"
+        app:showAsAction="never" />
+
+    <item android:id="@+id/action_copy_account_handle"
+        android:title="@string/action_copy_account_handle"
+        app:showAsAction="never" />
+
     <item android:id="@+id/action_mute"
         android:title="@string/action_mute"
         app:showAsAction="never" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,10 @@
     <string name="action_unfollow">Unfollow</string>
     <string name="action_block">Block</string>
     <string name="action_unblock">Unblock</string>
+    <string name="action_share_account_link">Share link to account</string>
+    <string name="action_share_account_handle">Share handle of account</string>
+    <string name="action_copy_account_link">Copy link to account</string>
+    <string name="action_copy_account_handle">Copy handle of account</string>
     <string name="action_hide_reblogs">Hide boosts</string>
     <string name="action_show_reblogs">Show boosts</string>
     <string name="action_report">Report</string>
@@ -180,6 +184,8 @@
 
     <string name="send_post_link_to">Share post URL to…</string>
     <string name="send_post_content_to">Share post to…</string>
+    <string name="send_account_link_to">Share account URL to…</string>
+    <string name="send_account_handle_to">Share account handle to…</string>
     <string name="send_media_to">Share media to…</string>
 
     <string name="confirmation_reported">Sent!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,9 +103,7 @@
     <string name="action_block">Block</string>
     <string name="action_unblock">Unblock</string>
     <string name="action_share_account_link">Share link to account</string>
-    <string name="action_share_account_handle">Share handle of account</string>
-    <string name="action_copy_account_link">Copy link to account</string>
-    <string name="action_copy_account_handle">Copy handle of account</string>
+    <string name="action_share_account_username">Share username of account</string>
     <string name="action_hide_reblogs">Hide boosts</string>
     <string name="action_show_reblogs">Show boosts</string>
     <string name="action_report">Report</string>
@@ -185,7 +183,7 @@
     <string name="send_post_link_to">Share post URL to…</string>
     <string name="send_post_content_to">Share post to…</string>
     <string name="send_account_link_to">Share account URL to…</string>
-    <string name="send_account_handle_to">Share account handle to…</string>
+    <string name="send_account_username_to">Share account username to…</string>
     <string name="send_media_to">Share media to…</string>
 
     <string name="confirmation_reported">Sent!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,6 +185,7 @@
     <string name="send_account_link_to">Share account URL to…</string>
     <string name="send_account_username_to">Share account username to…</string>
     <string name="send_media_to">Share media to…</string>
+    <string name="account_username_copied">Username copied</string>
 
     <string name="confirmation_reported">Sent!</string>
     <string name="confirmation_unblocked">User unblocked</string>


### PR DESCRIPTION
Attempting to address #3093 (and maybe some of the semi-overlap bugs linked at the bottom of 3093). Here's what I have currently:

[<img width=250 src="https://files.mastodon.social/media_attachments/files/109/594/372/136/707/170/original/7db50a0dde776e97.png" />](https://files.mastodon.social/media_attachments/files/109/594/372/136/707/170/original/7db50a0dde776e97.png) [<img width=250 src="https://files.mastodon.social/media_attachments/files/109/594/373/215/574/008/original/83f72331a773c14c.png" />](https://files.mastodon.social/media_attachments/files/109/594/373/215/574/008/original/83f72331a773c14c.png)

And what you see works but there are Problems and I need Advice.

1. What should the wording be (IE, should "handle" be "handle"? or "address"? Or "username"? or something else? I think the term we want is "Fully-Qualified Username" but that's no good for). Should it be "Share link to account" or just "Share link"? or "share account link" or… I'm just not sure about any of these strings.

2. Although I like having both "Share" and "Copy" items, this menu is very long now and I think it is just too much. I **think** I'm going to change it so:

    * Only one added item in menu ("Share")
    * Long-press on the username/displayname copies the Fully Qualified Username to the clipboard

    Any thoughts?

3. "Share handle"/"Copy handle" works as expected when copying handles from other instances. However if copying handle from your home instance it will be missing the domain name. In AccountActivity I have access to a struct Account with three fields:

            val localUsername: String,
            val username: String,
            val displayName: String?, 

    displayName is as obvious, localUsername I think (???) always contains just the non-domain part of the username. "username" is the one I'm using, and I think it's the username displayed in the actual GUI. This username does not show the domain name for your home instance, which is correct in that case, but not correct for copying the username to share. I need to do one of the following:

        * Get hold of a AccountEntity from inside AccountActivity
        * Figure out where Account is being constructed and add a fullName field copying AccountEntity.fullName (or a domain field copying AccountEntity.domain, which I can combine with localUsername)

    But I can't figure it out. Help?