### PR TITLE
Set statusView width/height to match_parent

### DIFF
--- a/app/src/main/res/layout/fragment_view_thread.xml
+++ b/app/src/main/res/layout/fragment_view_thread.xml
@@ -37,8 +37,8 @@
 
                 <com.keylesspalace.tusky.view.BackgroundMessageView
                     android:id="@+id/statusView"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
                     android:layout_gravity="center"
                     android:visibility="gone" />
             </FrameLayout>


### PR DESCRIPTION
Fixes an issue where the view's width is only enough to wrap the image, resulting in a very narrow view that obscures the text of the error.