### PR TITLE
Convert lint "Typos" errors to warnings

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -36,6 +36,10 @@
     <!-- Ensure we are warned about errors in the baseline -->
     <issue id="LintBaseline" severity="warning" />
 
+    <!-- Warn about typos. The typo database in lint is not exhaustive, and it's unclear
+         how to add to it when it's wrong. -->
+    <issue id="Typos" severity="warning" />
+
     <!-- Mark all other lint issues as errors -->
     <issue id="all" severity="error" />
 </lint>


### PR DESCRIPTION
The typo database that lint uses may be incorrect, and it's unclear how to add or remove entries to it.