### PR TITLE
Fix sporadic failure in non-git build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,12 +7,13 @@ plugins {
 
 // For constructing gitSha only
 def getGitSha = {
-    try {
+    try {  // Try-catch is necessary for build to work on non-git distributions
         providers.exec {
             commandLine 'git', 'rev-parse', 'HEAD'
+            executionResult.rethrowFailure() // Without this, sometimes it just stops immediately instead of throwing
         }.standardOutput.asText.get().trim()
     } catch (Exception e) {
-        "unknown" // Try-catch is necessary for build to work on non-git distributions
+        "unknown"
     }
 }
 


### PR DESCRIPTION
(using patch by @nikclayton)

#3296 worked for non-incremental builds but not incremental builds. So it would always work on the first try and fail on all subsequent tries. Apparently spooky gradle magic is needed here