### PR TITLE
Set default alt-text to media label when pasting images

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -943,7 +943,9 @@ class ComposeActivity :
             val split = contentInfo.partition { item: ClipData.Item -> item.uri != null }
             split.first?.let { content ->
                 for (i in 0 until content.clip.itemCount) {
-                    pickMedia(content.clip.getItemAt(i).uri)
+                    pickMedia(content.clip.getItemAt(i).uri,
+                        contentInfo.clip.description.label as String?
+                    )
                 }
             }
             return split.second
@@ -1064,9 +1066,9 @@ class ComposeActivity :
         viewModel.removeMediaFromQueue(item)
     }
 
-    private fun pickMedia(uri: Uri) {
+    private fun pickMedia(uri: Uri, description: String? = null) {
         lifecycleScope.launch {
-            viewModel.pickMedia(uri).onFailure { throwable ->
+            viewModel.pickMedia(uri, description).onFailure { throwable ->
                 val errorString = when (throwable) {
                     is FileSizeException -> {
                         val decimalFormat = DecimalFormat("0.##")

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -943,7 +943,8 @@ class ComposeActivity :
             val split = contentInfo.partition { item: ClipData.Item -> item.uri != null }
             split.first?.let { content ->
                 for (i in 0 until content.clip.itemCount) {
-                    pickMedia(content.clip.getItemAt(i).uri,
+                    pickMedia(
+                        content.clip.getItemAt(i).uri,
                         contentInfo.clip.description.label as String?
                     )
                 }


### PR DESCRIPTION
GBoard and other IME's support pasting images, which are converted to attachments.

Sometimes these have labels that describe the image. If present, set it as the default alt-text.

Fixes #3799