### PR TITLE
Add a menu option to load the newest notifications

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
@@ -453,6 +453,10 @@ class NotificationsFragment :
                 onRefresh()
                 true
             }
+            R.id.load_newest -> {
+                viewModel.accept(FallibleUiAction.LoadNewest)
+                true
+            }
             else -> false
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
@@ -454,7 +454,7 @@ class NotificationsFragment :
                 true
             }
             R.id.load_newest -> {
-                viewModel.accept(FallibleUiAction.LoadNewest)
+                viewModel.accept(InfallibleUiAction.LoadNewest)
                 true
             }
             else -> false

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
@@ -99,9 +99,6 @@ sealed class UiAction
 sealed class FallibleUiAction : UiAction() {
     /** Clear all notifications */
     object ClearNotifications : FallibleUiAction()
-
-    /** Ignore the saved reading position, load the newest items */
-    object LoadNewest : InfallibleUiAction()
 }
 
 /**
@@ -122,6 +119,12 @@ sealed class InfallibleUiAction : UiAction() {
      * can do.
      */
     data class SaveVisibleId(val visibleId: String) : InfallibleUiAction()
+
+    /** Ignore the saved reading position, load the page with the newest items */
+    // Resets the account's `lastNotificationId`, which can't fail, which is why this is
+    // infallible. Reloading the data may fail, but that's handled by the paging system /
+    // adapter refresh logic.
+    object LoadNewest : InfallibleUiAction()
 }
 
 /** Actions the user can trigger on an individual notification. These may fail. */
@@ -341,7 +344,7 @@ class NotificationsViewModel @Inject constructor(
         // increment `reload` to trigger creation of a new PagingSource.
         viewModelScope.launch {
             uiAction
-                .filterIsInstance<FallibleUiAction.LoadNewest>()
+                .filterIsInstance<InfallibleUiAction.LoadNewest>()
                 .collectLatest {
                     account.lastNotificationId = "0"
                     accountManager.saveAccount(account)

--- a/app/src/main/res/menu/fragment_notifications.xml
+++ b/app/src/main/res/menu/fragment_notifications.xml
@@ -22,4 +22,9 @@
         android:id="@+id/action_refresh"
         android:title="@string/action_refresh"
         app:showAsAction="never" />
+
+    <item
+        android:id="@+id/load_newest"
+        android:title="@string/load_newest_notifications"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -810,4 +810,5 @@
         you follow.\n\nTo explore accounts you can either discover them in one of the other timelines.
         For example the local timeline of your instance [iconics gmd_group]. Or you can search them
         by name [iconics gmd_search]; for example search for Tusky to find our Mastodon account.</string>
+    <string name="load_newest_notifications">Load newest notifications</string>
 </resources>


### PR DESCRIPTION
- Create a flow with new items (arbitrary ints) when a reload from the top should happen
- Combine this flow with notificationFilter, so changes to either of them trigger a reload
- Provide a menu item in NotificationsFragment to initiate the reload
- Handle the action in the view model