### PR TITLE
Fetch list title from second value in arguments

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -697,7 +697,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
             tab: TabLayout.Tab, position: Int ->
             tab.icon = AppCompatResources.getDrawable(this@MainActivity, tabs[position].icon)
             tab.contentDescription = when (tabs[position].id) {
-                LIST -> tabs[position].arguments[position]
+                LIST -> tabs[position].arguments[1]
                 else -> getString(tabs[position].text)
             }
         }.also { it.attach() }


### PR DESCRIPTION
Previous code was:

```
for (i in tabs.indices) {
    // ...
    if (tabs[i].id == LIST) {
        tab.contentDescription = tabs[i].arguments[1]
    } else {
        tab.setContentDescription(tabs[i].text)
    }
    // ...
}
```

When I converted it over, `i` was replaced with `position`, but I misread `tab.contentDescription = tabs[i].arguments[1]` as `tab.contentDescription = tabs[i].arguments[i]`.

Put the `1` back.