### PR TITLE
Remove old opt-in for RequiresOptIn

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,9 +88,6 @@ android {
             enableSplit = false
         }
     }
-    kotlinOptions {
-        freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
-    }
     dependenciesInfo {
         includeInApk false
         includeInBundle false


### PR DESCRIPTION
As of Kotlin 1.7 the opt-in feature is now stable and does not need an explicit declaration.

https://kotlinlang.org/docs/whatsnew17.html#stable-opt-in-requirements