### PR TITLE
Show categories in emoji picker

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/EmojiAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/EmojiAdapter.kt
@@ -37,7 +37,7 @@ class EmojiAdapter(
     private val emojiList = mutableListOf<EmojiGridItem>()
     lateinit var emojiCategories: LinkedHashMap<String?, Int>
         private set
-    private lateinit var emojiCategoryPositions: HashMap<String?, Int>
+    private lateinit var emojiCategoryPositions: LinkedHashMap<String?, Int>
 
     data class EmojiGridItem(val emoji: Emoji?, val trueIndex: Int?)
 
@@ -47,7 +47,7 @@ class EmojiAdapter(
         val spanCount = (recyclerView.layoutManager as GridLayoutManager).spanCount
 
         val catMap = LinkedHashMap<String?, Int>()
-        val catPosMap = HashMap<String?, Int>()
+        val catPosMap = LinkedHashMap<String?, Int>()
         var currentCategory: String? = null
         for (index in trueEmojiList.indices) {
             val emoji = trueEmojiList[index]
@@ -71,6 +71,17 @@ class EmojiAdapter(
 
     fun getCategoryStartPosition(category: String?): Int {
         return emojiCategoryPositions.getValue(category)
+    }
+
+    fun getCategoryForPosition(position: Int): String? {
+        var prevKey: String? = null
+        for (entry in emojiCategoryPositions) {
+            if (position < entry.value) {
+                return prevKey
+            }
+            prevKey = entry.key
+        }
+        return prevKey
     }
 
     override fun getItemCount() = emojiList.size

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -26,6 +26,7 @@ import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
+import android.graphics.Typeface
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -33,6 +34,7 @@ import android.os.Parcelable
 import android.provider.MediaStore
 import android.util.DisplayMetrics
 import android.util.Log
+import android.util.TypedValue
 import android.view.KeyEvent
 import android.view.MenuItem
 import android.view.View
@@ -55,6 +57,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.view.ContentInfoCompat
 import androidx.core.view.OnReceiveContentListener
+import androidx.core.view.forEach
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
@@ -1227,14 +1230,16 @@ class ComposeActivity :
             val emojiAdapter = EmojiAdapter(emojiList, this@ComposeActivity, animateEmojis)
             binding.emojiView.adapter = emojiAdapter
 
-            emojiAdapter.emojiCategories.keys.forEachIndexed() { i: Int, s: String? ->
+            emojiAdapter.emojiCategories.keys.forEachIndexed { i: Int, s: String? ->
                 val categoryTextView = TextView(this)
                 categoryTextView.text = s ?: getString(R.string.custom_emoji_default_category_title)
                 val padding = (8 * resources.displayMetrics.density + 0.5f).toInt()
                 categoryTextView.setPadding(padding, padding, padding, padding)
-                // categoryTextView.textSize = ... R.attr.status_text_medium ...
-                // if (i == 0) categoryTextView.setTypeface(null, Typeface.BOLD)
-                categoryTextView.setOnClickListener() {
+                val typedValue = TypedValue()
+                this.theme.resolveAttribute(R.attr.status_text_medium, typedValue, true)
+                categoryTextView.setTextSize(TypedValue.COMPLEX_UNIT_PX, typedValue.getDimension(resources.displayMetrics))
+                if (i == 0) categoryTextView.setTypeface(null, Typeface.BOLD)
+                categoryTextView.setOnClickListener {
                     val p = emojiAdapter.getCategoryStartPosition(s)
                     val smoothScroller: RecyclerView.SmoothScroller = object : LinearSmoothScroller(binding.emojiView.context) {
                         override fun getHorizontalSnapPreference(): Int {
@@ -1246,6 +1251,11 @@ class ComposeActivity :
                     }
                     smoothScroller.targetPosition = p;
                     binding.emojiView.layoutManager?.startSmoothScroll(smoothScroller)
+
+                    binding.emojiCategoryLinearLayout.forEach { view ->
+                        (view as TextView).setTypeface(null, if (view == it) Typeface.BOLD else Typeface.NORMAL)
+                    }
+                    binding.emojiCategoryScrollView.smoothScrollTo(it.left, 0)
                 }
                 binding.emojiCategoryLinearLayout.addView(categoryTextView)
             }

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -483,7 +483,7 @@ class ComposeActivity :
         composeOptionsBehavior = BottomSheetBehavior.from(binding.composeOptionsBottomSheet)
         addMediaBehavior = BottomSheetBehavior.from(binding.addMediaBottomSheet)
         scheduleBehavior = BottomSheetBehavior.from(binding.composeScheduleView)
-        emojiBehavior = BottomSheetBehavior.from(binding.emojiView)
+        emojiBehavior = BottomSheetBehavior.from(binding.emojiBottomSheet)
 
         enableButton(binding.composeEmojiButton, clickable = false, colorActive = false)
 

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Emoji.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Emoji.kt
@@ -24,5 +24,6 @@ data class Emoji(
     val shortcode: String,
     val url: String,
     @SerializedName("static_url") val staticUrl: String,
-    @SerializedName("visible_in_picker") val visibleInPicker: Boolean?
+    @SerializedName("visible_in_picker") val visibleInPicker: Boolean?,
+    val category: String?
 ) : Parcelable

--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -236,19 +236,27 @@
             android:textSize="?attr/status_text_medium" />
     </LinearLayout>
 
-    <com.keylesspalace.tusky.view.EmojiPicker
-        android:id="@+id/emojiView"
+    <LinearLayout
+        android:id="@+id/emojiBottomSheet"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorSurface"
         android:elevation="12dp"
+        android:orientation="vertical"
         android:paddingStart="16dp"
         android:paddingTop="8dp"
         android:paddingEnd="16dp"
         android:paddingBottom="60dp"
         app:behavior_hideable="true"
         app:behavior_peekHeight="0dp"
-        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior" />
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+
+
+        <com.keylesspalace.tusky.view.EmojiPicker
+            android:id="@+id/emojiView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
 
     <com.keylesspalace.tusky.components.compose.view.ComposeOptionsView
         android:id="@+id/composeOptionsBottomSheet"

--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -251,6 +251,20 @@
         app:behavior_peekHeight="0dp"
         app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
+        <HorizontalScrollView
+            android:id="@+id/emojiCategoryScrollView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:scrollbars="none"
+            android:visibility="gone">
+
+            <LinearLayout
+                android:id="@+id/emojiCategoryLinearLayout"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+            </LinearLayout>
+        </HorizontalScrollView>
 
         <com.keylesspalace.tusky.view.EmojiPicker
             android:id="@+id/emojiView"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -467,6 +467,7 @@
     <string name="action_compose_shortcut">Compose</string>
 
     <string name="error_no_custom_emojis">Your instance %s does not have any custom emojis</string>
+    <string name="custom_emoji_default_category_title">Custom</string>
     <string name="emoji_style">Emoji style</string>
     <string name="system_default">System default</string>
     <string name="download_fonts">You\'ll need to download these emoji sets first</string>
@@ -727,7 +728,7 @@
 
     <string name="action_unfollow_hashtag_format">Unfollow #%s?</string>
     <string name="mute_notifications_switch">Mute notifications</string>
-    
+
     <!-- Reading order preference -->
     <string name="pref_title_reading_order">Reading order</string>
     <string name="pref_reading_order_oldest_first">Oldest first</string>


### PR DESCRIPTION
[Categories can be defined](https://docs.joinmastodon.org/entities/CustomEmoji/) for custom emojis in Mastodon.  
For example on [zug.network](https://zug.network), there are over 1800 custom emojis and at least some categories have been introduced, which can be seen in the web interface like in the next screenshot. Meanwhile in Tusky the emojis can only be browsed alphabetically without categories.

<img src="https://user-images.githubusercontent.com/9254305/218233671-130bf396-1874-48a4-867a-e5e17b988e06.png" width="250px">

In this PR I tried to group custom emojis by category and only sort alphabetically within the group, furthermore there's a kind of header for the emoji picker containing all the categories and highlighting the current one.

![image](https://user-images.githubusercontent.com/9254305/218233931-686a2afd-df0a-4175-bd01-15c49fc72862.png)

![image](https://user-images.githubusercontent.com/9254305/218233944-d6151f5a-66b1-4b4a-814f-980f4dbf4ad9.png)

When scrolling the emoji grid, the header gets updated, however the code marked with TODO needs to be improved to suppress this during the smooth scrolling that happens when clicking on a category.

Besides that, I'm sure some refactoring has to be done since I probably placed some of the code in inappropriate places. The idea of using empty/fake grid items might also be controversial?