### PR TITLE
Enable parallel GC for Gradle builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+# If jvmargs is changed then the default values must also be included, see https://github.com/gradle/gradle/issues/19750
+org.gradle.jvmargs=XX:+UseParallelGC -Xmx4g -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError -Xms256m
 # use parallel execution
 org.gradle.parallel=true
 # https://docs.gradle.org/7.6/userguide/configuration_cache.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 # If jvmargs is changed then the default values must also be included, see https://github.com/gradle/gradle/issues/19750
-org.gradle.jvmargs=XX:+UseParallelGC -Xmx4g -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError -Xms256m
+org.gradle.jvmargs=-XX:+UseParallelGC -Xmx4g -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError -Xms256m
 # use parallel execution
 org.gradle.parallel=true
 # https://docs.gradle.org/7.6/userguide/configuration_cache.html


### PR DESCRIPTION
Per https://developer.android.com/studio/build/optimize-your-build#experiment-with-the-jvm-parallel-garbage-collector

I benchmarked this, and p75 incremental build time dropped from 33s to 30s.

https://github.com/gradle/gradle/issues/19750 means that if `org.gradle.jvmargs` is set any unchanged default values are lost, so include those too.