### PR TITLE
fix reporting

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -677,7 +677,7 @@ interface MastodonApi {
 
     @FormUrlEncoded
     @POST("api/v1/reports")
-    fun report(
+    suspend fun report(
         @Field("account_id") accountId: String,
         @Field("status_ids[]") statusIds: List<String>,
         @Field("comment") comment: String,


### PR DESCRIPTION
without the `suspend` it throws `android.os.NetworkOnMainThreadException`

relevant for #3551 