### PR TITLE
fix crash in NotificationsFragment

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
@@ -211,7 +211,9 @@ class NotificationsFragment :
             override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
                 if (positionStart == 0 && adapter.itemCount != itemCount) {
                     binding.recyclerView.post {
-                        binding.recyclerView.scrollBy(0, Utils.dpToPx(requireContext(), -30))
+                        if (getView() != null) {
+                            binding.recyclerView.scrollBy(0, Utils.dpToPx(requireContext(), -30))
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Found in Google Play crash reports

same fix we have in TimelineFragment

```
Exception java.lang.IllegalStateException: Can't access the Fragment View's LifecycleOwner when getView() is null i.e., before onCreateView() or after onDestroyView()
  at androidx.fragment.app.Fragment.getViewLifecycleOwner (Fragment.java:380)
  at com.keylesspalace.tusky.util.FragmentViewBindingDelegate.getValue (ViewBindingExtensions.kt:60)
  at com.keylesspalace.tusky.components.notifications.NotificationsFragment.getBinding (NotificationsFragment.kt)
  at com.keylesspalace.tusky.components.notifications.NotificationsFragment.access$getBinding (NotificationsFragment.kt:82)
  at com.keylesspalace.tusky.components.notifications.NotificationsFragment$onViewCreated$7.onItemRangeInserted$lambda$0 (NotificationsFragment.java:214)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:201)
  at android.os.Looper.loop (Looper.java:288)
  at android.app.ActivityThread.main (ActivityThread.java:7884)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:548)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:936)
```