### PR TITLE
Save and restore the user's reading position more frequently

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
@@ -41,6 +41,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.SCROLL_STATE_IDLE
 import androidx.recyclerview.widget.SimpleItemAnimator
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
 import at.connyduck.sparkbutton.helpers.Utils
@@ -190,6 +191,18 @@ class NotificationsFragment :
                         }
                     } else if (!fab.isShown) {
                         fab.show()
+                    }
+                }
+            }
+
+            override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                newState != SCROLL_STATE_IDLE && return
+
+                // Save the ID of the first notification visible in the list, so the user's
+                // reading position is always restorable.
+                layoutManager.findFirstVisibleItemPosition().takeIf { it >= 0 }?.let { position ->
+                    adapter.snapshot().getOrNull(position)?.id?.let { id ->
+                        viewModel.accept(InfallibleUiAction.SaveVisibleId(visibleId = id))
                     }
                 }
             }

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
@@ -195,6 +195,7 @@ class NotificationsFragment :
                 }
             }
 
+            @Suppress("SyntheticAccessor")
             override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
                 newState != SCROLL_STATE_IDLE && return
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
@@ -455,17 +455,9 @@ class NotificationsViewModel @Inject constructor(
             }
         }
 
-        // The database stores "0" as the last notification ID if notifications have not been
-        // fetched. Convert to null to ensure a full fetch in this case
-        val lastNotificationId = when (val id = accountManager.activeAccount?.lastNotificationId) {
-            "0" -> null
-            else -> id
-        }
-        Log.d(TAG, "Restoring at $lastNotificationId")
-
         pagingData = notificationFilter
             .flatMapLatest { action ->
-                getNotifications(filters = action.filter, initialKey = lastNotificationId)
+                getNotifications(filters = action.filter, initialKey = getInitialKey())
             }
             .cachedIn(viewModelScope)
 
@@ -497,6 +489,17 @@ class NotificationsViewModel @Inject constructor(
                     )
                 }
             }
+    }
+
+    // The database stores "0" as the last notification ID if notifications have not been
+    // fetched. Convert to null to ensure a full fetch in this case
+    private fun getInitialKey(): String? {
+        val initialKey = when (val id = accountManager.activeAccount?.lastNotificationId) {
+            "0" -> null
+            else -> id
+        }
+        Log.d(TAG, "Restoring at $initialKey")
+        return initialKey
     }
 
     /**


### PR DESCRIPTION
The previous code gets the user's reading position *once*, when the viewmodel is created, and uses that whenever it needs to be restored.

This is a problem. Suppose the user is a few days behind on their notifications, and opens the app.

The reading position is restored, as expected. They scroll up to start reading newer notifications.

Then they change their notification filters. This causes the notifications list to change, and when it does their reading position is set back to what it was when they first switched to the Notifications tab.

Fix this by:

NotificationsFragment:
- Save the reading position whenever the user stops scrolling.

NotificationsViewModel:
- Use the saved reading position whenever the list of notifications can change, not just when the view model is created.