### PR TITLE
Disable lint checks for unused resource IDs

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -24,6 +24,12 @@
          a noun and a verb -->
     <issue id="DuplicateStrings" severity="ignore" />
 
+    <!-- Resource IDs used in viewbinding are incorrectly reported as unused,
+         https://issuetracker.google.com/issues/204797401.
+
+         Disable these for the time being. -->
+    <issue id="UnusedIds" severity="ignore" />
+    
     <!-- Ensure we are warned about errors in the baseline -->
     <issue id="LintBaseline" severity="warning" />
 


### PR DESCRIPTION
The check doesn't catch some instances where resources are used through viewbinding, and has too many false positives to be useful.