### PR TITLE
#2528: Also clear notifications on refresh in notifications timeline

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
@@ -444,6 +444,7 @@ class NotificationsFragment :
     override fun onRefresh() {
         binding.progressBar.isVisible = false
         adapter.refresh()
+        NotificationHelper.clearNotificationsForActiveAccount(requireContext(), accountManager)
     }
 
     override fun onPause() {


### PR DESCRIPTION
This one's missing.

(Be on notifications timeline, get bing of new notifications, refresh should be the same as resume.)