### PR TITLE
Create send and error notification channels when the app starts

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -16,6 +16,7 @@
 package com.keylesspalace.tusky
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
@@ -40,6 +41,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.view.GravityCompat
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import androidx.viewpager2.widget.MarginPageTransformer
@@ -76,6 +78,7 @@ import com.keylesspalace.tusky.components.scheduled.ScheduledStatusActivity
 import com.keylesspalace.tusky.components.search.SearchActivity
 import com.keylesspalace.tusky.databinding.ActivityMainBinding
 import com.keylesspalace.tusky.db.AccountEntity
+import com.keylesspalace.tusky.db.AppDatabase
 import com.keylesspalace.tusky.entity.Account
 import com.keylesspalace.tusky.entity.Notification
 import com.keylesspalace.tusky.interfaces.AccountSelectionListener
@@ -100,6 +103,7 @@ import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
 import com.mikepenz.materialdrawer.holder.BadgeStyle
 import com.mikepenz.materialdrawer.holder.ColorHolder
+import com.mikepenz.materialdrawer.holder.DimenHolder
 import com.mikepenz.materialdrawer.holder.StringHolder
 import com.mikepenz.materialdrawer.iconics.iconicsIcon
 import com.mikepenz.materialdrawer.model.AbstractDrawerItem
@@ -132,6 +136,9 @@ import javax.inject.Inject
 class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInjector {
     @Inject
     lateinit var androidInjector: DispatchingAndroidInjector<Any>
+
+    @Inject
+    lateinit var database: AppDatabase
 
     @Inject
     lateinit var eventHub: EventHub
@@ -258,6 +265,8 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
 
         setupDrawer(savedInstanceState, addSearchButton = hideTopToolbar)
 
+        updateDraftsBadge()
+
         /* Fetch user info while we're doing other things. This has to be done after setting up the
          * drawer, though, because its callback touches the header in the drawer. */
         fetchUserInfo()
@@ -312,6 +321,34 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
                 arrayOf(Manifest.permission.POST_NOTIFICATIONS),
                 1
             )
+        }
+    }
+
+    /**
+     * Update the badge on the "Drafts" drawer item whenever the count of drafts that
+     * are because of send failures changes.
+     */
+    private fun updateDraftsBadge() {
+        lifecycleScope.launch {
+            database.draftDao()
+                .getFailedToSendCount(accountManager.activeAccount?.id!!)
+                .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+                .collect { count ->
+                    binding.mainDrawer.updateBadge(
+                        DRAWER_ITEM_DRAFTS,
+                        StringHolder(
+                            if (count == 0) {
+                                null
+                            } else {
+                                resources.getQuantityString(
+                                    R.plurals.drafts_failed_count,
+                                    count,
+                                    count
+                                )
+                            }
+                        )
+                    )
+                }
         }
     }
 
