### PR TITLE
3820: Group android notifications and properly use the "group summary alert"

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
@@ -17,6 +17,7 @@ import com.keylesspalace.tusky.util.isLessThan
 import kotlinx.coroutines.delay
 import javax.inject.Inject
 import kotlin.math.min
+import kotlin.time.Duration.Companion.milliseconds
 
 /** Models next/prev links from the "Links" header in an API response */
 data class Links(val next: String?, val prev: String?) {
@@ -106,10 +107,12 @@ class NotificationFetcher @Inject constructor(
                                 notificationListEntry.value.size == 1
                             )
                             notificationManager.notify(notification.id, account.id.toInt(), androidNotification)
-                        }
 
-                        // Leave some time between notifications from different types (to be able to distinguish them)
-                        delay(1000)
+                            // Android will rate limit / drop notifications if they're posted too
+                            // quickly. There is no indication to the user that this happened.
+                            // See https://github.com/tuskyapp/Tusky/pull/3626#discussion_r1192963664
+                            delay(1000.milliseconds)
+                        }
                     }
 
                     NotificationHelper.updateSummaryNotifications(

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
@@ -97,14 +97,14 @@ class NotificationFetcher @Inject constructor(
                     // 1.11 and up (https://developer.android.com/jetpack/androidx/releases/core#1.11.0-alpha01)
                     // when it is released.
 
-                    notificationsByType.forEach { notificationGroup ->
-                        notificationGroup.value.forEach { notification ->
+                    notificationsByType.forEach { notificationsGroup ->
+                        notificationsGroup.value.forEach { notification ->
                             val androidNotification = NotificationHelper.make(
                                 context,
                                 notificationManager,
                                 notification,
                                 account,
-                                notificationGroup.value.size == 1
+                                notificationsGroup.value.size == 1
                             )
                             notificationManager.notify(notification.id, account.id.toInt(), androidNotification)
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
@@ -90,21 +90,21 @@ class NotificationFetcher @Inject constructor(
                         }
                     }
 
-                    val notificationsGrouped = notifications.groupBy { it.type }
+                    val notificationsByType = notifications.groupBy { it.type }
 
                     // Make and send the new notifications
                     // TODO: Use the batch notification API available in NotificationManagerCompat
                     // 1.11 and up (https://developer.android.com/jetpack/androidx/releases/core#1.11.0-alpha01)
                     // when it is released.
 
-                    notificationsGrouped.forEach { notificationListEntry ->
-                        notificationListEntry.value.forEach { notification ->
+                    notificationsByType.forEach { notificationGroup ->
+                        notificationGroup.value.forEach { notification ->
                             val androidNotification = NotificationHelper.make(
                                 context,
                                 notificationManager,
                                 notification,
                                 account,
-                                notificationListEntry.value.size == 1
+                                notificationGroup.value.size == 1
                             )
                             notificationManager.notify(notification.id, account.id.toInt(), androidNotification)
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationFetcher.kt
@@ -153,8 +153,8 @@ class NotificationFetcher @Inject constructor(
         // - account.notificationMarkerId
         // - account.lastNotificationId
         Log.d(TAG, "getting notification marker for ${account.fullName}")
-        val remoteMarkerId = 516362.toString() //fetchMarker(authHeader, account)?.lastReadId ?: "0"
-        val localMarkerId = 516362.toString() //account.notificationMarkerId
+        val remoteMarkerId = fetchMarker(authHeader, account)?.lastReadId ?: "0"
+        val localMarkerId = account.notificationMarkerId
         val markerId = if (remoteMarkerId.isLessThan(localMarkerId)) localMarkerId else remoteMarkerId
         val readingPosition = account.lastNotificationId
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationHelper.java
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationHelper.java
@@ -149,7 +149,7 @@ public class NotificationHelper {
      * @return the new notification
      */
     @NonNull
-    public static android.app.Notification make(final @NonNull Context context, @NonNull NotificationManager notificationManager, @NonNull Notification body, @NonNull AccountEntity account, boolean isFirstOfBatch) {
+    public static android.app.Notification make(final @NonNull Context context, @NonNull NotificationManager notificationManager, @NonNull Notification body, @NonNull AccountEntity account, boolean isOnlyOneInGroup) {
         body = body.rewriteToStatusTypeIfNeeded(account.getAccountId());
         String mastodonNotificationId = body.getId();
         int accountId = (int) account.getId();
@@ -241,7 +241,7 @@ public class NotificationHelper {
         builder.addExtras(extras);
 
         // Only alert for the first notification of a batch to avoid multiple alerts at once
-        if(!isFirstOfBatch) {
+        if(!isOnlyOneInGroup) {
             builder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY);
         }
 
@@ -695,7 +695,7 @@ public class NotificationHelper {
     }
 
     @Nullable
-    private static String getChannelId(AccountEntity account, Notification notification) {
+    public static String getChannelId(AccountEntity account, Notification notification) {
         return getChannelId(account, notification.getType());
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationHelper.java
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationHelper.java
@@ -695,7 +695,7 @@ public class NotificationHelper {
     }
 
     @Nullable
-    public static String getChannelId(AccountEntity account, Notification notification) {
+    private static String getChannelId(AccountEntity account, Notification notification) {
         return getChannelId(account, notification.getType());
     }
 


### PR DESCRIPTION
Fixes #3820 

This mainly corrects the "first of batch" logic.
(Each group/batch has a list so the question "only one per this group?" can be answered.)