### PR TITLE
#3562: Only allow the view pager if it makes sense

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
@@ -82,6 +82,7 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
     private var attachments: ArrayList<AttachmentViewData>? = null
     private val toolbarVisibilityListeners = mutableListOf<ToolbarVisibilityListener>()
     private var imageUrl: String? = null
+    private var hasMultiple: Boolean = false
 
     fun addToolbarVisibilityListener(listener: ToolbarVisibilityListener): Function0<Boolean> {
         this.toolbarVisibilityListeners.add(listener)
@@ -113,6 +114,8 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
             SingleImagePagerAdapter(this, imageUrl!!)
         }
 
+        hasMultiple = attachments != null && attachments!!.size > 1
+
         binding.viewPager.adapter = adapter
         binding.viewPager.setCurrentItem(initialPosition, false)
         binding.viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
@@ -120,6 +123,7 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
                 binding.toolbar.title = getPageTitle(position)
             }
         })
+        binding.viewPager.isUserInputEnabled = hasMultiple
 
         // Setup the toolbar.
         setSupportActionBar(binding.toolbar)
@@ -193,6 +197,16 @@ class ViewMediaActivity : BaseActivity(), ViewImageFragment.PhotoActionsListener
                 }
             })
             .start()
+    }
+
+    override fun onZoom(zoomFactor: Float) {
+        // If the view pager is (input) enabled it will grab most interaction at the device edges; this disturbs zooming or dragging
+
+        if (zoomFactor > 1.01) {
+            binding.viewPager.isUserInputEnabled = false
+        } else {
+            binding.viewPager.isUserInputEnabled = hasMultiple
+        }
     }
 
     private fun getPageTitle(position: Int): CharSequence {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewImageFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewImageFragment.kt
@@ -45,6 +45,7 @@ class ViewImageFragment : ViewMediaFragment() {
         fun onBringUp()
         fun onDismiss()
         fun onPhotoTap()
+        fun onZoom(zoomFactor: Float)
     }
 
     private var _binding: FragmentViewImageBinding? = null
@@ -124,6 +125,10 @@ class ViewImageFragment : ViewMediaFragment() {
                     result = true
                 }
                 result
+            }
+
+            setOnScaleChangeListener { scaleFactor, _, _ ->
+                photoActionsListener.onZoom(scale) // TODO at least for the first call here during pinch zoom only scaleFactor is different; "scale" is still 1
             }
         }
 


### PR DESCRIPTION
Concerns #3562

Disable the view pager (gesture input) when an image is zoomed.

This is only a draft (or RFC): The enabling and disabling of the view pager is quite hack-ish.
It works better with this but not perfect on my device.
(What happens if for example the behavior/contract of "isUserInputEnabled changes or behaves slightly different on different devices?)

Especially there is and always will be a conflict between 2 to 3 parties here:
- The view pager wants to switch pages (and also highlight what it will do starting with very small finger movements)
- The photo view wants to pinch zoom and move the zoomed image around; also a negative pinch zoom might dismiss it
- We want to add the dismiss feature for swiping down