### PR TITLE
Perform unicode text isolation on user names in post edit history view

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/viewthread/edits/ViewEditsAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/viewthread/edits/ViewEditsAdapter.kt
@@ -27,6 +27,7 @@ import com.keylesspalace.tusky.util.loadAvatar
 import com.keylesspalace.tusky.util.parseAsMastodonHtml
 import com.keylesspalace.tusky.util.setClickableText
 import com.keylesspalace.tusky.util.show
+import com.keylesspalace.tusky.util.unicodeWrap
 import com.keylesspalace.tusky.util.visible
 import com.keylesspalace.tusky.viewdata.toViewData
 
@@ -72,7 +73,7 @@ class ViewEditsAdapter(
 
         binding.statusEditInfo.text = context.getString(
             infoStringRes,
-            edit.account.name,
+            edit.account.name.unicodeWrap(),
             timestamp
         ).emojify(edit.account.emojis, binding.statusEditInfo, animateEmojis)
 


### PR DESCRIPTION
before | after
---|---
![screenshot of a post history view, showing words "detide" and "detaerc" (which are "edited" and "created" but backwards) after a user name, which are a result of non-isolated text](https://user-images.githubusercontent.com/119071347/220167571-93fcb328-4ba1-440c-8a45-d231d12daff6.jpg) | ![screenshot, showing "edited" and "created" correctly :)](https://user-images.githubusercontent.com/119071347/220167575-b4979d27-19e9-4fff-96ac-da5ac27f3fe1.jpg)
