### PR TITLE
Implement a NotificationId value class for better type safety

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
@@ -9,6 +9,7 @@ import com.keylesspalace.tusky.db.AccountEntity
 import com.keylesspalace.tusky.db.AccountManager
 import com.keylesspalace.tusky.entity.Marker
 import com.keylesspalace.tusky.entity.Notification
+import com.keylesspalace.tusky.entity.NotificationId
 import com.keylesspalace.tusky.network.MastodonApi
 import javax.inject.Inject
 import kotlin.math.min
@@ -36,7 +37,7 @@ class NotificationFetcher @Inject constructor(
                     // Create sorted list of new notifications
                     val notifications = fetchNewNotifications(account)
                         .filter { filterNotification(notificationManager, account, it) }
-                        .sortedWith(compareBy({ it.id.length }, { it.id })) // oldest notifications first
+                        .sortedBy { it.id }
                         .toMutableList()
 
                     // There's a maximum limit on the number of notifications an Android app
@@ -74,7 +75,7 @@ class NotificationFetcher @Inject constructor(
                             account,
                             index == 0
                         )
-                        notificationManager.notify(notification.id, account.id.toInt(), androidNotification)
+                        notificationManager.notify(notification.id.toString(), account.id.toInt(), androidNotification)
                         // Android will rate limit / drop notifications if they're posted too
                         // quickly. There is no indication to the user that this happened.
                         // See https://github.com/tuskyapp/Tusky/pull/3626#discussion_r1192963664
@@ -115,7 +116,7 @@ class NotificationFetcher @Inject constructor(
         val authHeader = String.format("Bearer %s", account.accessToken)
 
         val minId = when (val marker = fetchMarker(authHeader, account)) {
-            null -> account.lastNotificationId.takeIf { it != "0" }
+            null -> account.lastNotificationId.takeIf { it != NotificationId("0") }
             else -> if (marker.lastReadId > account.lastNotificationId) marker.lastReadId else account.lastNotificationId
         }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
@@ -34,6 +34,7 @@ import com.keylesspalace.tusky.appstore.PreferenceChangedEvent
 import com.keylesspalace.tusky.components.timeline.util.ifExpected
 import com.keylesspalace.tusky.db.AccountManager
 import com.keylesspalace.tusky.entity.Notification
+import com.keylesspalace.tusky.entity.NotificationId
 import com.keylesspalace.tusky.entity.Poll
 import com.keylesspalace.tusky.settings.PrefKeys
 import com.keylesspalace.tusky.usecase.TimelineCases
@@ -117,7 +118,7 @@ sealed class InfallibleUiAction : UiAction() {
      * Infallible because if it fails there's nowhere to show the error, and nothing the user
      * can do.
      */
-    data class SaveVisibleId(val visibleId: String) : InfallibleUiAction()
+    data class SaveVisibleId(val visibleId: NotificationId) : InfallibleUiAction()
 }
 
 /** Actions the user can trigger on an individual notification. These may fail. */

--- a/app/src/main/java/com/keylesspalace/tusky/db/AccountEntity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/AccountEntity.kt
@@ -22,6 +22,7 @@ import androidx.room.TypeConverters
 import com.keylesspalace.tusky.TabData
 import com.keylesspalace.tusky.defaultTabs
 import com.keylesspalace.tusky.entity.Emoji
+import com.keylesspalace.tusky.entity.NotificationId
 import com.keylesspalace.tusky.entity.Status
 
 @Entity(
@@ -70,7 +71,7 @@ data class AccountEntity(
      * that media previews are shown as well as downloaded.
      */
     var mediaPreviewEnabled: Boolean = true,
-    var lastNotificationId: String = "0",
+    var lastNotificationId: NotificationId = NotificationId("0"),
     var emojis: List<Emoji> = emptyList(),
     var tabPreferences: List<TabData> = defaultTabs(),
     var notificationsFilter: String = "[\"follow_request\"]",

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Marker.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Marker.kt
@@ -8,7 +8,7 @@ import java.util.Date
  */
 data class Marker(
     @SerializedName("last_read_id")
-    val lastReadId: String,
+    val lastReadId: NotificationId,
     val version: Int,
     @SerializedName("updated_at")
     val updatedAt: Date

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Notification.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Notification.kt
@@ -23,9 +23,20 @@ import com.google.gson.JsonParseException
 import com.google.gson.annotations.JsonAdapter
 import com.keylesspalace.tusky.R
 
+
+@JvmInline
+value class NotificationId(private val s: String) : Comparable<NotificationId>, CharSequence by s {
+    override fun compareTo(other: NotificationId) = compareValuesBy(
+        this,
+        other,
+        { it.s.length },
+        { it.s }
+    )
+}
+
 data class Notification(
     val type: Type,
-    val id: String,
+    val id: NotificationId,
     val account: TimelineAccount,
     val status: Status?,
     val report: Report?

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -34,6 +34,7 @@ import com.keylesspalace.tusky.entity.MastoList
 import com.keylesspalace.tusky.entity.MediaUploadResult
 import com.keylesspalace.tusky.entity.NewStatus
 import com.keylesspalace.tusky.entity.Notification
+import com.keylesspalace.tusky.entity.NotificationId
 import com.keylesspalace.tusky.entity.NotificationSubscribeResult
 import com.keylesspalace.tusky.entity.Poll
 import com.keylesspalace.tusky.entity.Relationship
@@ -156,15 +157,15 @@ interface MastodonApi {
     @POST("api/v1/markers")
     fun updateMarkersWithAuth(
         @Header("Authorization") auth: String,
-        @Field("home[last_read_id]") homeLastReadId: String? = null,
-        @Field("notifications[last_read_id]") notificationsLastReadId: String? = null
+        @Field("home[last_read_id]") homeLastReadId: NotificationId? = null,
+        @Field("notifications[last_read_id]") notificationsLastReadId: NotificationId? = null
     ): NetworkResult<Unit>
 
     @GET("api/v1/notifications")
     fun notificationsWithAuth(
         @Header("Authorization") auth: String,
         @Header(DOMAIN_HEADER) domain: String,
-        @Query("min_id") minId: String?
+        @Query("min_id") minId: NotificationId?
     ): Single<List<Notification>>
 
     @POST("api/v1/notifications/clear")

--- a/app/src/main/java/com/keylesspalace/tusky/viewdata/NotificationViewData.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/viewdata/NotificationViewData.kt
@@ -31,12 +31,13 @@
 package com.keylesspalace.tusky.viewdata
 
 import com.keylesspalace.tusky.entity.Notification
+import com.keylesspalace.tusky.entity.NotificationId
 import com.keylesspalace.tusky.entity.Report
 import com.keylesspalace.tusky.entity.TimelineAccount
 
 data class NotificationViewData(
     val type: Notification.Type,
-    val id: String,
+    val id: NotificationId,
     val account: TimelineAccount,
     var statusViewData: StatusViewData.Concrete?,
     val report: Report?


### PR DESCRIPTION
The new class implements Comparable so it sorts by Mastodon ID order as well.

Does not currently compile, as it needs a newer version of Room (Room 2.5.x does not work with value classes, 2.6.x should), per https://issuetracker.google.com/issues/124624218#comment15

The current Room version is listed at https://developer.android.com/jetpack/androidx/releases/room