### PR TITLE
fix crash in ViewThreadFragment.removeItem

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadFragment.kt
@@ -416,13 +416,14 @@ class ViewThreadFragment :
     }
 
     public override fun removeItem(position: Int) {
-        val status = adapter.currentList[position]
-        if (status.isDetailed) {
-            // the main status we are viewing is being removed, finish the activity
-            activity?.finish()
-            return
+        adapter.currentList.getOrNull(position)?.let { status ->
+            if (status.isDetailed) {
+                // the main status we are viewing is being removed, finish the activity
+                activity?.finish()
+                return
+            }
+            viewModel.removeStatus(status)
         }
-        viewModel.removeStatus(status)
     }
 
     override fun onVoteInPoll(position: Int, choices: List<Int>) {


### PR DESCRIPTION
from Google Play console

```
Exception java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
  at java.util.ArrayList.get (ArrayList.java:437)
  at java.util.Collections$UnmodifiableList.get (Collections.java:1356)
  at com.keylesspalace.tusky.components.viewthread.ViewThreadFragment.removeItem (ViewThreadFragment.kt:419)
  at com.keylesspalace.tusky.fragment.SFragment$showConfirmDeleteDialog$1$1.invokeSuspend (SFragment.kt:364)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:33)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:106)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:226)
  at android.os.Looper.loop (Looper.java:313)
  at android.app.ActivityThread.main (ActivityThread.java:8663)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:571)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1135)
```