### PR TITLE
Do not crash on empty relationship response

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountViewModel.kt
@@ -85,7 +85,7 @@ class AccountViewModel @Inject constructor(
                 mastodonApi.relationships(listOf(accountId))
                     .fold(
                         { relationships ->
-                            relationshipData.postValue(Success(relationships[0]))
+                            relationshipData.postValue(if (relationships.isNotEmpty()) Success(relationships[0]) else Error())
                         },
                         { t ->
                             Log.w(TAG, "failed obtaining relationships", t)


### PR DESCRIPTION
Found while looking at Google crash reports.

I checked a few other "[0]" in the code. Most are guarded by a "isNotEmpty" but some are not.
For example in `searchAutocompleteSuggestions`.