### PR TITLE
Set initialLoadSize = pageSize

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsRepository.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsRepository.kt
@@ -53,7 +53,7 @@ class NotificationsRepository @Inject constructor(
         }
 
         return Pager(
-            config = PagingConfig(pageSize = pageSize),
+            config = PagingConfig(pageSize = pageSize, initialLoadSize = pageSize),
             initialKey = initialKey,
             pagingSourceFactory = factory!!
         ).flow


### PR DESCRIPTION
The pageSize is large enough that there's no need for the default 3 x pageSize initialLoadSize value, and this improves performance.

Fixes https://github.com/tuskyapp/Tusky/issues/3578