### PR TITLE
Show reblog/favourite confirmations as menus not dialogs

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -9,6 +9,7 @@ import android.graphics.drawable.Drawable;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
+import android.view.Menu;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
@@ -21,7 +22,7 @@ import android.widget.Toast;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.widget.PopupMenu;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.core.content.ContextCompat;
 import androidx.core.text.HtmlCompat;
@@ -74,6 +75,8 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
     public static class Key {
         public static final String KEY_CREATED = "created";
     }
+
+    private final String TAG = "StatusBaseViewHolder";
 
     private final TextView displayName;
     private final TextView username;
@@ -627,7 +630,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                 int position = getBindingAdapterPosition();
                 if (position != RecyclerView.NO_POSITION) {
                     if (statusDisplayOptions.confirmReblogs()) {
-                        showConfirmReblogDialog(listener, statusContent, buttonState, position);
+                        showConfirmReblog(listener, buttonState, position);
                         return false;
                     } else {
                         listener.onReblog(!buttonState, position);
@@ -644,7 +647,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             int position = getBindingAdapterPosition();
             if (position != RecyclerView.NO_POSITION) {
                 if (statusDisplayOptions.confirmFavourites()) {
-                    showConfirmFavouriteDialog(listener, statusContent, buttonState, position);
+                    showConfirmFavourite(listener, buttonState, position);
                     return false;
                 } else {
                     listener.onFavourite(!buttonState, position);
@@ -683,38 +686,46 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         itemView.setOnClickListener(viewThreadListener);
     }
 
-    private void showConfirmReblogDialog(StatusActionListener listener,
-                                         String statusContent,
-                                         boolean buttonState,
-                                         int position) {
-        int okButtonTextId = buttonState ? R.string.action_unreblog : R.string.action_reblog;
-        new AlertDialog.Builder(reblogButton.getContext())
-                .setMessage(statusContent)
-                .setPositiveButton(okButtonTextId, (__, ___) -> {
-                    listener.onReblog(!buttonState, position);
-                    if (!buttonState) {
-                        // Play animation only when it's reblog, not unreblog
-                        reblogButton.playAnimation();
-                    }
-                })
-                .show();
+    private void showConfirmReblog(StatusActionListener listener,
+                                   boolean buttonState,
+                                   int position) {
+        PopupMenu popup = new PopupMenu(itemView.getContext(), reblogButton);
+        popup.inflate(R.menu.status_reblog);
+        Menu menu = popup.getMenu();
+        if (buttonState) {
+            menu.findItem(R.id.menu_action_reblog).setVisible(false);
+        } else {
+            menu.findItem(R.id.menu_action_unreblog).setVisible(false);
+        }
+        popup.setOnMenuItemClickListener(item -> {
+            listener.onReblog(!buttonState, position);
+            if(!buttonState) {
+                reblogButton.playAnimation();
+            }
+            return true;
+        });
+        popup.show();
     }
 
-    private void showConfirmFavouriteDialog(StatusActionListener listener,
-                                            String statusContent,
-                                            boolean buttonState,
-                                            int position) {
-        int okButtonTextId = buttonState ? R.string.action_unfavourite : R.string.action_favourite;
-        new AlertDialog.Builder(favouriteButton.getContext())
-                .setMessage(statusContent)
-                .setPositiveButton(okButtonTextId, (__, ___) -> {
-                    listener.onFavourite(!buttonState, position);
-                    if (!buttonState) {
-                        // Play animation only when it's favourite, not unfavourite
-                        favouriteButton.playAnimation();
-                    }
-                })
-                .show();
+    private void showConfirmFavourite(StatusActionListener listener,
+                                      boolean buttonState,
+                                      int position) {
+        PopupMenu popup = new PopupMenu(itemView.getContext(), favouriteButton);
+        popup.inflate(R.menu.status_favourite);
+        Menu menu = popup.getMenu();
+        if (buttonState) {
+            menu.findItem(R.id.menu_action_favourite).setVisible(false);
+        } else {
+            menu.findItem(R.id.menu_action_unfavourite).setVisible(false);
+        }
+        popup.setOnMenuItemClickListener(item -> {
+            listener.onFavourite(!buttonState, position);
+            if(!buttonState) {
+                favouriteButton.playAnimation();
+            }
+            return true;
+        });
+        popup.show();
     }
 
     public void setupWithStatus(StatusViewData.Concrete status, final StatusActionListener listener,

--- a/app/src/main/res/menu/status_favourite.xml
+++ b/app/src/main/res/menu/status_favourite.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/menu_action_favourite"
+        android:icon="@drawable/ic_favourite_24dp"
+        android:title="@string/action_favourite" />
+    <item
+        android:id="@+id/menu_action_unfavourite"
+        android:icon="@drawable/ic_favourite_24dp"
+        android:title="@string/action_unfavourite" />
+</menu>

--- a/app/src/main/res/menu/status_reblog.xml
+++ b/app/src/main/res/menu/status_reblog.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/menu_action_reblog"
+        android:icon="@drawable/ic_reblog_24dp"
+        android:title="@string/action_reblog" />
+    <item
+        android:id="@+id/menu_action_unreblog"
+        android:icon="@drawable/ic_reblog_24dp"
+        android:title="@string/action_unreblog" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -675,8 +675,8 @@
     <string name="warning_scheduling_interval">Mastodon has a minimum scheduling interval of 5 minutes.</string>
     <string name="pref_title_show_self_username">Show username in toolbars</string>
     <string name="pref_title_show_cards_in_timelines">Show link previews in timelines</string>
-    <string name="pref_title_confirm_reblogs">Show confirmation dialog before boosting</string>
-    <string name="pref_title_confirm_favourites">Show confirmation dialog before favoriting</string>
+    <string name="pref_title_confirm_reblogs">Show confirmation before boosting</string>
+    <string name="pref_title_confirm_favourites">Show confirmation before favoriting</string>
     <string name="pref_title_hide_top_toolbar">Hide the title of the top toolbar</string>
     <string name="pref_title_wellbeing_mode">Wellbeing</string>
     <string name="account_note_hint">Your private note about this account</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -89,6 +89,8 @@
         <item name="chipStyle">@style/Widget.MaterialComponents.Chip.Choice</item>
 
         <item name="preferenceTheme">@style/TuskyPreferenceTheme</item>
+
+        <item name="popupMenuStyle">@style/PopupMenu</item>
     </style>
 
     <style name="ViewMediaActivity.AppBarLayout" parent="ThemeOverlay.AppCompat">
@@ -185,4 +187,7 @@
         <item name="cornerSize">12.5%</item>
     </style>
 
+    <style name="PopupMenu" parent="@style/Widget.AppCompat.PopupMenu">
+        <item name="overlapAnchor">true</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -89,8 +89,6 @@
         <item name="chipStyle">@style/Widget.MaterialComponents.Chip.Choice</item>
 
         <item name="preferenceTheme">@style/TuskyPreferenceTheme</item>
-
-        <item name="popupMenuStyle">@style/PopupMenu</item>
     </style>
 
     <style name="ViewMediaActivity.AppBarLayout" parent="ThemeOverlay.AppCompat">
@@ -185,9 +183,5 @@
     <style name="ShapeAppearance.Avatar" parent="ShapeAppearance.MaterialComponents">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">12.5%</item>
-    </style>
-
-    <style name="PopupMenu" parent="@style/Widget.AppCompat.PopupMenu">
-        <item name="overlapAnchor">true</item>
     </style>
 </resources>


### PR DESCRIPTION
The previous code used dialogs and displayed the text of the status when reblogging or favouriting.

This didn't work when the post just contained images, and other material from the status (content warning, polls) was not shown either.

Fix this by displaying a popup menu instead. The status remains visible so the user can clearly see what they're acting on.

In addition, this lays the groundwork for supporting a long-press menu in the future to allow the user to reblog/favourite from a different account.

Fixes https://github.com/tuskyapp/Tusky/issues/3308