### PR TITLE
prevent thread view from scrolling when post is interacted with

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadFragment.kt
@@ -202,11 +202,21 @@ class ViewThreadFragment : SFragment(), OnRefreshListener, StatusActionListener,
                         }
                     }
                     is ThreadUiState.Success -> {
+                        if (uiState.statusViewData.none { viewData -> viewData.isDetailed }) {
+                            // no detailed statuses available, e.g. because author is blocked
+                            activity?.finish()
+                            return@collect
+                        }
+
                         threadProgressBar.cancel()
 
                         adapter.submitList(uiState.statusViewData) {
-                            // Ensure the top of the status is visible
-                            (binding.recyclerView.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(uiState.detailedStatusPosition, 0)
+                            if (viewModel.isInitialLoad) {
+                                viewModel.isInitialLoad = false
+                                // Ensure the top of the status is visible
+                                binding.recyclerView.scrollToPosition(uiState.detailedStatusPosition)
+                                //(binding.recyclerView.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(uiState.detailedStatusPosition, 0)
+                            }
                         }
 
                         updateRevealButton(uiState.revealButton)

--- a/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadFragment.kt
@@ -213,9 +213,9 @@ class ViewThreadFragment : SFragment(), OnRefreshListener, StatusActionListener,
                         adapter.submitList(uiState.statusViewData) {
                             if (viewModel.isInitialLoad) {
                                 viewModel.isInitialLoad = false
+
                                 // Ensure the top of the status is visible
-                                binding.recyclerView.scrollToPosition(uiState.detailedStatusPosition)
-                                //(binding.recyclerView.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(uiState.detailedStatusPosition, 0)
+                                (binding.recyclerView.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(uiState.detailedStatusPosition, 0)
                             }
                         }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModel.kt
@@ -70,6 +70,8 @@ class ViewThreadViewModel @Inject constructor(
     val errors: Flow<Throwable>
         get() = _errors
 
+    var isInitialLoad: Boolean = true
+
     private val alwaysShowSensitiveMedia: Boolean
     private val alwaysOpenSpoiler: Boolean
 


### PR DESCRIPTION
Also make sure that thread view is closed when detailed status is blocked or deleted

closes https://github.com/tuskyapp/Tusky/issues/3158