### PR TITLE
Fix media preview bugs

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -476,7 +476,6 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             } else {
                 imageView.setContentDescription(imageView.getContext().getString(R.string.action_view_media));
             }
-            descriptionIndicator.setVisibility(hasDescription ? View.VISIBLE : View.GONE);
 
             loadImage(
                     imageView,
@@ -502,6 +501,9 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
             sensitiveMediaWarning.setVisibility(showingContent ? View.GONE : View.VISIBLE);
             sensitiveMediaShow.setVisibility(showingContent ? View.VISIBLE : View.GONE);
+
+            descriptionIndicator.setVisibility(hasDescription && showingContent ? View.VISIBLE : View.GONE);
+
             sensitiveMediaShow.setOnClickListener(v -> {
                 if (getBindingAdapterPosition() != RecyclerView.NO_POSITION) {
                     listener.onContentHiddenChange(false, getBindingAdapterPosition());

--- a/app/src/main/java/com/keylesspalace/tusky/components/viewthread/edits/ViewEditsAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/viewthread/edits/ViewEditsAdapter.kt
@@ -129,7 +129,7 @@ class ViewEditsAdapter(
             binding.statusEditMediaPreview.show()
             binding.statusEditMediaPreview.aspectRatios = edit.mediaAttachments.aspectRatios()
 
-            binding.statusEditMediaPreview.forEachIndexed { index, _, imageView, descriptionIndicator ->
+            binding.statusEditMediaPreview.forEachIndexed { index, imageView, descriptionIndicator ->
 
                 val attachment = edit.mediaAttachments[index]
                 val hasDescription = !attachment.description.isNullOrBlank()

--- a/app/src/main/java/com/keylesspalace/tusky/view/MediaPreviewLayout.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/view/MediaPreviewLayout.kt
@@ -184,12 +184,11 @@ class MediaPreviewLayout(context: Context, attrs: AttributeSet? = null) :
         }
     }
 
-    inline fun forEachIndexed(action: (Int, View, MediaPreviewImageView, TextView) -> Unit) {
+    inline fun forEachIndexed(action: (Int, MediaPreviewImageView, TextView) -> Unit) {
         for (index in 0 until childCount) {
             val wrapper = getChildAt(index)
             action(
                 index,
-                wrapper,
                 wrapper.findViewById(R.id.preview_image_view) as MediaPreviewImageView,
                 wrapper.findViewById(R.id.preview_media_description_indicator) as TextView
             )


### PR DESCRIPTION
This fixes two issues
- blurhashes sometimes not being scaled to fit the imageview
<img src="https://user-images.githubusercontent.com/10157047/211648952-33a67a7a-f296-4f7d-9b80-5ef23a4a2951.png" width="200"/>

- ALT labels being displayed when the media preview is hidden

I have also been seeing layout shifts after media was loaded, I can no longer reproduce this though.
Not 100% sure why the `doOnLayout` was added in the first place, it defintely causes more problems than it solves.