### PR TITLE
Use "System default" as name of default emoji style

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -285,6 +285,8 @@
     <string name="pref_title_animate_gif_avatars">Animate GIF avatars</string>
     <string name="pref_title_gradient_for_media">Show colorful gradients for hidden media</string>
     <string name="pref_title_animate_custom_emojis">Animate custom emojis</string>
+    <!-- Label for default emoji pack -->
+    <string name="system_default_pack">System default</string>
 
     <string name="pref_title_post_filter">Timeline filtering</string>
     <string name="pref_title_post_tabs">Tabs</string>


### PR DESCRIPTION
Other preferences use "System default" (lowercase "d"). This one uses "System Default" because of the default strings in the library. But it can be overridden here for consistency.