### PR TITLE
RFC: Try to (also) provide notifications for the list from a simple list

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/appstore/Events.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/appstore/Events.kt
@@ -2,6 +2,7 @@ package com.keylesspalace.tusky.appstore
 
 import com.keylesspalace.tusky.TabData
 import com.keylesspalace.tusky.entity.Account
+import com.keylesspalace.tusky.entity.Notification
 import com.keylesspalace.tusky.entity.Poll
 import com.keylesspalace.tusky.entity.Status
 
@@ -23,3 +24,4 @@ data class PollVoteEvent(val statusId: String, val poll: Poll) : Event
 data class DomainMuteEvent(val instance: String) : Event
 data class AnnouncementReadEvent(val announcementId: String) : Event
 data class PinEvent(val statusId: String, val pinned: Boolean) : Event
+data class NewNotificationsEvent(val accountId: String, val notifications: List<Notification>) : Event

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsStaticPagingSource.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsStaticPagingSource.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Tusky Contributors
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package com.keylesspalace.tusky.components.notifications
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.keylesspalace.tusky.viewdata.NotificationViewData
+import javax.inject.Inject
+
+class NotificationsStaticPagingSource @Inject constructor(
+    private val notifications: List<NotificationViewData>
+) : PagingSource<String, NotificationViewData>() {
+    override suspend fun load(params: LoadParams<String>): LoadResult<String, NotificationViewData> {
+            return LoadResult.Page(
+                notifications, null, null
+            )
+    }
+
+    override fun getRefreshKey(state: PagingState<String, NotificationViewData>): String? {
+        return null
+    }
+
+    companion object {
+        private const val TAG = "NotificationsStaticPagingSource"
+    }
+}


### PR DESCRIPTION
Well more like a "request for pointers to the right concepts".

I tried to integrate notifications coming in via the fetcher to the normal notifications timeline (if open).

However I'm struggling again mightily with paging sources (and /or the data flow surrounding them).

Where would I put in "other notifications" which are not coming from the current NotificationsPagingSource?
Currently I would guess that I need a "combining source" (is that a Mediator?).