### PR TITLE
Previous attempt to fix git sha on non-git build broke git build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,19 +5,9 @@ plugins {
     alias(libs.plugins.kotlin.parcelize)
 }
 
-// For constructing gitSha only
-def getGitSha = {
-    try {  // Try-catch is necessary for build to work on non-git distributions
-        providers.exec {
-            commandLine 'git', 'rev-parse', 'HEAD'
-            executionResult.rethrowFailure() // Without this, sometimes it just stops immediately instead of throwing
-        }.standardOutput.asText.get().trim()
-    } catch (Exception e) {
-        "unknown"
-    }
-}
+apply from: 'getGitSha.gradle'
 
-final def gitSha = getGitSha()
+final def gitSha = ext.getGitSha()
 
 // The app name
 final def APP_NAME = "Tusky"

--- a/app/getGitSha.gradle
+++ b/app/getGitSha.gradle
@@ -1,0 +1,27 @@
+import org.gradle.api.provider.ValueSourceParameters
+import javax.inject.Inject
+
+// Must wrap this in a ValueSource in order to get well-defined fail behavior without confusing Gradle on repeat builds.
+abstract class GitShaValueSource implements ValueSource<String, ValueSourceParameters.None> {
+    @Inject abstract ExecOperations getExecOperations()
+
+    @Override String obtain() {
+        try {
+            def output = new ByteArrayOutputStream()
+
+            execOperations.exec {
+                it.commandLine 'git', 'rev-parse', '--short=8', 'HEAD'
+                it.standardOutput = output
+            }
+            return output.toString().trim()
+        } catch (GradleException ignore) {
+            // Git executable unavailable, or we are not building in a git repo. Fall through:
+        }
+        return "unknown"
+    }
+}
+
+// Export closure
+ext.getGitSha = {
+    providers.of(GitShaValueSource) {}.get()
+}


### PR DESCRIPTION
https://github.com/tuskyapp/Tusky/pull/3299 fixed the non-git build, but unbeknowst to us, only by forcing the git build to always use the git hash "unknown". :(

This fix uses unusual code provided by Mikhail Lopatkin of Gradle Inc in an issue I filed on gradle complaining about our problems: 

https://github.com/gradle/gradle/issues/23914#issuecomment-1431909019

It wraps the git sha function in a "value source". This allows it to interact correctly with configuration caching. Because the code is longer than before, it is now broken out into its own file getGitSha.gradle.

I did more extensive tests than I did on the previous PR (with git, without git, with git but in a non-git repo) and it worked correctly and consistently on all of them. Changing the git hash but not changing any project files was picked up properly on successive incremental builds.

The "modernization" commit changed us from `exec` to `providers.exec`; this changes us again to `execOperations.exec`, which seems to lose us `.standardOutput`. I do not understand the difference between any of these three things (I will ask in the gradle issue).