### PR TITLE
Add additional margin after the "X <performed an action>" view

### DIFF
--- a/app/src/main/res/layout/item_status_notification.xml
+++ b/app/src/main/res/layout/item_status_notification.xml
@@ -51,6 +51,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="14dp"
+        android:layout_marginTop="6dp"
         android:ellipsize="end"
         android:maxLines="1"
         android:paddingStart="0dp"
@@ -78,19 +79,18 @@
         android:textSize="?attr/status_text_medium"
         app:layout_constraintEnd_toStartOf="@id/status_meta_info"
         app:layout_constraintStart_toEndOf="@id/status_display_name"
-        app:layout_constraintTop_toBottomOf="@id/notification_top_text"
+        app:layout_constraintTop_toTopOf="@+id/status_display_name"
         tools:text="\@Entenhausen" />
 
     <TextView
         android:id="@+id/status_meta_info"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="4dp"
         android:paddingBottom="4dp"
         android:textColor="?android:textColorTertiary"
         android:textSize="?attr/status_text_medium"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/notification_top_text"
+        app:layout_constraintTop_toTopOf="@+id/status_username"
         tools:text="13:37" />
 
     <com.keylesspalace.tusky.view.ClickableSpanTextView


### PR DESCRIPTION
Add additional 6dp margin to the top of the username view, to provide more space after the "X <performed an action>" view, consistent with item_follow.xml and previous iterations of this layout.