### PR TITLE
Disable wildcard imports for Java and Kotlin files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,5 +7,11 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+# Disable wildcard imports
+[*.{java, kt}]
+ij_kotlin_name_count_to_use_star_import = 999
+ij_kotlin_name_count_to_use_star_import_for_members = 999
+ij_java_class_count_to_use_import_on_demand = 999
+
 [*.{yml,yaml}]
 indent_size = 2


### PR DESCRIPTION
Out-of-the-box Android Studio will perform wildcard imports if the import list is >= 3. This is a lint failure.

Adjust the default to 999 so that, in practice, wildcard imports never happen.