### PR TITLE
Add support for updating media description and focus point when editing statuses

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -334,17 +334,20 @@ class ComposeViewModel @Inject constructor(
             }
         }
 
-        val updatedItem = newMediaList.find { it.localId == localId }
-        if (updatedItem?.id != null) {
-            val focus = updatedItem.focus
-            val focusString = if (focus != null) "${focus.x},${focus.y}" else null
-            return api.updateMedia(updatedItem.id, updatedItem.description, focusString)
-                .fold({
-                    true
-                }, { throwable ->
-                    Log.w(TAG, "failed to update media", throwable)
-                    false
-                })
+        if (!editing) {
+            // Updates to media for already-published statuses need to go through the status edit api
+            val updatedItem = newMediaList.find { it.localId == localId }
+            if (updatedItem?.id != null) {
+                val focus = updatedItem.focus
+                val focusString = if (focus != null) "${focus.x},${focus.y}" else null
+                return api.updateMedia(updatedItem.id, updatedItem.description, focusString)
+                    .fold({
+                        true
+                    }, { throwable ->
+                        Log.w(TAG, "failed to update media", throwable)
+                        false
+                    })
+            }
         }
         return true
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaPreviewAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaPreviewAdapter.kt
@@ -48,11 +48,12 @@ class MediaPreviewAdapter(
         val addFocusId = 2
         val editImageId = 3
         val removeId = 4
-        if (item.state != ComposeActivity.QueuedMedia.State.PUBLISHED) {
-            // Already-published items can't have their metadata edited
-            popup.menu.add(0, addCaptionId, 0, R.string.action_set_caption)
-            if (item.type == ComposeActivity.QueuedMedia.Type.IMAGE) {
-                popup.menu.add(0, addFocusId, 0, R.string.action_set_focus)
+
+        popup.menu.add(0, addCaptionId, 0, R.string.action_set_caption)
+        if (item.type == ComposeActivity.QueuedMedia.Type.IMAGE) {
+            popup.menu.add(0, addFocusId, 0, R.string.action_set_focus)
+            if (item.state != ComposeActivity.QueuedMedia.State.PUBLISHED) {
+                // Already-published items can't be edited
                 popup.menu.add(0, editImageId, 0, R.string.action_edit_image)
             }
         }

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Attachment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Attachment.kt
@@ -83,7 +83,9 @@ data class Attachment(
     data class Focus(
         val x: Float,
         val y: Float
-    ) : Parcelable
+    ) : Parcelable {
+        fun toMastodonApiString(): String = "$x,$y"
+    }
 
     /**
      * The size of an image, used to specify the width/height.

--- a/app/src/main/java/com/keylesspalace/tusky/entity/NewStatus.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/NewStatus.kt
@@ -26,6 +26,7 @@ data class NewStatus(
     val visibility: String,
     val sensitive: Boolean,
     @SerializedName("media_ids") val mediaIds: List<String>?,
+    @SerializedName("media_attributes") val mediaAttributes: List<MediaAttribute>?,
     @SerializedName("scheduled_at") val scheduledAt: String?,
     val poll: NewPoll?,
     val language: String?,
@@ -36,4 +37,14 @@ data class NewPoll(
     val options: List<String>,
     @SerializedName("expires_in") val expiresIn: Int,
     val multiple: Boolean
+) : Parcelable
+
+// It would be nice if we could reuse MediaToSend,
+// but the server requires a different format for focus
+@Parcelize
+data class MediaAttribute(
+    val id: String,
+    val description: String?,
+    val focus: String?,
+    val thumbnail: String?,
 ) : Parcelable

--- a/app/src/main/java/com/keylesspalace/tusky/service/SendStatusService.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/service/SendStatusService.kt
@@ -29,6 +29,7 @@ import com.keylesspalace.tusky.components.notifications.NotificationHelper
 import com.keylesspalace.tusky.db.AccountManager
 import com.keylesspalace.tusky.di.Injectable
 import com.keylesspalace.tusky.entity.Attachment
+import com.keylesspalace.tusky.entity.MediaAttribute
 import com.keylesspalace.tusky.entity.NewPoll
 import com.keylesspalace.tusky.entity.NewStatus
 import com.keylesspalace.tusky.entity.Status
@@ -190,6 +191,14 @@ class SendStatusService : Service(), Injectable {
                 scheduledAt = statusToSend.scheduledAt,
                 poll = statusToSend.poll,
                 language = statusToSend.language,
+                mediaAttributes = media.map { media ->
+                    MediaAttribute(
+                        id = media.id!!,
+                        description = media.description,
+                        focus = media.focus?.toMastodonApiString(),
+                        thumbnail = null,
+                    )
+                },
             )
 
             val sendResult = if (statusToSend.statusId == null) {


### PR DESCRIPTION
Completes #3211 

We could also add support for viewing them in the edit history view, but I think that will maybe not be super useful since that view is mainly for seeing the history of *other* people's statuses

Also fixes #3273 