### PR TITLE
Improve prompt when draft is empty

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -76,6 +76,7 @@ import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.adapter.EmojiAdapter
 import com.keylesspalace.tusky.adapter.LocaleAdapter
 import com.keylesspalace.tusky.adapter.OnEmojiSelectedListener
+import com.keylesspalace.tusky.components.compose.ComposeViewModel.ConfirmationPromptType
 import com.keylesspalace.tusky.components.compose.dialog.CaptionDialog
 import com.keylesspalace.tusky.components.compose.dialog.makeFocusDialog
 import com.keylesspalace.tusky.components.compose.dialog.showAddPollDialog
@@ -1124,21 +1125,19 @@ class ComposeActivity :
     private fun handleCloseButton() {
         val contentText = binding.composeEditField.text.toString()
         val contentWarning = binding.composeContentWarningField.text.toString()
-        if (viewModel.composeKind == ComposeKind.NEW && viewModel.isEmpty(contentText, contentWarning)) {
-            viewModel.stopUploads()
-            finishWithoutSlideOutAnimation()
-        } else if (viewModel.composeKind == ComposeKind.EDIT_DRAFT && viewModel.isEmpty(contentText, contentWarning)) {
-            getDeleteEmptyDraftOrContinueEditing().show()
-        } else if (viewModel.didChange(contentText, contentWarning)) {
-            when (viewModel.composeKind) {
-                ComposeKind.NEW -> getSaveAsDraftOrDiscardDialog(contentText, contentWarning)
-                ComposeKind.EDIT_DRAFT -> getUpdateDraftOrDiscardDialog(contentText, contentWarning)
-                ComposeKind.EDIT_POSTED -> getContinueEditingOrDiscardDialog()
-                ComposeKind.EDIT_SCHEDULED -> getContinueEditingOrDiscardDialog()
-            }.show()
-        } else {
-            viewModel.stopUploads()
-            finishWithoutSlideOutAnimation()
+        when (viewModel.handleCloseButton(contentText, contentWarning)) {
+            ConfirmationPromptType.NONE -> {
+                viewModel.stopUploads()
+                finishWithoutSlideOutAnimation()
+            }
+            ConfirmationPromptType.SAVE_OR_DISCARD ->
+                getSaveAsDraftOrDiscardDialog(contentText, contentWarning).show()
+            ConfirmationPromptType.UPDATE_OR_DISCARD ->
+                getUpdateDraftOrDiscardDialog(contentText, contentWarning).show()
+            ConfirmationPromptType.CONTINUE_EDITING_OR_DISCARD_CHANGES ->
+                getContinueEditingOrDiscardDialog().show()
+            ConfirmationPromptType.CONTINUE_EDITING_OR_DISCARD_DRAFT ->
+                getDeleteEmptyDraftOrContinueEditing().show()
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -1124,7 +1124,12 @@ class ComposeActivity :
     private fun handleCloseButton() {
         val contentText = binding.composeEditField.text.toString()
         val contentWarning = binding.composeContentWarningField.text.toString()
-        if (viewModel.didChange(contentText, contentWarning)) {
+        if (viewModel.composeKind == ComposeKind.NEW && viewModel.isEmpty(contentText, contentWarning)) {
+            viewModel.stopUploads()
+            finishWithoutSlideOutAnimation()
+        } else if (viewModel.composeKind == ComposeKind.EDIT_DRAFT && viewModel.isEmpty(contentText, contentWarning)) {
+            getDeleteEmptyDraftOrContinueEditing().show()
+        } else if (viewModel.didChange(contentText, contentWarning)) {
             when (viewModel.composeKind) {
                 ComposeKind.NEW -> getSaveAsDraftOrDiscardDialog(contentText, contentWarning)
                 ComposeKind.EDIT_DRAFT -> getUpdateDraftOrDiscardDialog(contentText, contentWarning)
@@ -1195,6 +1200,23 @@ class ComposeActivity :
             .setNegativeButton(R.string.action_discard) { _, _ ->
                 viewModel.stopUploads()
                 finishWithoutSlideOutAnimation()
+            }
+    }
+
+    /**
+     * User is editing an existing draft and making it empty.
+     * The user can either delete the empty draft or go back to editing.
+     */
+    private fun getDeleteEmptyDraftOrContinueEditing(): AlertDialog.Builder {
+        return AlertDialog.Builder(this)
+            .setMessage(R.string.compose_delete_draft)
+            .setPositiveButton(R.string.action_delete) { _, _ ->
+                viewModel.deleteDraft()
+                viewModel.stopUploads()
+                finishWithoutSlideOutAnimation()
+            }
+            .setNegativeButton(R.string.action_continue_edit) { _, _ ->
+                // Do nothing, dialog will dismiss, user can continue editing
             }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -76,7 +76,7 @@ import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.adapter.EmojiAdapter
 import com.keylesspalace.tusky.adapter.LocaleAdapter
 import com.keylesspalace.tusky.adapter.OnEmojiSelectedListener
-import com.keylesspalace.tusky.components.compose.ComposeViewModel.ConfirmationPromptType
+import com.keylesspalace.tusky.components.compose.ComposeViewModel.ConfirmationKind
 import com.keylesspalace.tusky.components.compose.dialog.CaptionDialog
 import com.keylesspalace.tusky.components.compose.dialog.makeFocusDialog
 import com.keylesspalace.tusky.components.compose.dialog.showAddPollDialog
@@ -1126,17 +1126,17 @@ class ComposeActivity :
         val contentText = binding.composeEditField.text.toString()
         val contentWarning = binding.composeContentWarningField.text.toString()
         when (viewModel.handleCloseButton(contentText, contentWarning)) {
-            ConfirmationPromptType.NONE -> {
+            ConfirmationKind.NONE -> {
                 viewModel.stopUploads()
                 finishWithoutSlideOutAnimation()
             }
-            ConfirmationPromptType.SAVE_OR_DISCARD ->
+            ConfirmationKind.SAVE_OR_DISCARD ->
                 getSaveAsDraftOrDiscardDialog(contentText, contentWarning).show()
-            ConfirmationPromptType.UPDATE_OR_DISCARD ->
+            ConfirmationKind.UPDATE_OR_DISCARD ->
                 getUpdateDraftOrDiscardDialog(contentText, contentWarning).show()
-            ConfirmationPromptType.CONTINUE_EDITING_OR_DISCARD_CHANGES ->
+            ConfirmationKind.CONTINUE_EDITING_OR_DISCARD_CHANGES ->
                 getContinueEditingOrDiscardDialog().show()
-            ConfirmationPromptType.CONTINUE_EDITING_OR_DISCARD_DRAFT ->
+            ConfirmationKind.CONTINUE_EDITING_OR_DISCARD_DRAFT ->
                 getDeleteEmptyDraftOrContinueEditing().show()
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -223,6 +223,10 @@ class ComposeViewModel @Inject constructor(
         return modifiedInitialState || textChanged || contentWarningChanged || mediaChanged || pollChanged || didScheduledTimeChange
     }
 
+    fun isEmpty(content: String?, contentWarning: String?): Boolean {
+        return !modifiedInitialState && (content.isNullOrBlank() && contentWarning.isNullOrBlank() && media.value.isEmpty() && poll.value == null)
+    }
+
     fun contentWarningChanged(value: Boolean) {
         showContentWarning.value = value
         contentWarningStateChanged = true

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -213,7 +213,28 @@ class ComposeViewModel @Inject constructor(
         this.markMediaAsSensitive.value = this.markMediaAsSensitive.value != true
     }
 
-    fun didChange(content: String?, contentWarning: String?): Boolean {
+    fun handleCloseButton(contentText: String?, contentWarning: String?): ConfirmationPromptType {
+        return if (didChange(contentText, contentWarning)) {
+            when (composeKind) {
+                ComposeActivity.ComposeKind.NEW -> if (isEmpty(contentText, contentWarning)) {
+                    ConfirmationPromptType.NONE
+                } else {
+                    ConfirmationPromptType.SAVE_OR_DISCARD
+                }
+                ComposeActivity.ComposeKind.EDIT_DRAFT -> if (isEmpty(contentText, contentWarning)) {
+                    ConfirmationPromptType.CONTINUE_EDITING_OR_DISCARD_DRAFT
+                } else {
+                    ConfirmationPromptType.UPDATE_OR_DISCARD
+                }
+                ComposeActivity.ComposeKind.EDIT_POSTED -> ConfirmationPromptType.CONTINUE_EDITING_OR_DISCARD_CHANGES
+                ComposeActivity.ComposeKind.EDIT_SCHEDULED -> ConfirmationPromptType.CONTINUE_EDITING_OR_DISCARD_CHANGES
+            }
+        } else {
+            ConfirmationPromptType.NONE
+        }
+    }
+
+    private fun didChange(content: String?, contentWarning: String?): Boolean {
         val textChanged = content.orEmpty() != startingText.orEmpty()
         val contentWarningChanged = contentWarning.orEmpty() != startingContentWarning
         val mediaChanged = media.value.isNotEmpty()
@@ -223,7 +244,7 @@ class ComposeViewModel @Inject constructor(
         return modifiedInitialState || textChanged || contentWarningChanged || mediaChanged || pollChanged || didScheduledTimeChange
     }
 
-    fun isEmpty(content: String?, contentWarning: String?): Boolean {
+    private fun isEmpty(content: String?, contentWarning: String?): Boolean {
         return !modifiedInitialState && (content.isNullOrBlank() && contentWarning.isNullOrBlank() && media.value.isEmpty() && poll.value == null)
     }
 
@@ -489,6 +510,14 @@ class ComposeViewModel @Inject constructor(
 
     private companion object {
         const val TAG = "ComposeViewModel"
+    }
+
+    enum class ConfirmationPromptType {
+        NONE, // just close
+        SAVE_OR_DISCARD,
+        UPDATE_OR_DISCARD,
+        CONTINUE_EDITING_OR_DISCARD_CHANGES, // editing post
+        CONTINUE_EDITING_OR_DISCARD_DRAFT // edit draft
     }
 }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -21,6 +21,7 @@ import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.connyduck.calladapter.networkresult.fold
+import com.keylesspalace.tusky.components.compose.ComposeActivity.ComposeKind
 import com.keylesspalace.tusky.components.compose.ComposeActivity.QueuedMedia
 import com.keylesspalace.tusky.components.compose.ComposeAutoCompleteAdapter.AutocompleteResult
 import com.keylesspalace.tusky.components.drafts.DraftHelper
@@ -94,7 +95,7 @@ class ComposeViewModel @Inject constructor(
     val media: MutableStateFlow<List<QueuedMedia>> = MutableStateFlow(emptyList())
     val uploadError = MutableSharedFlow<Throwable>(replay = 0, extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 
-    lateinit var composeKind: ComposeActivity.ComposeKind
+    lateinit var composeKind: ComposeKind
 
     // Used in ComposeActivity to pass state to result function when cropImage contract inflight
     var cropImageItemOld: QueuedMedia? = null
@@ -213,24 +214,24 @@ class ComposeViewModel @Inject constructor(
         this.markMediaAsSensitive.value = this.markMediaAsSensitive.value != true
     }
 
-    fun handleCloseButton(contentText: String?, contentWarning: String?): ConfirmationPromptType {
+    fun handleCloseButton(contentText: String?, contentWarning: String?): ConfirmationKind {
         return if (didChange(contentText, contentWarning)) {
             when (composeKind) {
-                ComposeActivity.ComposeKind.NEW -> if (isEmpty(contentText, contentWarning)) {
-                    ConfirmationPromptType.NONE
+                ComposeKind.NEW -> if (isEmpty(contentText, contentWarning)) {
+                    ConfirmationKind.NONE
                 } else {
-                    ConfirmationPromptType.SAVE_OR_DISCARD
+                    ConfirmationKind.SAVE_OR_DISCARD
                 }
-                ComposeActivity.ComposeKind.EDIT_DRAFT -> if (isEmpty(contentText, contentWarning)) {
-                    ConfirmationPromptType.CONTINUE_EDITING_OR_DISCARD_DRAFT
+                ComposeKind.EDIT_DRAFT -> if (isEmpty(contentText, contentWarning)) {
+                    ConfirmationKind.CONTINUE_EDITING_OR_DISCARD_DRAFT
                 } else {
-                    ConfirmationPromptType.UPDATE_OR_DISCARD
+                    ConfirmationKind.UPDATE_OR_DISCARD
                 }
-                ComposeActivity.ComposeKind.EDIT_POSTED -> ConfirmationPromptType.CONTINUE_EDITING_OR_DISCARD_CHANGES
-                ComposeActivity.ComposeKind.EDIT_SCHEDULED -> ConfirmationPromptType.CONTINUE_EDITING_OR_DISCARD_CHANGES
+                ComposeKind.EDIT_POSTED -> ConfirmationKind.CONTINUE_EDITING_OR_DISCARD_CHANGES
+                ComposeKind.EDIT_SCHEDULED -> ConfirmationKind.CONTINUE_EDITING_OR_DISCARD_CHANGES
             }
         } else {
-            ConfirmationPromptType.NONE
+            ConfirmationKind.NONE
         }
     }
 
@@ -415,7 +416,7 @@ class ComposeViewModel @Inject constructor(
             return
         }
 
-        composeKind = composeOptions?.kind ?: ComposeActivity.ComposeKind.NEW
+        composeKind = composeOptions?.kind ?: ComposeKind.NEW
 
         val preferredVisibility = accountManager.activeAccount!!.defaultPostPrivacy
 
@@ -512,7 +513,7 @@ class ComposeViewModel @Inject constructor(
         const val TAG = "ComposeViewModel"
     }
 
-    enum class ConfirmationPromptType {
+    enum class ConfirmationKind {
         NONE, // just close
         SAVE_OR_DISCARD,
         UPDATE_OR_DISCARD,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -481,7 +481,7 @@
     <string name="action_remove">Remove</string>
     <string name="lock_account_label">Lock account</string>
     <string name="lock_account_label_description">Requires you to manually approve followers</string>
-    <string name="compose_delete_draft">Delete this draft?</string>
+    <string name="compose_delete_draft">Delete draft?</string>
     <string name="compose_save_draft">Save draft?</string>
     <string name="compose_save_draft_loses_media">Save draft? (Attachments will be uploaded again when you restore the draft.)</string>
     <string name="compose_unsaved_changes">You have unsaved changes.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -481,6 +481,7 @@
     <string name="action_remove">Remove</string>
     <string name="lock_account_label">Lock account</string>
     <string name="lock_account_label_description">Requires you to manually approve followers</string>
+    <string name="compose_delete_draft">Delete this draft?</string>
     <string name="compose_save_draft">Save draft?</string>
     <string name="compose_save_draft_loses_media">Save draft? (Attachments will be uploaded again when you restore the draft.)</string>
     <string name="compose_unsaved_changes">You have unsaved changes.</string>


### PR DESCRIPTION
address #3576 

I'm sort of following https://github.com/tuskyapp/Tusky/issues/3576#issuecomment-1527504752.

When the user is closing the compose view,
- if it's new and empty, don't show a prompt.
- if it's an existing draft and now empty, ask if the user wants to delete it or continue editing. I don't think there is much value in saving an empty draft.
  <img src="https://github.com/tuskyapp/Tusky/assets/616399/ef50c4b1-13d1-4d80-bab6-385bb04437c6" width=240>
