### PR TITLE
Support /api/v1/instance and /api/v2/instance

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/EditProfileActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/EditProfileActivity.kt
@@ -38,7 +38,7 @@ import com.canhub.cropper.CropImageContract
 import com.canhub.cropper.options
 import com.google.android.material.snackbar.Snackbar
 import com.keylesspalace.tusky.adapter.AccountFieldEditAdapter
-import com.keylesspalace.tusky.components.instanceinfo.InstanceInfoRepository
+import com.keylesspalace.tusky.components.instanceinfo.InstanceInfo.Companion.DEFAULT_MAX_ACCOUNT_FIELDS
 import com.keylesspalace.tusky.databinding.ActivityEditProfileBinding
 import com.keylesspalace.tusky.di.Injectable
 import com.keylesspalace.tusky.di.ViewModelFactory
@@ -72,7 +72,7 @@ class EditProfileActivity : BaseActivity(), Injectable {
 
     private val accountFieldEditAdapter = AccountFieldEditAdapter()
 
-    private var maxAccountFields = InstanceInfoRepository.DEFAULT_MAX_ACCOUNT_FIELDS
+    private var maxAccountFields = DEFAULT_MAX_ACCOUNT_FIELDS
 
     private enum class PickType {
         AVATAR,

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -76,7 +76,9 @@ import com.keylesspalace.tusky.components.compose.dialog.makeFocusDialog
 import com.keylesspalace.tusky.components.compose.dialog.showAddPollDialog
 import com.keylesspalace.tusky.components.compose.view.ComposeOptionsListener
 import com.keylesspalace.tusky.components.compose.view.ComposeScheduleView
-import com.keylesspalace.tusky.components.instanceinfo.InstanceInfoRepository
+import com.keylesspalace.tusky.components.instanceinfo.InstanceInfo.Companion.DEFAULT_CHARACTERS_RESERVED_PER_URL
+import com.keylesspalace.tusky.components.instanceinfo.InstanceInfo.Companion.DEFAULT_CHARACTER_LIMIT
+import com.keylesspalace.tusky.components.instanceinfo.InstanceInfo.Companion.DEFAULT_MAX_MEDIA_ATTACHMENTS
 import com.keylesspalace.tusky.databinding.ActivityComposeBinding
 import com.keylesspalace.tusky.db.AccountEntity
 import com.keylesspalace.tusky.db.DraftAttachment
@@ -142,14 +144,14 @@ class ComposeActivity :
     private val preferences by lazy { PreferenceManager.getDefaultSharedPreferences(this) }
 
     @VisibleForTesting
-    var maximumTootCharacters = InstanceInfoRepository.DEFAULT_CHARACTER_LIMIT
-    var charactersReservedPerUrl = InstanceInfoRepository.DEFAULT_CHARACTERS_RESERVED_PER_URL
+    var maximumTootCharacters = DEFAULT_CHARACTER_LIMIT
+    var charactersReservedPerUrl = DEFAULT_CHARACTERS_RESERVED_PER_URL
 
     private val viewModel: ComposeViewModel by viewModels { viewModelFactory }
 
     private val binding by viewBinding(ActivityComposeBinding::inflate)
 
-    private var maxUploadMediaNumber = InstanceInfoRepository.DEFAULT_MAX_MEDIA_ATTACHMENTS
+    private var maxUploadMediaNumber = DEFAULT_MAX_MEDIA_ATTACHMENTS
 
     private val takePicture = registerForActivityResult(ActivityResultContracts.TakePicture()) { success ->
         if (success) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/instanceinfo/InstanceInfo.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/instanceinfo/InstanceInfo.kt
@@ -15,6 +15,8 @@
 
 package com.keylesspalace.tusky.components.instanceinfo
 
+import com.keylesspalace.tusky.db.InstanceInfoEntity
+
 data class InstanceInfo(
     val maxChars: Int,
     val pollMaxOptions: Int,
@@ -29,4 +31,59 @@ data class InstanceInfo(
     val maxFields: Int,
     val maxFieldNameLength: Int?,
     val maxFieldValueLength: Int?
-)
+) {
+
+    companion object {
+        const val DEFAULT_CHARACTER_LIMIT = 500
+        private const val DEFAULT_MAX_OPTION_COUNT = 4
+        private const val DEFAULT_MAX_OPTION_LENGTH = 50
+        private const val DEFAULT_MIN_POLL_DURATION = 300
+        private const val DEFAULT_MAX_POLL_DURATION = 604800
+
+        private const val DEFAULT_VIDEO_SIZE_LIMIT = 41943040 // 40MiB
+        private const val DEFAULT_IMAGE_SIZE_LIMIT = 10485760 // 10MiB
+        private const val DEFAULT_IMAGE_MATRIX_LIMIT = 16777216 // 4096^2 Pixels
+
+        // Mastodon only counts URLs as this long in terms of status character limits
+        const val DEFAULT_CHARACTERS_RESERVED_PER_URL = 23
+
+        const val DEFAULT_MAX_MEDIA_ATTACHMENTS = 4
+        const val DEFAULT_MAX_ACCOUNT_FIELDS = 4
+
+        fun default(): InstanceInfo {
+            return InstanceInfo(
+                maxChars = DEFAULT_CHARACTER_LIMIT,
+                pollMaxOptions = DEFAULT_MAX_OPTION_COUNT,
+                pollMaxLength = DEFAULT_MAX_OPTION_LENGTH,
+                pollMinDuration = DEFAULT_MIN_POLL_DURATION,
+                pollMaxDuration = DEFAULT_MAX_POLL_DURATION,
+                charactersReservedPerUrl = DEFAULT_CHARACTERS_RESERVED_PER_URL,
+                videoSizeLimit = DEFAULT_VIDEO_SIZE_LIMIT,
+                imageSizeLimit = DEFAULT_IMAGE_SIZE_LIMIT,
+                imageMatrixLimit = DEFAULT_IMAGE_MATRIX_LIMIT,
+                maxMediaAttachments = DEFAULT_MAX_MEDIA_ATTACHMENTS,
+                maxFields = DEFAULT_MAX_ACCOUNT_FIELDS,
+                maxFieldNameLength = null,
+                maxFieldValueLength = null
+            )
+        }
+
+        fun from(instanceInfo: InstanceInfoEntity): InstanceInfo {
+            return InstanceInfo(
+                maxChars = instanceInfo.maximumTootCharacters ?: DEFAULT_CHARACTER_LIMIT,
+                pollMaxOptions = instanceInfo.maxPollOptions ?: DEFAULT_MAX_OPTION_COUNT,
+                pollMaxLength = instanceInfo.maxPollOptionLength ?: DEFAULT_MAX_OPTION_LENGTH,
+                pollMinDuration = instanceInfo.minPollDuration ?: DEFAULT_MIN_POLL_DURATION,
+                pollMaxDuration = instanceInfo.maxPollDuration ?: DEFAULT_MAX_POLL_DURATION,
+                charactersReservedPerUrl = instanceInfo.charactersReservedPerUrl ?: DEFAULT_CHARACTERS_RESERVED_PER_URL,
+                videoSizeLimit = instanceInfo.videoSizeLimit ?: DEFAULT_VIDEO_SIZE_LIMIT,
+                imageSizeLimit = instanceInfo.imageSizeLimit ?: DEFAULT_IMAGE_SIZE_LIMIT,
+                imageMatrixLimit = instanceInfo.imageMatrixLimit ?: DEFAULT_IMAGE_MATRIX_LIMIT,
+                maxMediaAttachments = instanceInfo.maxMediaAttachments ?: DEFAULT_MAX_MEDIA_ATTACHMENTS,
+                maxFields = instanceInfo.maxFields ?: DEFAULT_MAX_ACCOUNT_FIELDS,
+                maxFieldNameLength = instanceInfo.maxFieldNameLength,
+                maxFieldValueLength = instanceInfo.maxFieldValueLength
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/keylesspalace/tusky/db/InstanceEntity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/InstanceEntity.kt
@@ -19,6 +19,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
 import com.keylesspalace.tusky.entity.Emoji
+import com.keylesspalace.tusky.entity.Instance
 
 @Entity
 @TypeConverters(Converters::class)
@@ -63,4 +64,27 @@ data class InstanceInfoEntity(
     val maxFields: Int?,
     val maxFieldNameLength: Int?,
     val maxFieldValueLength: Int?
-)
+) {
+
+    companion object {
+        fun from(instance: Instance, instanceName: String): InstanceInfoEntity {
+            return InstanceInfoEntity(
+                instance = instanceName,
+                maximumTootCharacters = instance.configuration?.statuses?.maxCharacters ?: instance.maxTootChars,
+                maxPollOptions = instance.configuration?.polls?.maxOptions ?: instance.pollConfiguration?.maxOptions,
+                maxPollOptionLength = instance.configuration?.polls?.maxCharactersPerOption ?: instance.pollConfiguration?.maxOptionChars,
+                minPollDuration = instance.configuration?.polls?.minExpiration ?: instance.pollConfiguration?.minExpiration,
+                maxPollDuration = instance.configuration?.polls?.maxExpiration ?: instance.pollConfiguration?.maxExpiration,
+                charactersReservedPerUrl = instance.configuration?.statuses?.charactersReservedPerUrl,
+                version = instance.version,
+                videoSizeLimit = instance.configuration?.mediaAttachments?.videoSizeLimit ?: instance.uploadLimit,
+                imageSizeLimit = instance.configuration?.mediaAttachments?.imageSizeLimit ?: instance.uploadLimit,
+                imageMatrixLimit = instance.configuration?.mediaAttachments?.imageMatrixLimit,
+                maxMediaAttachments = instance.configuration?.statuses?.maxMediaAttachments ?: instance.maxMediaAttachments,
+                maxFields = instance.pleroma?.metadata?.fieldLimits?.maxFields,
+                maxFieldNameLength = instance.pleroma?.metadata?.fieldLimits?.nameLength,
+                maxFieldValueLength = instance.pleroma?.metadata?.fieldLimits?.valueLength
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/keylesspalace/tusky/di/NetworkModule.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/di/NetworkModule.kt
@@ -27,6 +27,8 @@ import com.keylesspalace.tusky.db.AccountManager
 import com.keylesspalace.tusky.json.Rfc3339DateJsonAdapter
 import com.keylesspalace.tusky.network.InstanceSwitchAuthInterceptor
 import com.keylesspalace.tusky.network.MastodonApi
+import com.keylesspalace.tusky.network.MastodonApiV1
+import com.keylesspalace.tusky.network.MastodonApiV2
 import com.keylesspalace.tusky.network.MediaUploadApi
 import com.keylesspalace.tusky.settings.PrefKeys.HTTP_PROXY_ENABLED
 import com.keylesspalace.tusky.settings.PrefKeys.HTTP_PROXY_PORT
@@ -127,6 +129,14 @@ class NetworkModule {
     @Provides
     @Singleton
     fun providesApi(retrofit: Retrofit): MastodonApi = retrofit.create()
+
+    @Provides
+    @Singleton
+    fun providesApiV1(retrofit: Retrofit): MastodonApiV1 = retrofit.create()
+
+    @Provides
+    @Singleton
+    fun providesApiV2(retrofit: Retrofit): MastodonApiV2 = retrofit.create()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -26,7 +26,6 @@ import com.keylesspalace.tusky.entity.DeletedStatus
 import com.keylesspalace.tusky.entity.Emoji
 import com.keylesspalace.tusky.entity.Filter
 import com.keylesspalace.tusky.entity.HashTag
-import com.keylesspalace.tusky.entity.Instance
 import com.keylesspalace.tusky.entity.Marker
 import com.keylesspalace.tusky.entity.MastoList
 import com.keylesspalace.tusky.entity.MediaUploadResult
@@ -77,11 +76,9 @@ interface MastodonApi {
         const val PLACEHOLDER_DOMAIN = "dummy.placeholder"
     }
 
+
     @GET("/api/v1/custom_emojis")
     suspend fun getCustomEmojis(): NetworkResult<List<Emoji>>
-
-    @GET("api/v1/instance")
-    suspend fun getInstance(@Header(DOMAIN_HEADER) domain: String? = null): NetworkResult<Instance>
 
     @GET("api/v1/filters")
     suspend fun getFilters(): NetworkResult<List<Filter>>

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -76,7 +76,6 @@ interface MastodonApi {
         const val PLACEHOLDER_DOMAIN = "dummy.placeholder"
     }
 
-
     @GET("/api/v1/custom_emojis")
     suspend fun getCustomEmojis(): NetworkResult<List<Emoji>>
 

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApiV1.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApiV1.kt
@@ -1,0 +1,14 @@
+package com.keylesspalace.tusky.network
+
+import at.connyduck.calladapter.networkresult.NetworkResult
+import com.keylesspalace.tusky.entity.Instance
+import retrofit2.http.GET
+import retrofit2.http.Header
+
+@JvmSuppressWildcards
+interface MastodonApiV1 {
+    @GET("/api/v1/instance")
+    suspend fun instance(
+        @Header(MastodonApi.DOMAIN_HEADER) domain: String? = null
+    ): NetworkResult<Instance>
+}

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApiV2.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApiV2.kt
@@ -1,0 +1,14 @@
+package com.keylesspalace.tusky.network
+
+import at.connyduck.calladapter.networkresult.NetworkResult
+import com.keylesspalace.tusky.entity.Instance
+import retrofit2.http.GET
+import retrofit2.http.Header
+
+@JvmSuppressWildcards
+interface MastodonApiV2 {
+    @GET("/api/v2/instance")
+    suspend fun instance(
+        @Header(MastodonApi.DOMAIN_HEADER) domain: String? = null
+    ): NetworkResult<Instance>
+}


### PR DESCRIPTION
Start to split the API code in to v1 and v2 interfaces.

Migrate the getInstance() function (rename to instance() for consistency with most other API functions) to v1, and create a v2 equivalent. At the moment they're identical because they return the same type.

Modify InstanceInfoRepository to prefer the v2 call, falling back to v1 if that fails (then the cache, or defaults, per previous behaviour).

Create factory methods for InstanceInfo and InstanceEntity to keep related code together, ditto for defaults.

Update consumers and tests.

Fixes https://github.com/tuskyapp/Tusky/issues/3146