### PR TITLE
3435: Have loading progress visible

### DIFF
--- a/app/src/main/res/layout/fragment_view_thread.xml
+++ b/app/src/main/res/layout/fragment_view_thread.xml
@@ -4,34 +4,34 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-        android:id="@+id/swipeRefreshLayout"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
+        android:orientation="vertical">
 
-        <LinearLayout
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+            android:id="@+id/threadProgressBar"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical">
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            android:indeterminate="true"
+            android:contentDescription="@string/a11y_label_loading_thread" />
+
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/swipeRefreshLayout"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/recyclerView"
                 android:layout_width="match_parent"
-                android:layout_height="0dp"
-                android:layout_weight="1"
+                android:layout_height="match_parent"
                 android:background="?android:attr/colorBackground"
                 android:scrollbars="vertical" />
-
-            <com.google.android.material.progressindicator.LinearProgressIndicator
-                android:id="@+id/threadProgressBar"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:visibility="gone"
-                android:indeterminate="true"
-                android:contentDescription="@string/a11y_label_loading_thread" />
-        </LinearLayout>
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+    </LinearLayout>
 
     <ProgressBar
         android:id="@+id/initialProgressBar"


### PR DESCRIPTION
Fixes https://github.com/tuskyapp/Tusky/issues/3435

This especially moves the progress bar to the top (where I would have expected it anyway).

I only wonder if this is the only location where we have a progress display like this?
The circular ones are all only for empty lists?