### PR TITLE
fix crash in AccountListFragment when network calls are cancelled

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/AccountListFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/AccountListFragment.kt
@@ -134,7 +134,7 @@ class AccountListFragment : Fragment(R.layout.fragment_account_list), AccountAct
     }
 
     override fun onMute(mute: Boolean, id: String, position: Int, notifications: Boolean) {
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             try {
                 if (!mute) {
                     api.unmuteAccount(id)
@@ -180,7 +180,7 @@ class AccountListFragment : Fragment(R.layout.fragment_account_list), AccountAct
     }
 
     override fun onBlock(block: Boolean, id: String, position: Int) {
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             try {
                 if (!block) {
                     api.unblockAccount(id)
@@ -290,7 +290,7 @@ class AccountListFragment : Fragment(R.layout.fragment_account_list), AccountAct
             binding.recyclerView.post { adapter.setBottomLoading(true) }
         }
 
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             try {
                 val response = getFetchCallByListType(fromId)
                 if (!response.isSuccessful) {
@@ -307,8 +307,8 @@ class AccountListFragment : Fragment(R.layout.fragment_account_list), AccountAct
 
                 val linkHeader = response.headers()["Link"]
                 onFetchAccountsSuccess(accountList, linkHeader)
-            } catch (throwable: Throwable) {
-                onFetchAccountsFailure(throwable)
+            } catch (exception: IOException) {
+                onFetchAccountsFailure(exception)
             }
         }
     }


### PR DESCRIPTION
Open a AccountListFragment and close it before stuff is loaded -> 💥 

Happens because catching all exception also catches the CancellationException, and in onFetchAccountsFailure the binding is accessed which no longer exists at that point. Solution is to only catch the expected IOException. Cancellation exception will be propagated and ignored. 
Also launch coroutines with view lifecycle to make sure binding is always available.

```
Exception java.lang.IllegalStateException: Can't access the Fragment View's LifecycleOwner when getView() is null i.e., before onCreateView() or after onDestroyView()
  at androidx.fragment.app.Fragment.getViewLifecycleOwner (Fragment.java:377)
  at com.keylesspalace.tusky.util.FragmentViewBindingDelegate.getValue (ViewBindingExtensions.kt:56)
  at com.keylesspalace.tusky.fragment.AccountListFragment.getBinding (AccountListFragment.kt:69)
  at com.keylesspalace.tusky.fragment.AccountListFragment.onFetchAccountsFailure (AccountListFragment.kt:374)
  at com.keylesspalace.tusky.fragment.AccountListFragment.access$onFetchAccountsFailure (AccountListFragment.kt:62)
  at com.keylesspalace.tusky.fragment.AccountListFragment$fetchAccounts$2.invokeSuspend (AccountListFragment.kt:311)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:33)
  at kotlinx.coroutines.DispatchedTaskKt.resume (DispatchedTaskKt.java:234)
  at kotlinx.coroutines.DispatchedTaskKt.resumeUnconfined (DispatchedTaskKt.java:190)
  at kotlinx.coroutines.DispatchedTaskKt.dispatch (DispatchedTaskKt.java:161)
  at kotlinx.coroutines.CancellableContinuationImpl.dispatchResume (CancellableContinuationImpl.kt:397)
  at kotlinx.coroutines.CancellableContinuationImpl.cancel (CancellableContinuationImpl.kt:183)
  at kotlinx.coroutines.CancellableContinuationImpl.parentCancelled$kotlinx_coroutines_core (CancellableContinuationImpl.java:190)
  at kotlinx.coroutines.ChildContinuation.invoke (JobSupport.kt:1475)
  at kotlinx.coroutines.JobSupport.notifyCancelling (JobSupport.kt:1500)
  at kotlinx.coroutines.JobSupport.tryMakeCancelling (JobSupport.kt:795)
  at kotlinx.coroutines.JobSupport.makeCancelling (JobSupport.kt:755)
  at kotlinx.coroutines.JobSupport.cancelImpl$kotlinx_coroutines_core (JobSupport.kt:671)
  at kotlinx.coroutines.JobSupport.parentCancelled (JobSupport.java:637)
  at kotlinx.coroutines.ChildHandleNode.invoke (JobSupport.kt:1466)
  at kotlinx.coroutines.JobSupport.notifyCancelling (JobSupport.kt:1500)
  at kotlinx.coroutines.JobSupport.tryMakeCompletingSlowPath (JobSupport.kt:900)
  at kotlinx.coroutines.JobSupport.tryMakeCompleting (JobSupport.kt:863)
  at kotlinx.coroutines.JobSupport.cancelMakeCompleting (JobSupport.kt:696)
  at kotlinx.coroutines.JobSupport.cancelImpl$kotlinx_coroutines_core (JobSupport.kt:667)
  at kotlinx.coroutines.JobSupport.cancelInternal (JobSupport.kt:632)
  at kotlinx.coroutines.JobSupport.cancel (JobSupport.kt:617)
  at kotlinx.coroutines.JobKt__JobKt.cancel (JobKt__JobKt.java:549)
  at kotlinx.coroutines.JobKt__JobKt.cancel$default (JobKt__JobKt.java:548)
  at kotlinx.coroutines.JobKt.cancel$default (JobKt.java:1)
  at androidx.lifecycle.LifecycleCoroutineScopeImpl.onStateChanged (Lifecycle.kt:144)
  at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent (LifecycleRegistry.java:360)
  at androidx.lifecycle.LifecycleRegistry.backwardPass (LifecycleRegistry.java:290)
  at androidx.lifecycle.LifecycleRegistry.sync (LifecycleRegistry.java:308)
  at androidx.lifecycle.LifecycleRegistry.moveToState (LifecycleRegistry.java:151)
  at androidx.lifecycle.LifecycleRegistry.handleLifecycleEvent (LifecycleRegistry.java:134)
  at androidx.fragment.app.Fragment.performDestroy (Fragment.java:3352)
  at androidx.fragment.app.FragmentStateManager.destroy (FragmentStateManager.java:781)
  at androidx.fragment.app.FragmentStateManager.moveToExpectedState (FragmentStateManager.java:335)
  at androidx.fragment.app.SpecialEffectsController$FragmentStateManagerOperation.complete (SpecialEffectsController.java:771)
  at androidx.fragment.app.SpecialEffectsController$Operation.cancel (SpecialEffectsController.java:615)
  at androidx.fragment.app.SpecialEffectsController$Operation.cancel (SpecialEffectsController.java:17)
  at androidx.fragment.app.SpecialEffectsController.forceCompleteAllOperations (SpecialEffectsController.java:350)
  at androidx.fragment.app.FragmentManager.dispatchStateChange (FragmentManager.java:2980)
  at androidx.fragment.app.FragmentManager.dispatchStateChange (FragmentManager.java:59)
  at androidx.fragment.app.FragmentManager.dispatchDestroy (FragmentManager.java:2931)
  at androidx.fragment.app.FragmentManager.dispatchDestroy (FragmentManager.java:119)
  at androidx.fragment.app.FragmentController.dispatchDestroy (FragmentController.java:346)
  at androidx.fragment.app.FragmentActivity.onDestroy (FragmentActivity.java:259)
  at androidx.appcompat.app.AppCompatActivity.onDestroy (AppCompatActivity.java:283)
  at android.app.Activity.performDestroy (Activity.java:8395)
  at android.app.Instrumentation.callActivityOnDestroy (Instrumentation.java:1345)
  at android.app.ActivityThread.performDestroyActivity (ActivityThread.java:5194)
  at android.app.ActivityThread.handleDestroyActivity (ActivityThread.java:5238)
  at android.app.servertransaction.DestroyActivityItem.execute (DestroyActivityItem.java:44)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleState (TransactionExecutor.java:176)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:97)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2112)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:236)
  at android.app.ActivityThread.main (ActivityThread.java:7889)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:600)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:967)
```


