### PR TITLE
Add extra proguard rules for OkHttp

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -78,6 +78,13 @@
 -keepattributes Signature
 -keep class kotlin.coroutines.Continuation
 
+# We can remove these rules after updating to OkHttp 4.10.x
+# https://github.com/square/okhttp/blob/339732e3a1b78be5d792860109047f68a011b5eb/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro#L11-L14
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**
+
 # preserve line numbers for crash reporting
 -keepattributes SourceFile,LineNumberTable
 -renamesourcefileattribute SourceFile

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -78,7 +78,7 @@
 -keepattributes Signature
 -keep class kotlin.coroutines.Continuation
 
-# We can remove these rules after updating to OkHttp 4.10.x
+# We can remove these rules after updating to OkHttp 4.10.1
 # https://github.com/square/okhttp/blob/339732e3a1b78be5d792860109047f68a011b5eb/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro#L11-L14
 -dontwarn okhttp3.internal.platform.**
 -dontwarn org.conscrypt.**


### PR DESCRIPTION
Suppress some warnings, this is necessary for upgrading AGP 8, we can remove these rules after updating to OkHttp 4.10.x.

```
> Task :app:minifyBlueReleaseWithR8
AGPBI: {"kind":"warning","text":"Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in /Users/goooler/StudioProjects/Tusky/app/build/outputs/mapping/blueRelease/missing_rules.txt.\n","sources":[{}]}
Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in /Users/goooler/StudioProjects/Tusky/app/build/outputs/mapping/blueRelease/missing_rules.txt.


AGPBI: {"kind":"warning","text":"Missing class com.android.org.conscrypt.SSLParametersImpl (referenced from: void org.conscrypt.KitKatPlatformOpenSSLSocketImplAdapter.<init>(org.conscrypt.AbstractConscryptSocket))\nMissing class org.apache.harmony.xnet.provider.jsse.SSLParametersImpl (referenced from: void org.conscrypt.PreKitKatPlatformOpenSSLSocketImplAdapter.<init>(org.conscrypt.AbstractConscryptSocket))\nMissing class org.bouncycastle.jsse.BCSSLParameters (referenced from: void okhttp3.internal.platform.BouncyCastlePlatform.configureTlsExtensions(javax.net.ssl.SSLSocket, java.lang.String, java.util.List) and 1 other context)\nMissing class org.bouncycastle.jsse.BCSSLSocket (referenced from: void okhttp3.internal.platform.BouncyCastlePlatform.configureTlsExtensions(javax.net.ssl.SSLSocket, java.lang.String, java.util.List) and 5 other contexts)\nMissing class org.bouncycastle.jsse.provider.BouncyCastleJsseProvider (referenced from: void okhttp3.internal.platform.BouncyCastlePlatform.<init>())\nMissing class org.openjsse.javax.net.ssl.SSLParameters (referenced from: void okhttp3.internal.platform.OpenJSSEPlatform.configureTlsExtensions(javax.net.ssl.SSLSocket, java.lang.String, java.util.List))\nMissing class org.openjsse.javax.net.ssl.SSLSocket (referenced from: void okhttp3.internal.platform.OpenJSSEPlatform.configureTlsExtensions(javax.net.ssl.SSLSocket, java.lang.String, java.util.List) and 1 other context)\nMissing class org.openjsse.net.ssl.OpenJSSE (referenced from: void okhttp3.internal.platform.OpenJSSEPlatform.<init>())","sources":[{}],"tool":"R8"}
Missing class com.android.org.conscrypt.SSLParametersImpl (referenced from: void org.conscrypt.KitKatPlatformOpenSSLSocketImplAdapter.<init>(org.conscrypt.AbstractConscryptSocket))
Missing class org.apache.harmony.xnet.provider.jsse.SSLParametersImpl (referenced from: void org.conscrypt.PreKitKatPlatformOpenSSLSocketImplAdapter.<init>(org.conscrypt.AbstractConscryptSocket))
Missing class org.bouncycastle.jsse.BCSSLParameters (referenced from: void okhttp3.internal.platform.BouncyCastlePlatform.configureTlsExtensions(javax.net.ssl.SSLSocket, java.lang.String, java.util.List) and 1 other context)
Missing class org.bouncycastle.jsse.BCSSLSocket (referenced from: void okhttp3.internal.platform.BouncyCastlePlatform.configureTlsExtensions(javax.net.ssl.SSLSocket, java.lang.String, java.util.List) and 5 other contexts)
Missing class org.bouncycastle.jsse.provider.BouncyCastleJsseProvider (referenced from: void okhttp3.internal.platform.BouncyCastlePlatform.<init>())
Missing class org.openjsse.javax.net.ssl.SSLParameters (referenced from: void okhttp3.internal.platform.OpenJSSEPlatform.configureTlsExtensions(javax.net.ssl.SSLSocket, java.lang.String, java.util.List))
Missing class org.openjsse.javax.net.ssl.SSLSocket (referenced from: void okhttp3.internal.platform.OpenJSSEPlatform.configureTlsExtensions(javax.net.ssl.SSLSocket, java.lang.String, java.util.List) and 1 other context)
Missing class org.openjsse.net.ssl.OpenJSSE (referenced from: void okhttp3.internal.platform.OpenJSSEPlatform.<init>())
```

https://github.com/square/okhttp/blob/339732e3a1b78be5d792860109047f68a011b5eb/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro#L11-L14