### PR TITLE
Use the adapter position when responding to clicks on followed tags

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/followedtags/FollowedTagsAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/followedtags/FollowedTagsAdapter.kt
@@ -22,7 +22,7 @@ class FollowedTagsAdapter(
         viewModel.tags[position].let { tag ->
             holder.itemView.findViewById<TextView>(R.id.followed_tag).text = tag.name
             holder.itemView.findViewById<ImageButton>(R.id.followed_tag_unfollow).setOnClickListener {
-                actionListener.unfollow(tag.name, position)
+                actionListener.unfollow(tag.name, holder.bindingAdapterPosition)
             }
         }
     }


### PR DESCRIPTION
This ensures that the position is valid w.r.t. to the backing array.

Fixes https://github.com/tuskyapp/Tusky/issues/3333