### PR TITLE
include card and collapsed state in instant expanded change

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
@@ -159,7 +159,7 @@ public class StatusDetailedViewHolder extends StatusBaseViewHolder {
                 status;
 
         super.setupWithStatus(uncollapsedStatus, listener, statusDisplayOptions, payloads);
-        setupCard(uncollapsedStatus, CardViewMode.FULL_WIDTH, statusDisplayOptions, listener); // Always show card for detailed status
+        setupCard(uncollapsedStatus, status.isExpanded(), CardViewMode.FULL_WIDTH, statusDisplayOptions, listener); // Always show card for detailed status
         if (payloads == null) {
             Status actionable = uncollapsedStatus.getActionable();
 

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusViewHolder.java
@@ -60,7 +60,10 @@ public class StatusViewHolder extends StatusBaseViewHolder {
                                 @Nullable Object payloads) {
         if (payloads == null) {
 
-            setupCollapsedState(status, listener);
+            boolean sensitive = !TextUtils.isEmpty(status.getActionable().getSpoilerText());
+            boolean expanded = status.isExpanded();
+
+            setupCollapsedState(sensitive, expanded, status, listener);
 
             Status reblogging = status.getRebloggingStatus();
             if (reblogging == null) {
@@ -74,7 +77,6 @@ public class StatusViewHolder extends StatusBaseViewHolder {
 
         }
         super.setupWithStatus(status, listener, statusDisplayOptions, payloads);
-
     }
 
     private void setRebloggedByDisplayName(final CharSequence name,
@@ -103,9 +105,12 @@ public class StatusViewHolder extends StatusBaseViewHolder {
         statusInfo.setVisibility(View.GONE);
     }
 
-    private void setupCollapsedState(final StatusViewData.Concrete status, final StatusActionListener listener) {
+    private void setupCollapsedState(boolean sensitive,
+                                     boolean expanded,
+                                     final StatusViewData.Concrete status,
+                                     final StatusActionListener listener) {
         /* input filter for TextViews have to be set before text */
-        if (status.isCollapsible() && (status.isExpanded() || TextUtils.isEmpty(status.getSpoilerText()))) {
+        if (status.isCollapsible() && (!sensitive || expanded)) {
             contentCollapseButton.setOnClickListener(view -> {
                 int position = getBindingAdapterPosition();
                 if (position != RecyclerView.NO_POSITION)
@@ -129,5 +134,17 @@ public class StatusViewHolder extends StatusBaseViewHolder {
     public void showStatusContent(boolean show) {
         super.showStatusContent(show);
         contentCollapseButton.setVisibility(show ? View.VISIBLE : View.GONE);
+    }
+
+    @Override
+    protected void toggleExpandedState(boolean sensitive,
+                                       boolean expanded,
+                                       @NonNull StatusViewData.Concrete status,
+                                       @NonNull StatusDisplayOptions statusDisplayOptions,
+                                       @NonNull final StatusActionListener listener) {
+
+        setupCollapsedState(sensitive, expanded, status, listener);
+
+        super.toggleExpandedState(sensitive, expanded, status, statusDisplayOptions, listener);
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationViewHolder.java
@@ -36,7 +36,6 @@ import com.keylesspalace.tusky.interfaces.StatusActionListener;
 import com.keylesspalace.tusky.util.ImageLoadingHelper;
 import com.keylesspalace.tusky.util.SmartLengthInputFilter;
 import com.keylesspalace.tusky.util.StatusDisplayOptions;
-import com.keylesspalace.tusky.viewdata.PollViewDataKt;
 import com.keylesspalace.tusky.viewdata.StatusViewData;
 
 import java.util.List;
@@ -110,9 +109,7 @@ public class ConversationViewHolder extends StatusBaseViewHolder {
             setupButtons(listener, account.getId(), statusViewData.getContent().toString(),
                     statusDisplayOptions);
 
-            setSpoilerAndContent(statusViewData.isExpanded(), statusViewData.getContent(), status.getSpoilerText(),
-                    status.getMentions(), status.getTags(), status.getEmojis(),
-                    PollViewDataKt.toViewData(status.getPoll()), statusDisplayOptions, listener);
+            setSpoilerAndContent(statusViewData, statusDisplayOptions, listener);
 
             setConversationName(conversation.getAccounts());
 


### PR DESCRIPTION
When the spoiler warning is toggled, we update the ViewHolder immediately, but until now the "show more/less" button of collapsible posts and the link preview card were not included in this immediate update. The subsequent update through the rebinding of the ViewHolder sets their state correctly but a weird two step animation occurs, were first the post content is shown/hidden, and in a second step the card. This always felt extremely glitchy to me, I'm glad I could fix it.

Here you can see the glitch but it happens very quickly:
https://user-images.githubusercontent.com/10157047/221639655-03a56165-69b2-4dd9-b15c-a74643e0828b.mp4

I also experimented with removing the immediate updates completly and relying on the adapter rebind entirely, but that makes it feel a bit laggy so I went this way.

