### PR TITLE
Fix UI error, return the actual error body as a string

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsPagingSource.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsPagingSource.kt
@@ -58,7 +58,7 @@ class NotificationsPagingSource @Inject constructor(
             }
 
             if (!response.isSuccessful) {
-                return LoadResult.Error(Throwable(response.errorBody().toString()))
+                return LoadResult.Error(Throwable(response.errorBody()?.string()))
             }
 
             val links = getPageLinks(response.headers()["link"])


### PR DESCRIPTION
The previous code returned the text representation of the error body type, which resulted in errors appearing in the UI as:

```
okhttp3.ResponseBody$Companion$asResponseBody$1@...
```

This code actually converts the *body* of the error response to a string, so the error is displayed correctly.