### PR TITLE
updateMarkersWithAuth(): Require DOMAIN header

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
@@ -115,6 +115,7 @@ class NotificationFetcher @Inject constructor(
     private fun fetchNewNotifications(account: AccountEntity): List<Notification> {
         val authHeader = String.format("Bearer %s", account.accessToken)
 
+        Log.d(TAG, "getting notification marker for ${account.fullName}")
         val minId = when (val marker = fetchMarker(authHeader, account)) {
             null -> account.lastNotificationId.takeIf { it != "0" }
             else -> if (account.lastNotificationId.isLessThan(marker.lastReadId)) marker.lastReadId else account.lastNotificationId
@@ -132,8 +133,12 @@ class NotificationFetcher @Inject constructor(
         // in the marker.
         notifications.firstOrNull()?.let {
             val newMarkerId = notifications.first().id
-            Log.d(TAG, "updating notification marker to: $newMarkerId")
-            mastodonApi.updateMarkersWithAuth(authHeader, notificationsLastReadId = newMarkerId)
+            Log.d(TAG, "updating notification marker for ${account.fullName} to: $newMarkerId")
+            mastodonApi.updateMarkersWithAuth(
+                auth = authHeader,
+                domain = account.domain,
+                notificationsLastReadId = newMarkerId
+            )
         }
 
         return notifications
@@ -147,7 +152,7 @@ class NotificationFetcher @Inject constructor(
                 listOf("notifications")
             ).blockingGet()
             val notificationMarker = allMarkers["notifications"]
-            Log.d(TAG, "Fetched marker: $notificationMarker")
+            Log.d(TAG, "Fetched marker for ${account.fullName}: $notificationMarker")
             notificationMarker
         } catch (e: Exception) {
             Log.e(TAG, "Failed to fetch marker", e)

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -156,6 +156,7 @@ interface MastodonApi {
     @POST("api/v1/markers")
     fun updateMarkersWithAuth(
         @Header("Authorization") auth: String,
+        @Header(DOMAIN_HEADER) domain: String,
         @Field("home[last_read_id]") homeLastReadId: String? = null,
         @Field("notifications[last_read_id]") notificationsLastReadId: String? = null
     ): NetworkResult<Unit>


### PR DESCRIPTION
Otherwise markers are updated for the wrong account.

Fixes https://github.com/tuskyapp/Tusky/issues/3658