### PR TITLE
correctly show non-square custom emojis

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/CustomEmojiHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/CustomEmojiHelper.kt
@@ -87,7 +87,7 @@ class EmojiSpan(val viewWeakReference: WeakReference<View>) : ReplacementSpan() 
             // start with a width relative to the text size
             var emojiWidth = paint.textSize * 1.1
 
-            // calculated the height based on the width to keep the aspect ratio correct
+            // calculate the height, keeping the aspect ratio correct
             val drawableWidth = drawable.intrinsicWidth
             val drawableHeight = drawable.intrinsicHeight
             var emojiHeight = emojiWidth / drawableWidth * drawableHeight

--- a/app/src/main/java/com/keylesspalace/tusky/util/CustomEmojiHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/CustomEmojiHelper.kt
@@ -84,11 +84,26 @@ class EmojiSpan(val viewWeakReference: WeakReference<View>) : ReplacementSpan() 
         imageDrawable?.let { drawable ->
             canvas.save()
 
-            val emojiSize = (paint.textSize * 1.1).toInt()
-            drawable.setBounds(0, 0, emojiSize, emojiSize)
+            // start with a width relative to the text size
+            var emojiWidth = paint.textSize * 1.1
 
-            var transY = bottom - drawable.bounds.bottom
-            transY -= paint.fontMetricsInt.descent / 2
+            // calculated the height based on the width to keep the aspect ratio correct
+            val drawableWidth = drawable.intrinsicWidth
+            val drawableHeight = drawable.intrinsicHeight
+            var emojiHeight = emojiWidth / drawableWidth * drawableHeight
+
+            // how much vertical space there is draw the emoji
+            val drawableSpace = (bottom - top).toDouble()
+
+            // in case the calculated height is bigger than the available space, scale the emoji down, preserving aspect ratio
+            if (emojiHeight > drawableSpace) {
+                emojiWidth *= drawableSpace / emojiHeight
+                emojiHeight = drawableSpace
+            }
+            drawable.setBounds(0, 0, emojiWidth.toInt(), emojiHeight.toInt())
+
+            // vertically center the emoji in the line
+            val transY = top + (drawableSpace / 2  - emojiHeight / 2)
 
             canvas.translate(x, transY.toFloat())
             drawable.draw(canvas)

--- a/app/src/main/java/com/keylesspalace/tusky/util/CustomEmojiHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/CustomEmojiHelper.kt
@@ -103,7 +103,7 @@ class EmojiSpan(val viewWeakReference: WeakReference<View>) : ReplacementSpan() 
             drawable.setBounds(0, 0, emojiWidth.toInt(), emojiHeight.toInt())
 
             // vertically center the emoji in the line
-            val transY = top + (drawableSpace / 2  - emojiHeight / 2)
+            val transY = top + (drawableSpace / 2 - emojiHeight / 2)
 
             canvas.translate(x, transY.toFloat())
             drawable.draw(canvas)


### PR DESCRIPTION
closes https://github.com/tuskyapp/Tusky/issues/635

Instead of forcing all emojis to be square, only the width is fixed now and the emoji scaled to fit.

For testing, check the replies to this post https://chaos.social/@ConnyDuck/110490834316501211