### PR TITLE
Keep worker classes

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -115,3 +115,7 @@
 # Preference fragments can be referenced by name, ensure they remain
 # https://github.com/tuskyapp/Tusky/issues/3161
 -keep class * extends androidx.preference.PreferenceFragmentCompat
+
+# Ensure that Workers are kept, https://github.com/tuskyapp/Tusky/issues/3740
+-keep class * extends androidx.work.Worker
+-keep class * extends com.keylesspalace.tusky.worker.ChildWorkerFactory

--- a/app/src/main/java/com/keylesspalace/tusky/worker/WorkerFactory.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/worker/WorkerFactory.kt
@@ -23,6 +23,7 @@ import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import javax.inject.Inject
 import javax.inject.Provider
+import javax.inject.Singleton
 
 /**
  * Workers implement this and are added to the map in [com.keylesspalace.tusky.di.WorkerModule]
@@ -37,10 +38,11 @@ interface ChildWorkerFactory {
  * Creates workers, delegating to each worker's [ChildWorkerFactory.createWorker] to do the
  * creation.
  *
- * @see [com.keylesspalace.tusky.components.notifications.NotificationWorker]
+ * @see [com.keylesspalace.tusky.worker.NotificationWorker]
  */
+@Singleton
 class WorkerFactory @Inject constructor(
-    val workerFactories: Map<Class<out ListenableWorker>, @JvmSuppressWildcards Provider<ChildWorkerFactory>>
+    private val workerFactories: Map<Class<out ListenableWorker>, @JvmSuppressWildcards Provider<ChildWorkerFactory>>
 ) : WorkerFactory() {
     override fun createWorker(
         appContext: Context,


### PR DESCRIPTION
Should fix this crash:

```
Exception java.lang.Error:
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1173)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:641)
  at java.lang.Thread.run (Thread.java:923)
Caused by java.lang.ClassNotFoundException:
  at java.lang.Class.classForName
  at java.lang.Class.forName (Class.java:454)
  at java.lang.Class.forName (Class.java:379)
  at com.keylesspalace.tusky.worker.WorkerFactory.createWorker (WorkerFactory.kt:50)
  at androidx.work.WorkerFactory.createWorkerWithDefaultFallback (WorkerFactory.kt:83)
  at androidx.work.impl.WorkerWrapper.runWorker (WorkerWrapper.java:243)
  at androidx.work.impl.WorkerWrapper.run (WorkerWrapper.java:145)
  at androidx.work.impl.utils.SerialExecutorImpl$Task.run (SerialExecutorImpl.java:96)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1167)
```

While I'm here:

- Mark workerFactories as private
- Mark WorkerFactory as a Singleton

Fixes https://github.com/tuskyapp/Tusky/issues/3740