### PR TITLE
fix crash in ViewThreadFragment

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadFragment.kt
@@ -24,6 +24,7 @@ import android.widget.LinearLayout
 import androidx.annotation.CheckResult
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -211,7 +212,7 @@ class ViewThreadFragment : SFragment(), OnRefreshListener, StatusActionListener,
                         threadProgressBar.cancel()
 
                         adapter.submitList(uiState.statusViewData) {
-                            if (viewModel.isInitialLoad) {
+                            if (lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED) && viewModel.isInitialLoad) {
                                 viewModel.isInitialLoad = false
 
                                 // Ensure the top of the status is visible


### PR DESCRIPTION
Seems like a very rare edge case where the adapter finished updating after the fragment is already destroyed.

```
Exception java.lang.IllegalStateException: Can't access the Fragment View's LifecycleOwner when getView() is null i.e., before onCreateView() or after onDestroyView()
  at androidx.fragment.app.Fragment.getViewLifecycleOwner (Fragment.java:377)
  at com.keylesspalace.tusky.util.FragmentViewBindingDelegate.getValue (ViewBindingExtensions.kt:56)
  at com.keylesspalace.tusky.components.viewthread.ViewThreadFragment.getBinding (ViewThreadFragment.kt:68)
  at com.keylesspalace.tusky.components.viewthread.ViewThreadFragment.access$getBinding (ViewThreadFragment.java:61)
  at com.keylesspalace.tusky.components.viewthread.ViewThreadFragment$onViewCreated$4$1.emit$lambda-1 (ViewThreadFragment.java:218)
  at androidx.appcompat.app.AppLocalesStorageHelper$SerialExecutor$$InternalSyntheticLambda$1$d83da90378edfef33d93bb4a13a0581c0950b0fd40ae81dacd53befaa7b3780c$0.run$bridge (AppLocalesStorageHelper.java:136)
  at androidx.recyclerview.widget.AsyncListDiffer.onCurrentListChanged (AsyncListDiffer.java:379)
  at androidx.recyclerview.widget.AsyncListDiffer.latchList (AsyncListDiffer.java:369)
  at androidx.recyclerview.widget.AsyncListDiffer$1$2.run (AsyncListDiffer.java:351)
  at androidx.recyclerview.widget.DefaultItemAnimator$1.run$bridge (DefaultItemAnimator.java:412)
  at android.os.Handler.handleCallback (Handler.java:883)
  at android.os.Handler.dispatchMessage (Handler.java:100)
  at android.os.Looper.loop (Looper.java:214)
  at android.app.ActivityThread.main (ActivityThread.java:7615)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:492)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:964)
```