### PR TITLE
Ignore "@instance..." part of username when computing status length

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -159,7 +159,7 @@ private fun getCustomSpanForMention(mentions: List<Mention>, span: URLSpan, list
 }
 
 private fun getCustomSpanForMentionUrl(url: String, mentionId: String, listener: LinkListener): ClickableSpan {
-    return object : NoUnderlineURLSpan(url) {
+    return object : MentionSpan(url) {
         override fun onClick(view: View) = listener.onViewAccount(mentionId)
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/util/NoUnderlineURLSpan.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/NoUnderlineURLSpan.kt
@@ -19,9 +19,14 @@ import android.text.TextPaint
 import android.text.style.URLSpan
 import android.view.View
 
-open class NoUnderlineURLSpan(
-    url: String
-) : URLSpan(url) {
+open class NoUnderlineURLSpan constructor(val url: String) : URLSpan(url) {
+
+    // This should not be necessary. But if you don't do this the [StatusLengthTest] tests
+    // fail. Without this, accessing the `url` property, or calling `getUrl()` (which should
+    // automatically call through to [UrlSpan.getURL]) returns null.
+    override fun getURL(): String {
+        return url
+    }
 
     override fun updateDrawState(ds: TextPaint) {
         super.updateDrawState(ds)
@@ -32,3 +37,8 @@ open class NoUnderlineURLSpan(
         view.context.openLink(url)
     }
 }
+
+/**
+ * Mentions of other users ("@user@example.org")
+ */
+open class MentionSpan(url: String) : NoUnderlineURLSpan(url)

--- a/app/src/main/java/com/keylesspalace/tusky/util/SpanUtils.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/SpanUtils.kt
@@ -131,6 +131,7 @@ private fun getSpan(matchType: FoundMatchType, string: String, colour: Int, star
     return when (matchType) {
         FoundMatchType.HTTP_URL -> NoUnderlineURLSpan(string.substring(start, end))
         FoundMatchType.HTTPS_URL -> NoUnderlineURLSpan(string.substring(start, end))
+        FoundMatchType.MENTION -> MentionSpan(string.substring(start, end))
         else -> ForegroundColorSpan(colour)
     }
 }

--- a/app/src/test/java/com/keylesspalace/tusky/SpanUtilsTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/SpanUtilsTest.kt
@@ -136,7 +136,7 @@ class SpanUtilsTest {
         }
 
         override fun <T : Any> getSpans(start: Int, end: Int, type: Class<T>): Array<T> {
-            return spans.filter { it.start >= start && it.end <= end && type.isInstance(it) }
+            return spans.filter { it.start >= start && it.end <= end && type.isInstance(it.span) }
                 .map { it.span }
                 .toTypedArray() as Array<T>
         }

--- a/app/src/test/java/com/keylesspalace/tusky/components/compose/ComposeActivity/ComposeActivityTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/compose/ComposeActivity/ComposeActivityTest.kt
@@ -1,4 +1,5 @@
-/* Copyright 2018 charlag
+/*
+ * Copyright 2018 Tusky Contributors
  *
  * This file is a part of Tusky.
  *
@@ -11,15 +12,17 @@
  * Public License for more details.
  *
  * You should have received a copy of the GNU General Public License along with Tusky; if not,
- * see <http://www.gnu.org/licenses>. */
+ * see <http://www.gnu.org/licenses>.
+ */
 
-package com.keylesspalace.tusky
+package com.keylesspalace.tusky.components.compose.ComposeActivity
 
 import android.content.Intent
 import android.os.Looper.getMainLooper
 import android.widget.EditText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import at.connyduck.calladapter.networkresult.NetworkResult
+import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.components.compose.ComposeActivity
 import com.keylesspalace.tusky.components.compose.ComposeViewModel
 import com.keylesspalace.tusky.components.instanceinfo.InstanceInfoRepository

--- a/app/src/test/java/com/keylesspalace/tusky/components/compose/ComposeActivity/StatusLengthTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/compose/ComposeActivity/StatusLengthTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 Tusky Contributors
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package com.keylesspalace.tusky.components.compose.ComposeActivity
+
+import com.keylesspalace.tusky.SpanUtilsTest
+import com.keylesspalace.tusky.components.compose.ComposeActivity
+import com.keylesspalace.tusky.util.highlightSpans
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class StatusLengthTest(
+    private val text: String,
+    private val expectedLength: Int
+) {
+    companion object {
+        @Parameterized.Parameters(name = "{0}")
+        @JvmStatic
+        fun data(): Iterable<Any> {
+            return listOf(
+                arrayOf("", 0),
+                arrayOf(" ", 1),
+                arrayOf("123", 3),
+                // "@user@server" should be treated as "@user"
+                arrayOf("123 @example@example.org", 12),
+                // URLs under 23 chars are treated as 23 chars
+                arrayOf("123 http://example.url", 27),
+                // URLs over 23 chars are treated as 23 chars
+                arrayOf("123 http://urlthatislongerthan23characters.example.org", 27),
+                // Short hashtags are treated as is
+                arrayOf("123 #basictag", 13),
+                // Long hashtags are *also* treated as is (not treated as 23, like URLs)
+                arrayOf("123 #atagthatislongerthan23characters", 37)
+            )
+        }
+    }
+
+    @Test
+    fun statusLength_matchesExpectations() {
+        val spannedText = SpanUtilsTest.FakeSpannable(text)
+        highlightSpans(spannedText, 0)
+
+        Assert.assertEquals(
+            expectedLength,
+            ComposeActivity.statusLength(spannedText, null, 23)
+        )
+    }
+
+    @Test
+    fun statusLength_withCwText_matchesExpectations() {
+        val spannedText = SpanUtilsTest.FakeSpannable(text)
+        highlightSpans(spannedText, 0)
+
+        val cwText = SpanUtilsTest.FakeSpannable(
+            "a @example@example.org #hashtagmention and http://example.org URL"
+        )
+        Assert.assertEquals(
+            expectedLength + cwText.length,
+            ComposeActivity.statusLength(spannedText, cwText, 23)
+        )
+    }
+}

--- a/app/src/test/java/com/keylesspalace/tusky/components/compose/ComposeActivity/StatusLengthTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/compose/ComposeActivity/StatusLengthTest.kt
@@ -20,7 +20,7 @@ package com.keylesspalace.tusky.components.compose.ComposeActivity
 import com.keylesspalace.tusky.SpanUtilsTest
 import com.keylesspalace.tusky.components.compose.ComposeActivity
 import com.keylesspalace.tusky.util.highlightSpans
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -57,7 +57,7 @@ class StatusLengthTest(
         val spannedText = SpanUtilsTest.FakeSpannable(text)
         highlightSpans(spannedText, 0)
 
-        Assert.assertEquals(
+        assertEquals(
             expectedLength,
             ComposeActivity.statusLength(spannedText, null, 23)
         )
@@ -71,7 +71,7 @@ class StatusLengthTest(
         val cwText = SpanUtilsTest.FakeSpannable(
             "a @example@example.org #hashtagmention and http://example.org URL"
         )
-        Assert.assertEquals(
+        assertEquals(
             expectedLength + cwText.length,
             ComposeActivity.statusLength(spannedText, cwText, 23)
         )

--- a/app/src/test/java/com/keylesspalace/tusky/components/compose/ComposeTokenizer/ComposeTokenizerTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/compose/ComposeTokenizer/ComposeTokenizerTest.kt
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License along with Tusky; if not,
  * see <http://www.gnu.org/licenses>. */
 
-package com.keylesspalace.tusky
+package com.keylesspalace.tusky.components.compose.ComposeTokenizer
 
 import com.keylesspalace.tusky.components.compose.ComposeTokenizer
 import org.junit.Assert


### PR DESCRIPTION
In a status with a mention ("@foo@example.org") only the "@foo" part should be included in the calculated status length. It wasn't, so the app was preventing people from posting statuses that should have been allowed.

Fix this.

- Lift the length calculation code in to a separate static function (easier and faster to test)
- Add a `MentionSpan` type, to reuse existing code for detecting mentions
- Fix a bug in `FakeSpannable.getSpans()` (it was returning the outer type, not the wrapped inner span)
- Add additional fast tests

The tests made sense under the `components.compose.ComposeActivity` package, so I also created that and moved the existing ComposeActivity tests there.

Fixes https://github.com/tuskyapp/Tusky/issues/3339