### PR TITLE
prevent the app from getting into an invalid state when old shortcuts are used

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/db/AccountManager.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/AccountManager.kt
@@ -45,9 +45,8 @@ class AccountManager @Inject constructor(db: AppDatabase) {
     init {
         accounts = accountDao.loadAll().toMutableList()
 
-        activeAccount = accounts.find { acc ->
-            acc.isActive
-        }
+        activeAccount = accounts.find { acc -> acc.isActive }
+            ?: accounts.firstOrNull()?.also { acc -> acc.isActive = true }
     }
 
     /**
@@ -169,15 +168,17 @@ class AccountManager @Inject constructor(db: AppDatabase) {
      */
     fun setActiveAccount(accountId: Long) {
 
+        val newActiveAccount = accounts.find { (id) ->
+            id == accountId
+        } ?: return // invalid accountId passed, do nothing
+
         activeAccount?.let {
             Log.d(TAG, "setActiveAccount: saving account with id " + it.id)
             it.isActive = false
             saveAccount(it)
         }
 
-        activeAccount = accounts.find { (id) ->
-            id == accountId
-        }
+        activeAccount = newActiveAccount
 
         activeAccount?.let {
             it.isActive = true


### PR DESCRIPTION
Original report in this thread: https://fosstodon.org/@gudenau/109785420799278861

Sometimes, shortcuts are kept around until after the corresponding account logged out. Clicking the shortcuts afterwards causes no account being marked as active which effectively logs all other accounts out as well.
Clicking invalid shortcuts can also result in null accounts being loaded in MainActivity:

```
java.lang.NullPointerException
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3635)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3792)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2210)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7839)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
    Caused by: java.lang.NullPointerException
        at com.keylesspalace.tusky.MainActivity.setupTabs(MainActivity.kt:633)
        at com.keylesspalace.tusky.MainActivity.onCreate(MainActivity.kt:271)
        at android.app.Activity.performCreate(Activity.java:8051)
        at android.app.Activity.performCreate(Activity.java:8031)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1329)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3608)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3792) 
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103) 
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135) 
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2210) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loopOnce(Looper.java:201) 
        at android.os.Looper.loop(Looper.java:288) 
        at android.app.ActivityThread.main(ActivityThread.java:7839) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003) 
```