### PR TITLE
Show filter title instead of filter keywords

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -828,8 +828,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
         for (FilterResult result : status.getActionable().getFiltered()) {
             Filter filter = result.getFilter();
-            List<String> keywords = result.getKeywordMatches();
-            if (filter.getAction() == Filter.Action.WARN && !keywords.isEmpty()) {
+            if (filter.getAction() == Filter.Action.WARN) {
                 matchedFilter = filter;
                 break;
             }

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -824,18 +824,18 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
         showFilteredPlaceholder(true);
 
-        String matchedKeyword = null;
+        Filter matchedFilter = null;
 
         for (FilterResult result : status.getActionable().getFiltered()) {
             Filter filter = result.getFilter();
             List<String> keywords = result.getKeywordMatches();
             if (filter.getAction() == Filter.Action.WARN && !keywords.isEmpty()) {
-                matchedKeyword = keywords.get(0);
+                matchedFilter = filter;
                 break;
             }
         }
 
-        filteredPlaceholderLabel.setText(itemView.getContext().getString(R.string.status_filter_placeholder_label_format, matchedKeyword));
+        filteredPlaceholderLabel.setText(itemView.getContext().getString(R.string.status_filter_placeholder_label_format, matchedFilter.getTitle()));
         filteredPlaceholderShowButton.setOnClickListener(view -> {
             listener.clearWarningAction(getBindingAdapterPosition());
         });


### PR DESCRIPTION
Avoid showing the user the things they have filtered on when showing a filter placeholder in a timeline.

Fixes https://github.com/tuskyapp/Tusky/issues/3587