### PR TITLE
Fix non-git build (for real this time)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ def getGitSha = {
         providers.exec {
             commandLine 'git', 'rev-parse', 'HEAD'
         }.standardOutput.asText.get().trim()
-    } catch (Exception e) {
+    } catch (Throwable e) {
         "unknown" // Try-catch is necessary for build to work on non-git distributions
     }
 }


### PR DESCRIPTION
Turns out org.gradle.process.internal.execexception is an Error and not an Exception. My last PR was wrong. Sorry!