### PR TITLE
When looking up fediverse urls, verify that account results returned match the input query

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/BottomSheetActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/BottomSheetActivity.kt
@@ -86,8 +86,11 @@ abstract class BottomSheetActivity : BaseActivity() {
                     if (statuses.isNotEmpty()) {
                         viewThread(statuses[0].id, statuses[0].url)
                         return@subscribe
-                    } else if (accounts.isNotEmpty()) {
-                        viewAccount(accounts[0].id)
+                    }
+                    accounts.firstOrNull { it.url == url }?.let { account ->
+                        // Some servers return (unrelated) accounts for url searches (#2804)
+                        // Verify that the account's url matches the query
+                        viewAccount(account.id)
                         return@subscribe
                     }
 

--- a/app/src/test/java/com/keylesspalace/tusky/BottomSheetActivityTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/BottomSheetActivityTest.kt
@@ -46,6 +46,7 @@ class BottomSheetActivityTest {
     private lateinit var apiMock: MastodonApi
     private val accountQuery = "http://mastodon.foo.bar/@User"
     private val statusQuery = "http://mastodon.foo.bar/@User/345678"
+    private val nonexistentStatusQuery = "http://mastodon.foo.bar/@User/345678000"
     private val nonMastodonQuery = "http://medium.com/@correspondent/345678"
     private val emptyCallback = Single.just(SearchResult(emptyList(), emptyList(), emptyList()))
     private val testScheduler = TestScheduler()
@@ -55,7 +56,7 @@ class BottomSheetActivityTest {
         localUsername = "admin",
         username = "admin",
         displayName = "Ad Min",
-        url = "http://mastodon.foo.bar",
+        url = "http://mastodon.foo.bar/@User",
         avatar = ""
     )
     private val accountSingle = Single.just(SearchResult(listOf(account), emptyList(), emptyList()))
@@ -101,6 +102,7 @@ class BottomSheetActivityTest {
         apiMock = mock {
             on { searchObservable(eq(accountQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn accountSingle
             on { searchObservable(eq(statusQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn statusSingle
+            on { searchObservable(eq(nonexistentStatusQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn accountSingle
             on { searchObservable(eq(nonMastodonQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn emptyCallback
         }
 
@@ -182,6 +184,14 @@ class BottomSheetActivityTest {
             assertEquals(nonMastodonQuery, activity.link)
             assertEquals(fallbackBehavior, activity.fallbackBehavior)
         }
+    }
+
+    @Test
+    fun search_doesNotRespectUnrelatedResult() {
+        activity.viewUrl(nonexistentStatusQuery)
+        testScheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS)
+        assertEquals(nonexistentStatusQuery, activity.link)
+        assertEquals(null, activity.accountId)
     }
 
     @Test


### PR DESCRIPTION
Fixes #2804