### PR TITLE
fix crash when user clicks url in partially loaded thread

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModel.kt
@@ -180,8 +180,12 @@ class ViewThreadViewModel @Inject constructor(
     }
 
     fun detailedStatus(): StatusViewData.Concrete? {
-        return (_uiState.value as ThreadUiState.Success?)?.statusViewData?.find { status ->
-            status.isDetailed
+        return when (val uiState = _uiState.value) {
+            is ThreadUiState.Success -> uiState.statusViewData.find { status ->
+                status.isDetailed
+            }
+            is ThreadUiState.LoadingThread -> uiState.statusViewDatum
+            else -> null
         }
     }
 


### PR DESCRIPTION
Click on a link that looks like a Mastodon url in the detailed status while the thread is still loading -> 💥 

```
Exception java.lang.ClassCastException:
  at com.keylesspalace.tusky.components.viewthread.ViewThreadViewModel.detailedStatus (ViewThreadViewModel.java:181)
  at com.keylesspalace.tusky.components.viewthread.ViewThreadFragment.onViewUrl (ViewThreadFragment.kt:310)
  at com.keylesspalace.tusky.util.LinkHelper$setClickableText$2$customSpan$1.onClick (LinkHelper.kt:123)
  at android.text.method.LinkMovementMethod.onTouchEvent (LinkMovementMethod.java:232)
  at android.widget.TextView.onTouchEvent (TextView.java:12347)
  at android.view.View.dispatchTouchEvent (View.java:15533)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3316)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2990)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3316)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2990)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3316)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2990)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3316)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2990)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3316)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2990)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3316)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2990)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3316)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2990)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3316)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2990)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3316)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2990)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3316)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2990)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3316)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2990)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3316)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:2990)
  at com.android.internal.policy.DecorView.superDispatchTouchEvent (DecorView.java:1103)
  at com.android.internal.policy.PhoneWindow.superDispatchTouchEvent (PhoneWindow.java:1968)
  at android.app.Activity.dispatchTouchEvent (Activity.java:4375)
  at androidx.appcompat.view.WindowCallbackWrapper.dispatchTouchEvent (WindowCallbackWrapper.java:70)
  at androidx.appcompat.view.WindowCallbackWrapper.dispatchTouchEvent (WindowCallbackWrapper.java)
  at com.android.internal.policy.DecorView.dispatchTouchEvent (DecorView.java:1061)
  at android.view.View.dispatchPointerEvent (View.java:15792)
  at android.view.ViewRootImpl$ViewPostImeInputStage.processPointerEvent (ViewRootImpl.java:7941)
  at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess (ViewRootImpl.java:7665)
  at android.view.ViewRootImpl$InputStage.deliver (ViewRootImpl.java:7001)
  at android.view.ViewRootImpl$InputStage.onDeliverToNext (ViewRootImpl.java:7058)
  at android.view.ViewRootImpl$InputStage.forward (ViewRootImpl.java:7024)
  at android.view.ViewRootImpl$AsyncInputStage.forward (ViewRootImpl.java:7222)
  at android.view.ViewRootImpl$InputStage.apply (ViewRootImpl.java:7032)
  at android.view.ViewRootImpl$AsyncInputStage.apply (ViewRootImpl.java:7279)
  at android.view.ViewRootImpl$InputStage.deliver (ViewRootImpl.java:7005)
  at android.view.ViewRootImpl$InputStage.onDeliverToNext (ViewRootImpl.java:7058)
  at android.view.ViewRootImpl$InputStage.forward (ViewRootImpl.java:7024)
  at android.view.ViewRootImpl$InputStage.apply (ViewRootImpl.java:7032)
  at android.view.ViewRootImpl$InputStage.deliver (ViewRootImpl.java:7005)
  at android.view.ViewRootImpl.deliverInputEvent (ViewRootImpl.java:10568)
  at android.view.ViewRootImpl.doProcessInputEvents (ViewRootImpl.java:10456)
  at android.view.ViewRootImpl.enqueueInputEvent (ViewRootImpl.java:10412)
  at android.view.ViewRootImpl$WindowInputEventReceiver.onInputEvent (ViewRootImpl.java:10706)
  at android.view.InputEventReceiver.dispatchInputEvent (InputEventReceiver.java:267)
  at android.os.MessageQueue.nativePollOnce (MessageQueue.java)
  at android.os.MessageQueue.next (MessageQueue.java:335)
  at android.os.Looper.loopOnce (Looper.java:186)
  at android.os.Looper.loop (Looper.java:313)
  at android.app.ActivityThread.main (ActivityThread.java:8741)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:571)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1067)
```