### PR TITLE
#3430: (fix) do not hide the anchor of the FAB

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersActivity.kt
@@ -82,7 +82,6 @@ class FiltersActivity : BaseActivity(), FiltersListener {
                         } else {
                             binding.messageView.hide()
                             binding.filtersList.adapter = FiltersAdapter(this@FiltersActivity, state.filters)
-                            binding.filtersList.show()
                         }
                     }
                 }
@@ -91,7 +90,6 @@ class FiltersActivity : BaseActivity(), FiltersListener {
     }
 
     private fun loadFilters() {
-        binding.filtersList.hide()
         viewModel.load()
     }
 


### PR DESCRIPTION
On Account preferences > Filters

With the list hidden on an empty view the FAB is erroneouly placed on the top left of the screen.

(Introduced with #3430)