### PR TITLE
Fix DraftDao queries on older SQLite

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/db/DraftDao.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/DraftDao.kt
@@ -31,10 +31,10 @@ interface DraftDao {
     @Query("SELECT * FROM DraftEntity WHERE accountId = :accountId ORDER BY id ASC")
     fun draftsPagingSource(accountId: Long): PagingSource<Int, DraftEntity>
 
-    @Query("SELECT COUNT(*) FROM DraftEntity where accountId = :accountId and failedToSendNew=true")
+    @Query("SELECT COUNT(*) FROM DraftEntity WHERE accountId = :accountId AND failedToSendNew = 1")
     fun draftsNeedUserAlert(accountId: Long): LiveData<Int>
 
-    @Query("UPDATE DraftEntity SET failedToSendNew=false where accountId = :accountId and failedToSendNew=true")
+    @Query("UPDATE DraftEntity SET failedToSendNew = 0 WHERE accountId = :accountId AND failedToSendNew = 1")
     suspend fun draftsClearNeedUserAlert(accountId: Long)
 
     @Query("SELECT * FROM DraftEntity WHERE accountId = :accountId")


### PR DESCRIPTION
"true" and "false" are not available before SQLite  3.23 / Android 11

> SQLite recognizes the keywords "TRUE" and "FALSE", as of version 3.23.0 (2018-04-02) but those keywords are really just alternative spellings for the integer literals 1 and 0 respectively. 

https://www.sqlite.org/datatype3.html

> API 30    3.28
API 28    3.22


https://developer.android.com/reference/android/database/sqlite/package-summary.html

closes #3230 






