### PR TITLE
Fix non-git build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,9 +5,19 @@ plugins {
     alias(libs.plugins.kotlin.parcelize)
 }
 
-final def gitSha = providers.exec {
-    commandLine('git', 'rev-parse', '--short=7', 'HEAD')
-}.standardOutput.asText.get().trim()
+// For constructing gitSha
+def getGitSha = {
+    def stdout = new ByteArrayOutputStream()
+    try {
+        providers.exec {
+            commandLine 'git', 'rev-parse', '--short=7', 'HEAD'
+        }.standardOutput.asText.get().trim()
+    } catch (Exception e) {
+        "unknown"
+    }
+}
+
+final def gitSha = getGitSha()
 
 // The app name
 final def APP_NAME = "Tusky"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,14 +5,14 @@ plugins {
     alias(libs.plugins.kotlin.parcelize)
 }
 
-// For constructing gitSha
+// For constructing gitSha only
 def getGitSha = {
     try {
         providers.exec {
-            commandLine 'git', 'rev-parse', '--short=7', 'HEAD'
+            commandLine 'git', 'rev-parse', 'HEAD'
         }.standardOutput.asText.get().trim()
     } catch (Exception e) {
-        "unknown"
+        "unknown" // Try-catch is necessary for build to work on non-git distributions
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,6 @@ plugins {
 
 // For constructing gitSha
 def getGitSha = {
-    def stdout = new ByteArrayOutputStream()
     try {
         providers.exec {
             commandLine 'git', 'rev-parse', '--short=7', 'HEAD'


### PR DESCRIPTION
This worked in 21.0 but was broken by the gradle modernization patch (PR#3171)

Building with this patch I get the warning

> Values of variant API AnnotationProcessorOptions.arguments are queried and may return non final values, this is unsupported

I don't know if this is because I broke something or if it was printing that warning already.