### PR TITLE
Handle Intent.ACTION_PROCESS_TEXT and convert to hashtags

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -109,6 +109,19 @@
             android:name=".components.compose.ComposeActivity"
             android:theme="@style/TuskyDialogActivityTheme"
             android:windowSoftInputMode="stateVisible|adjustResize" />
+
+        <activity android:name=".components.compose.AddHashTagActivity"
+            android:label="@string/action_convert_to_hashtags"
+            android:exported="false"
+            android:icon="@drawable/ic_hashtag"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="android.intent.action.PROCESS_TEXT" />
+                <data android:mimeType="text/plain"/>
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
         <activity
             android:name=".components.viewthread.ViewThreadActivity"
             android:configChanges="orientation|screenSize" />

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/AddHashTagActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/AddHashTagActivity.kt
@@ -1,0 +1,64 @@
+package com.keylesspalace.tusky.components.compose
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+
+/**
+ * Respond to ACTION_PROCESS_TEXT be inserting "#" at the start of every whitespace/non-whitespace
+ * boundary.
+ */
+class AddHashTagActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (intent.action != Intent.ACTION_PROCESS_TEXT) {
+            finish()
+            return
+        }
+
+        if (intent.getBooleanExtra(Intent.EXTRA_PROCESS_TEXT_READONLY, false)) {
+            finish()
+            return
+        }
+
+        val selectedText = intent.getStringExtra(Intent.EXTRA_PROCESS_TEXT)
+        if (selectedText == null) {
+            finish()
+            return
+        }
+
+        val newText = addHashtags(selectedText)
+
+        val intent = Intent()
+        intent.putExtra(Intent.EXTRA_PROCESS_TEXT, newText)
+        setResult(RESULT_OK, intent)
+
+        finish()
+    }
+
+    companion object {
+        /**
+         * Return a copy of `text` with "#" inserted at the start of every
+         * whitespace/non-whitespace boundary.
+         */
+        fun addHashtags(text: String): String {
+            var wasWhitespace = true
+            val out = mutableListOf<Char>()
+            for (ch in text.iterator()) {
+                if (ch.isWhitespace()) {
+                    wasWhitespace = true
+                    out.add(ch)
+                    continue
+                }
+
+                if (wasWhitespace) {
+                    out.add('#')
+                }
+                out.add(ch)
+                wasWhitespace = false
+            }
+
+            return out.joinToString(separator = "")
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -727,7 +727,7 @@
 
     <string name="action_unfollow_hashtag_format">Unfollow #%s?</string>
     <string name="mute_notifications_switch">Mute notifications</string>
-    
+
     <!-- Reading order preference -->
     <string name="pref_title_reading_order">Reading order</string>
     <string name="pref_reading_order_oldest_first">Oldest first</string>
@@ -739,4 +739,6 @@
     <string name="status_created_info">%1$s created %2$s</string>
 
     <string name="a11y_label_loading_thread">Loading thread</string>
+
+    <string name="action_convert_to_hashtags">As hashtags</string>
 </resources>

--- a/app/src/test/java/com/keylesspalace/tusky/components/compose/AddHashTagActivityTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/compose/AddHashTagActivityTest.kt
@@ -1,0 +1,36 @@
+package com.keylesspalace.tusky.components.compose
+
+import com.keylesspalace.tusky.components.compose.AddHashTagActivity.Companion.addHashtags
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class AddHashTagActivityTest(private val input: String, private val want: String) {
+    companion object {
+        @Parameterized.Parameters(name = "Test {index}: addHashtags({0}) -> {1}")
+        @JvmStatic
+        fun data() = listOf(
+            arrayOf("", ""),
+            arrayOf(" ", " "),
+            arrayOf("  ", "  "),
+            arrayOf("a", "#a"),
+            arrayOf(" a", " #a"),
+            arrayOf(" a ", " #a "),
+            arrayOf("  a", "  #a"),
+            arrayOf("  a  ", "  #a  "),
+            arrayOf("ab", "#ab"),
+            arrayOf(" ab", " #ab"),
+            arrayOf("foo bar", "#foo #bar"),
+            arrayOf("foo  bar", "#foo  #bar"),
+            arrayOf(" foo bar ", " #foo #bar "),
+            arrayOf("  foo  bar  ", "  #foo  #bar  ")
+        )
+    }
+
+    @Test
+    fun `addHashtags_matchesExpectations`() {
+        Assert.assertEquals(want, addHashtags(input))
+    }
+}


### PR DESCRIPTION
Allows the user to select editable text like "foo bar", choose "As hashtags" from the popup menu (next to Copy, Paste, etc), and get back "#foo #bar".

Fixes https://github.com/tuskyapp/Tusky/issues/3267