@@ -490,8 +527,14 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
                     }
                 },
                 primaryDrawerItem {
+                    identifier = DRAWER_ITEM_DRAFTS
                     nameRes = R.string.action_access_drafts
                     iconRes = R.drawable.ic_notebook
+                    badgeStyle = BadgeStyle().apply {
+                        textColor = ColorHolder.fromColorRes(R.color.tusky_red)
+                        color = ColorHolder.fromColor(Color.LTGRAY)
+                        paddingLeftRight = DimenHolder.fromDp(6)
+                    }
                     onClick = {
                         val intent = DraftsActivity.newIntent(context)
                         startActivityWithSlideInAnimation(intent)
@@ -954,8 +997,9 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
 
     companion object {
         private const val TAG = "MainActivity" // logging tag
-        private const val DRAWER_ITEM_ADD_ACCOUNT: Long = -13
-        private const val DRAWER_ITEM_ANNOUNCEMENTS: Long = 14
+        private const val DRAWER_ITEM_ADD_ACCOUNT = -13L
+        private const val DRAWER_ITEM_ANNOUNCEMENTS = 14L
+        private const val DRAWER_ITEM_DRAFTS = 1L
         const val REDIRECT_URL = "redirectUrl"
         const val OPEN_DRAFTS = "draft"
     }

--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -16,7 +16,6 @@
 package com.keylesspalace.tusky
 
 import android.Manifest
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent

--- a/app/src/main/java/com/keylesspalace/tusky/db/DraftDao.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/DraftDao.kt
@@ -20,6 +20,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface DraftDao {
@@ -32,6 +33,9 @@ interface DraftDao {
 
     @Query("SELECT * FROM DraftEntity WHERE accountId = :accountId")
     suspend fun loadDrafts(accountId: Long): List<DraftEntity>
+
+    @Query("SELECT COUNT(*) FROM DraftEntity WHERE accountId = :accountId AND failedToSend = 1")
+    fun getFailedToSendCount(accountId: Long): Flow<Int>
 
     @Query("DELETE FROM DraftEntity WHERE id = :id")
     suspend fun delete(id: Int)

--- a/app/src/main/java/com/keylesspalace/tusky/service/SendStatusService.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/service/SendStatusService.kt
@@ -82,6 +82,16 @@ class SendStatusService : Service(), Injectable {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 val channel = NotificationChannel(CHANNEL_ID, getString(R.string.send_post_notification_channel_name), NotificationManager.IMPORTANCE_LOW)
                 notificationManager.createNotificationChannel(channel)
+
+                val errorChannel = NotificationChannel(
+                    CHANNEL_ID_ERROR,
+                    getString(R.string.notification_send_error_name),
+                    NotificationManager.IMPORTANCE_HIGH
+                )
+                errorChannel.description = getString(R.string.notification_send_error_description)
+                errorChannel.enableVibration(true)
+                errorChannel.setShowBadge(true)
+                notificationManager.createNotificationChannel(errorChannel)
             }
 
             var notificationText = statusToSend.warningText
@@ -271,7 +281,8 @@ class SendStatusService : Service(), Injectable {
                 R.string.send_post_notification_error_title,
                 R.string.send_post_notification_saved_content,
                 failedStatus.accountId,
-                statusId
+                statusId,
+                channelId = CHANNEL_ID_ERROR
             )
 
             notificationManager.cancel(statusId)
@@ -340,7 +351,8 @@ class SendStatusService : Service(), Injectable {
         @StringRes title: Int,
         @StringRes content: Int,
         accountId: Long,
-        statusId: Int
+        statusId: Int,
+        channelId: String = CHANNEL_ID
     ): Notification {
 
         val intent = Intent(this, MainActivity::class.java)
@@ -354,7 +366,7 @@ class SendStatusService : Service(), Injectable {
             NotificationHelper.pendingIntentFlags(false)
         )
 
-        return NotificationCompat.Builder(this@SendStatusService, CHANNEL_ID)
+        return NotificationCompat.Builder(this@SendStatusService, channelId)
             .setSmallIcon(R.drawable.ic_notify)
             .setContentTitle(getString(title))
             .setContentText(getString(content))
@@ -376,6 +388,7 @@ class SendStatusService : Service(), Injectable {
         private const val KEY_STATUS = "status"
         private const val KEY_CANCEL = "cancel_id"
         private const val CHANNEL_ID = "send_toots"
+        private const val CHANNEL_ID_ERROR = "send_toots_failure"
 
         private val MAX_RETRY_INTERVAL = TimeUnit.MINUTES.toMillis(1)
 

--- a/app/src/main/java/com/keylesspalace/tusky/service/SendStatusService.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/service/SendStatusService.kt
@@ -1,7 +1,6 @@
 package com.keylesspalace.tusky.service
 
 import android.app.Notification
-import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
@@ -78,21 +77,6 @@ class SendStatusService : Service(), Injectable {
         if (intent.hasExtra(KEY_STATUS)) {
             val statusToSend: StatusToSend = intent.getParcelableExtra(KEY_STATUS)
                 ?: throw IllegalStateException("SendStatusService started without $KEY_STATUS extra")
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                val channel = NotificationChannel(CHANNEL_ID, getString(R.string.send_post_notification_channel_name), NotificationManager.IMPORTANCE_LOW)
-                notificationManager.createNotificationChannel(channel)
-
-                val errorChannel = NotificationChannel(
-                    CHANNEL_ID_ERROR,
-                    getString(R.string.notification_send_error_name),
-                    NotificationManager.IMPORTANCE_HIGH
-                )
-                errorChannel.description = getString(R.string.notification_send_error_description)
-                errorChannel.enableVibration(true)
-                errorChannel.setShowBadge(true)
-                notificationManager.createNotificationChannel(errorChannel)
-            }
 
             var notificationText = statusToSend.warningText
             if (notificationText.isBlank()) {
@@ -387,8 +371,10 @@ class SendStatusService : Service(), Injectable {
 
         private const val KEY_STATUS = "status"
         private const val KEY_CANCEL = "cancel_id"
-        private const val CHANNEL_ID = "send_toots"
-        private const val CHANNEL_ID_ERROR = "send_toots_failure"
+
+        // These channels are created in TuskyApplication
+        const val CHANNEL_ID = "send_toots"
+        const val CHANNEL_ID_ERROR = "send_toots_failure"
 
         private val MAX_RETRY_INTERVAL = TimeUnit.MINUTES.toMillis(1)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -322,6 +322,8 @@
     <string name="pref_show_self_username_disambiguate">When multiple accounts logged in</string>
     <string name="pref_show_self_username_never">Never</string>
 
+    <string name="notification_send_error_name">Sending errors</string>
+    <string name="notification_send_error_description">Notifications when posts can not be sent</string>
     <string name="notification_mention_name">New Mentions</string>
     <string name="notification_mention_descriptions">Notifications about new mentions</string>
     <string name="notification_follow_name">New Followers</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -693,6 +693,11 @@
     <string name="draft_deleted">Draft deleted</string>
     <string name="drafts_post_reply_removed">The post you drafted a reply to has been removed</string>
 
+    <plurals name="drafts_failed_count">
+        <item quantity="one">%1$d failure</item>
+        <item quantity="other">%1$d failures</item>
+    </plurals>
+
     <string name="follow_requests_info">Even though your account is not locked, the %1$s staff thought you might want to review follow requests from these accounts manually.</string>
 
     <string name="action_subscribe_account">Subscribe</string>


### PR DESCRIPTION
The previous code creates the channels when a message is sent, or encounters
a failure to send.

This means that the channel does not show up in the Android list of channels
that the user can interact with, until there's been at least one sent message
or failure.

Instead, create the channels early in the application life cycle, so the
user can see and interact with them immediately.