### PR TITLE
Improve language list prioritization

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -90,7 +90,7 @@ import com.keylesspalace.tusky.settings.PrefKeys
 import com.keylesspalace.tusky.util.APP_THEME_DEFAULT
 import com.keylesspalace.tusky.util.PickMediaFiles
 import com.keylesspalace.tusky.util.afterTextChanged
-import com.keylesspalace.tusky.util.getInitialLanguage
+import com.keylesspalace.tusky.util.getInitialLanguages
 import com.keylesspalace.tusky.util.getLocaleList
 import com.keylesspalace.tusky.util.getMediaSize
 import com.keylesspalace.tusky.util.hide
@@ -266,7 +266,7 @@ class ComposeActivity :
             binding.composeScheduleView.setDateTime(composeOptions?.scheduledAt)
         }
 
-        setupLanguageSpinner(getInitialLanguage(composeOptions?.language, accountManager.activeAccount))
+        setupLanguageSpinner(getInitialLanguages(composeOptions?.language, accountManager.activeAccount))
         setupComposeField(preferences, viewModel.startingText)
         setupContentWarningField(composeOptions?.contentWarning)
         setupPollView()
@@ -542,7 +542,7 @@ class ComposeActivity :
         )
     }
 
-    private fun setupLanguageSpinner(initialLanguage: String) {
+    private fun setupLanguageSpinner(initialLanguages: List<String>) {
         binding.composePostLanguageButton.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
                 viewModel.postLanguage = (parent.adapter.getItem(position) as Locale).modernLanguageCode
@@ -553,7 +553,7 @@ class ComposeActivity :
             }
         }
         binding.composePostLanguageButton.apply {
-            adapter = LocaleAdapter(context, android.R.layout.simple_spinner_dropdown_item, getLocaleList(initialLanguage))
+            adapter = LocaleAdapter(context, android.R.layout.simple_spinner_dropdown_item, getLocaleList(initialLanguages))
             setSelection(0)
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/AccountPreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/AccountPreferencesFragment.kt
@@ -49,7 +49,7 @@ import com.keylesspalace.tusky.settings.makePreferenceScreen
 import com.keylesspalace.tusky.settings.preference
 import com.keylesspalace.tusky.settings.preferenceCategory
 import com.keylesspalace.tusky.settings.switchPreference
-import com.keylesspalace.tusky.util.getInitialLanguage
+import com.keylesspalace.tusky.util.getInitialLanguages
 import com.keylesspalace.tusky.util.getLocaleList
 import com.keylesspalace.tusky.util.getTuskyDisplayName
 import com.keylesspalace.tusky.util.makeIcon
@@ -196,7 +196,7 @@ class AccountPreferencesFragment : PreferenceFragmentCompat(), Injectable {
                 }
 
                 listPreference {
-                    val locales = getLocaleList(getInitialLanguage(null, accountManager.activeAccount))
+                    val locales = getLocaleList(getInitialLanguages(null, accountManager.activeAccount))
                     setTitle(R.string.pref_default_post_language)
                     // Explicitly add "System default" to the start of the list
                     entries = (

--- a/app/src/test/java/com/keylesspalace/tusky/util/LocaleUtilsTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/util/LocaleUtilsTest.kt
@@ -1,0 +1,82 @@
+package com.keylesspalace.tusky.util
+
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.keylesspalace.tusky.db.AccountEntity
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.robolectric.annotation.Config
+
+@Config(sdk = [28])
+@RunWith(AndroidJUnit4::class)
+class LocaleUtilsTest {
+    @Test
+    fun initialLanguagesContainReplySelectedAppAndSystem() {
+        val expectedLanguages = arrayOf<String?>("yi", "tok", "da", "fr", "sv", "kab")
+        val languages = getMockedInitialLanguages(expectedLanguages)
+        Assert.assertArrayEquals(expectedLanguages, languages.subList(0, expectedLanguages.size).toTypedArray())
+    }
+
+    @Test
+    fun whenReplyLanguageIsNull_DefaultLanguageIsFirst() {
+        val defaultLanguage = "tok"
+        val languages = getMockedInitialLanguages(arrayOf(null, defaultLanguage, "da", "fr", "sv", "kab"))
+        Assert.assertEquals(defaultLanguage, languages[0])
+    }
+
+    @Test
+    fun initialLanguagesAreDistinct() {
+        val defaultLanguage = "da"
+        val languages = getMockedInitialLanguages(arrayOf(defaultLanguage, defaultLanguage, "fr", defaultLanguage, "kab", defaultLanguage))
+        Assert.assertEquals(1, languages.count { it == defaultLanguage })
+    }
+
+    @Test
+    fun initialLanguageDeduplicationDoesNotReorder() {
+        val defaultLanguage = "da"
+
+        Assert.assertEquals(
+            defaultLanguage,
+            getMockedInitialLanguages(arrayOf(defaultLanguage, defaultLanguage, "fr", defaultLanguage, "kab", defaultLanguage))[0]
+        )
+        Assert.assertEquals(
+            defaultLanguage,
+            getMockedInitialLanguages(arrayOf(null, defaultLanguage, "fr", defaultLanguage, "kab", defaultLanguage))[0]
+        )
+    }
+
+    @Test
+    fun emptyInitialLanguagesAreDropped() {
+        val languages = getMockedInitialLanguages(arrayOf("", "", "fr", "", "kab", ""))
+        Assert.assertFalse(languages.any { it.isEmpty() })
+    }
+
+    private fun getMockedInitialLanguages(configuredLanguages: Array<String?>): List<String> {
+        val appLanguages = LocaleListCompat.forLanguageTags(configuredLanguages.slice(2 until 4).joinToString(","))
+        val systemLanguages = LocaleListCompat.forLanguageTags(configuredLanguages.slice(4 until configuredLanguages.size).joinToString(","))
+
+        Mockito.mockStatic(AppCompatDelegate::class.java).use { appCompatDelegate ->
+            appCompatDelegate.`when`<LocaleListCompat> { AppCompatDelegate.getApplicationLocales() }.thenReturn(appLanguages)
+
+            Mockito.mockStatic(LocaleListCompat::class.java).use { localeListCompat ->
+                localeListCompat.`when`<LocaleListCompat> { LocaleListCompat.getDefault() }.thenReturn(systemLanguages)
+
+                return getInitialLanguages(
+                    configuredLanguages[0],
+                    AccountEntity(
+                        id = 0,
+                        domain = "foo.bar",
+                        accessToken = "",
+                        clientId = null,
+                        clientSecret = null,
+                        isActive = true,
+                        defaultPostLanguage = configuredLanguages[1] ?: "",
+                    )
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ensures that all of (language of the post being replied to, default post language, configured app languages, configured system languages) are prioritized when constructing the language list for composing, regardless of whether any of those are languages android knows about.

Partially addresses #3277