### PR TITLE
Fix media controller UI not showing during audio playback

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
@@ -70,8 +70,9 @@ class ViewVideoFragment : ViewMediaFragment() {
         super.onResume()
 
         if (_binding != null) {
-            if (mediaActivity.isToolbarVisible) {
                 handler.postDelayed(hideToolbar, TOOLBAR_HIDE_DELAY_MS)
+            if (mediaActivity.isToolbarVisible && !isAudio) {
+                hideToolbarAfterDelay(TOOLBAR_HIDE_DELAY_MS)
             }
             binding.videoView.start()
         }
@@ -124,16 +125,15 @@ class ViewVideoFragment : ViewMediaFragment() {
         binding.videoView.setMediaController(mediaController)
         binding.videoView.requestFocus()
         binding.videoView.setPlayPauseListener(object : ExposedPlayPauseVideoView.PlayPauseListener {
-            override fun onPause() {
-                handler.removeCallbacks(hideToolbar)
-            }
             override fun onPlay() {
-                // Audio doesn't cause the controller to show automatically,
-                // and we only want to hide the toolbar if it's a video.
-                if (isAudio) {
-                    mediaController.show()
-                } else {
+                if(!isAudio) {
                     hideToolbarAfterDelay(TOOLBAR_HIDE_DELAY_MS)
+                }
+            }
+
+            override fun onPause() {
+                if(!isAudio) {
+                    handler.removeCallbacks(hideToolbar)
                 }
             }
         })
@@ -159,6 +159,11 @@ class ViewVideoFragment : ViewMediaFragment() {
             binding.videoView.setOnTouchListener { _, _ ->
                 mediaActivity.onPhotoTap()
                 false
+            }
+
+            // Audio doesn't cause the controller to show automatically
+            if (isAudio) {
+                mediaController.show()
             }
 
             binding.progressBar.hide()

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
@@ -125,13 +125,13 @@ class ViewVideoFragment : ViewMediaFragment() {
         binding.videoView.requestFocus()
         binding.videoView.setPlayPauseListener(object : ExposedPlayPauseVideoView.PlayPauseListener {
             override fun onPlay() {
-                if(!isAudio) {
+                if (!isAudio) {
                     hideToolbarAfterDelay(TOOLBAR_HIDE_DELAY_MS)
                 }
             }
 
             override fun onPause() {
-                if(!isAudio) {
+                if (!isAudio) {
                     handler.removeCallbacks(hideToolbar)
                 }
             }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
@@ -70,7 +70,6 @@ class ViewVideoFragment : ViewMediaFragment() {
         super.onResume()
 
         if (_binding != null) {
-                handler.postDelayed(hideToolbar, TOOLBAR_HIDE_DELAY_MS)
             if (mediaActivity.isToolbarVisible && !isAudio) {
                 hideToolbarAfterDelay(TOOLBAR_HIDE_DELAY_MS)
             }


### PR DESCRIPTION
Partially related to 3170e1ce7167

Moved code to show UI to `OnPreparedListener` because internally `VideoView` calls `MediaController#setEnabled()`  in `onPrepared()`. Calling `MediaController#show()` before `MediaController#setEnabled()` will have no effect.

Testing
 - Open audio attachment: https://solarpunk.moe/@vv/109562659215759090
 - Ensure media control UI and alt text is shown once playback starts

![Screenshot_20230208_220954](https://user-images.githubusercontent.com/1333982/217732370-e6b4bb3f-9f1d-481d-bb12-cd78486fb1e6.png)

Fixes https://github.com/tuskyapp/Tusky/issues/3261