### PR TITLE
Fix crash when failing to unsubscribe push notifications

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/PushNotificationHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/PushNotificationHelper.kt
@@ -36,7 +36,6 @@ import com.keylesspalace.tusky.util.CryptoUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.unifiedpush.android.connector.UnifiedPush
-import retrofit2.HttpException
 
 private const val TAG = "PushNotificationHelper"
 
@@ -210,10 +209,8 @@ suspend fun updateUnifiedPushSubscription(context: Context, api: MastodonApi, ac
 suspend fun unregisterUnifiedPushEndpoint(api: MastodonApi, accountManager: AccountManager, account: AccountEntity) {
     withContext(Dispatchers.IO) {
         api.unsubscribePushNotifications("Bearer ${account.accessToken}", account.domain)
-            .onFailure {
-                Log.d(TAG, "Error unregistering push endpoint for account " + account.id)
-                Log.d(TAG, Log.getStackTraceString(it))
-                Log.d(TAG, (it as HttpException).response().toString())
+            .onFailure { throwable ->
+                Log.w(TAG, "Error unregistering push endpoint for account " + account.id, throwable)
             }
             .onSuccess {
                 Log.d(TAG, "UnifiedPush unregistration succeeded for account " + account.id)


### PR DESCRIPTION
It is not guaranteed to be a `HttpException`, could be `IOException` as well

```
Exception java.lang.ClassCastException:
  at com.keylesspalace.tusky.components.notifications.PushNotificationHelper$unregisterUnifiedPushEndpoint$2.invokeSuspend (PushNotificationHelper.kt:216)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:33)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:106)
  at kotlinx.coroutines.internal.LimitedDispatcher.run (LimitedDispatcher.kt:42)
  at kotlinx.coroutines.scheduling.TaskImpl.run (Tasks.kt:95)
  at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely (CoroutineScheduler.java:570)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask (CoroutineScheduler.kt:750)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker (CoroutineScheduler.kt:677)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run (CoroutineScheduler.kt:664)
```