### PR TITLE
Set Notifications page size to 15

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsRepository.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsRepository.kt
@@ -71,6 +71,6 @@ class NotificationsRepository @Inject constructor(
 
     companion object {
         private const val TAG = "NotificationsRepository"
-        private const val PAGE_SIZE = 30
+        private const val PAGE_SIZE = 15
     }
 }


### PR DESCRIPTION
This should balance loading enough notifications to allow the user to immediately start scrolling through them, without loading so many notifications that the server is slow to respond.

Fixes https://github.com/tuskyapp/Tusky/issues/3578