### PR TITLE
Clear listeners, hide icons when appropriate

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/view/SliderPreference.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/view/SliderPreference.kt
@@ -11,6 +11,8 @@ import com.google.android.material.slider.LabelFormatter.LABEL_GONE
 import com.google.android.material.slider.Slider
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.databinding.PrefSliderBinding
+import com.keylesspalace.tusky.util.hide
+import com.keylesspalace.tusky.util.show
 import java.lang.Float.max
 import java.lang.Float.min
 

--- a/app/src/main/java/com/keylesspalace/tusky/view/SliderPreference.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/view/SliderPreference.kt
@@ -132,7 +132,7 @@ class SliderPreference @JvmOverloads constructor(
         binding.root.isClickable = false
 
         binding.slider.clearOnChangeListeners()
-        binding.slicer.clearOnSliderTouchListeners()
+        binding.slider.clearOnSliderTouchListeners()
         binding.slider.addOnChangeListener(this)
         binding.slider.addOnSliderTouchListener(this)
         binding.slider.value = value // sliderValue

--- a/app/src/main/java/com/keylesspalace/tusky/view/SliderPreference.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/view/SliderPreference.kt
@@ -130,6 +130,8 @@ class SliderPreference @JvmOverloads constructor(
 
         binding.root.isClickable = false
 
+        binding.slider.clearOnChangeListeners()
+        binding.slicer.clearOnSliderTouchListeners()
         binding.slider.addOnChangeListener(this)
         binding.slider.addOnSliderTouchListener(this)
         binding.slider.value = value // sliderValue
@@ -141,24 +143,24 @@ class SliderPreference @JvmOverloads constructor(
         binding.slider.labelBehavior = LABEL_GONE
         binding.slider.isEnabled = isEnabled
 
-        binding.summary.visibility = VISIBLE
+        binding.summary.show()
         binding.summary.text = formatter(value)
 
         decrementIcon?.let { icon ->
             binding.decrement.icon = icon
-            binding.decrement.visibility = VISIBLE
+            binding.decrement.show()
             binding.decrement.setOnClickListener {
                 value -= stepSize
             }
-        }
+        } ?: binding.decrement.hide()
 
         incrementIcon?.let { icon ->
             binding.increment.icon = icon
-            binding.increment.visibility = VISIBLE
+            binding.increment.show()
             binding.increment.setOnClickListener {
                 value += stepSize
             }
-        }
+        } ?: binding.increment.hide()
     }
 
     override fun onValueChange(slider: Slider, value: Float, fromUser: Boolean) {

--- a/app/src/main/java/com/keylesspalace/tusky/view/SliderPreference.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/view/SliderPreference.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.res.TypedArray
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
-import android.view.View.VISIBLE
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder


### PR DESCRIPTION
Preferences are shown using view holders.

The previous code did not clear the listeners or hide the icons if necessary.

The practical upshot of this was that if you had two or more slider preferences, *and* they were situated more than a screen's height apart, the viewholder from the first one would get reused.

And if the first one enabled icons then the second one would show them. And clicking on the second one would also call the listeners for the first one.