### PR TITLE
don't crash on unparseable date

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/json/Rfc3339DateJsonAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/json/Rfc3339DateJsonAdapter.kt
@@ -16,6 +16,8 @@
  */
 package com.keylesspalace.tusky.json
 
+import android.util.Log
+import com.google.gson.JsonParseException
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonToken
@@ -42,7 +44,12 @@ class Rfc3339DateJsonAdapter : TypeAdapter<Date?>() {
                 null
             }
             else -> {
-                reader.nextString().parseIsoDate()
+                try {
+                    reader.nextString().parseIsoDate()
+                } catch (jpe: JsonParseException) {
+                    Log.w("Rfc3339DateJsonAdapter", jpe)
+                    null
+                }
             }
         }
     }


### PR DESCRIPTION
fixes https://github.com/tuskyapp/Tusky/issues/2272

according to the Google Play stats we had 36 crashes in the last 30 days because of this