### PR TITLE
Check for status "type" before casting (class cast exception Placeholder)

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModel.kt
@@ -107,7 +107,7 @@ class ViewThreadViewModel @Inject constructor(
             val contextCall = async { api.statusContext(id) }
             val timelineStatus = db.timelineDao().getStatus(id)
 
-            var detailedStatus = if (timelineStatus != null) {
+            var detailedStatus = if (timelineStatus != null && !timelineStatus.status.isPlaceholder) {
                 Log.d(TAG, "Loaded status from local timeline")
                 val viewData = timelineStatus.toViewData(
                     gson,

--- a/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModel.kt
@@ -107,8 +107,7 @@ class ViewThreadViewModel @Inject constructor(
             val contextCall = async { api.statusContext(id) }
             val timelineStatus = db.timelineDao().getStatus(id)
 
-            // TODO: Investigate how this could ever be the ID of a placeholder status
-            var detailedStatus = if (timelineStatus != null && !timelineStatus.status.isPlaceholder) {
+            var detailedStatus = if (timelineStatus != null) {
                 Log.d(TAG, "Loaded status from local timeline")
                 val viewData = timelineStatus.toViewData(
                     gson,

--- a/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModel.kt
@@ -107,6 +107,7 @@ class ViewThreadViewModel @Inject constructor(
             val contextCall = async { api.statusContext(id) }
             val timelineStatus = db.timelineDao().getStatus(id)
 
+            // TODO: Investigate how this could ever be the ID of a placeholder status
             var detailedStatus = if (timelineStatus != null && !timelineStatus.status.isPlaceholder) {
                 Log.d(TAG, "Loaded status from local timeline")
                 val viewData = timelineStatus.toViewData(

--- a/app/src/main/java/com/keylesspalace/tusky/db/TimelineDao.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/TimelineDao.kt
@@ -71,7 +71,8 @@ rb.emojis as 'rb_emojis', rb.bot as 'rb_bot'
 FROM TimelineStatusEntity s
 LEFT JOIN TimelineAccountEntity a ON (s.timelineUserId = a.timelineUserId AND s.authorServerId = a.serverId)
 LEFT JOIN TimelineAccountEntity rb ON (s.timelineUserId = rb.timelineUserId AND s.reblogAccountId = rb.serverId)
-WHERE s.serverId = :statusId OR s.reblogServerId = :statusId"""
+WHERE (s.serverId = :statusId OR s.reblogServerId = :statusId) 
+AND s.authorServerId IS NOT NULL"""
     )
     abstract suspend fun getStatus(statusId: String): TimelineStatusWithAccount?
 


### PR DESCRIPTION
Fixes a crash (class cast of a Placeholder) when tapping a reply in a conversation in the notfications and that conversation is then loaded starting with that reply.

I'm not really sure if this is correct/sufficient there. Or if for example that debug output ("Loaded status from network") is still correct.

@nikclayton 

Stems from: https://github.com/tuskyapp/Tusky/pull/3118
(Unfortunately there is no issue attached there.)

That is the exception: StatusViewData$Placeholder cannot be cast to com.keylesspalace.tusky.viewdata.StatusViewData$Concrete