### PR TITLE
Set OldTargetApi to a warning

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -40,6 +40,9 @@
          how to add to it when it's wrong. -->
     <issue id="Typos" severity="warning" />
 
+    <!-- Set OldTargetApi back to warning -->
+    <issue id="OldTargetApi" severity="warning" />
+
     <!-- Mark all other lint issues as errors -->
     <issue id="all" severity="error" />
 </lint>


### PR DESCRIPTION
`OldTargetApi` default behaviour is to warn (https://googlesamples.github.io/android-custom-lint-rules/checks/OldTargetApi.md.html)

Set it back to that, so that CI runs on runners with newer versions of the SDK installed do not fail.