### PR TITLE
Enable robolectric logging

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,6 +72,9 @@ android {
             returnDefaultValues = true
             includeAndroidResources = true
         }
+        unitTests.all {
+            systemProperty 'robolectric.logging.enabled', 'true'
+        }        
     }
     sourceSets {
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())


### PR DESCRIPTION
Robolectric normally swallows output from `Log.*` calls in tests and the code under test. This can make debugging failing tests more difficult than it needs to be.

Set `robolectric.logging.enabled` to `true` to enable the logs.