### PR TITLE
Lazily load activities in Robolectric tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,6 +72,7 @@ android {
         }
         unitTests.all {
             systemProperty 'robolectric.logging.enabled', 'true'
+            systemProperty 'robolectric.lazyload', 'ON'
         }
     }
     sourceSets {


### PR DESCRIPTION
Not all Robolectric tests interact with activities, so lazy loading the activity can speed them up.

I benchmarked the impact with gradle-profiler. Each test run performed 6 warmup runs, and then 10 benchmarked runs with and without this change.

Without this change (all values rounded to nearest second):
Mean: 151
Median: 149
P75: 157
StdDev: 10

With this change:
Mean: 127
Median: 125
P75: 130
StdDev: 7

So a ~ 18% reduction in median and P75 times,