### PR TITLE
Create the greenRelease versionCode from the git commit count

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,9 +6,10 @@ plugins {
     alias(libs.plugins.kotlin.parcelize)
 }
 
-apply from: 'getGitSha.gradle'
+apply from: 'gitTools.gradle'
 
 final def gitSha = ext.getGitSha()
+final def gitRevCount = ext.getGitRevCount()
 
 // The app name
 final def APP_NAME = "Tusky"
@@ -106,8 +107,16 @@ android {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
+
     applicationVariants.configureEach { variant ->
         variant.outputs.configureEach {
+            // Set the "green" release versionCode to the number of commits on the
+            // branch, to ensure the versionCode updates on every release.
+            //
+            // "+ 8000" to ensure this doesn't clash with versionCodes from Bitrise.
+            if (variant.buildType.name == "release" && variant.flavorName == "green") {
+                versionCodeOverride = gitRevCount + 8000
+            }
             outputFileName = "Tusky_${variant.versionName}_${variant.versionCode}_${gitSha}_" +
                 "${variant.flavorName}_${buildType.name}.apk"
         }

--- a/app/gitTools.gradle
+++ b/app/gitTools.gradle
@@ -21,7 +21,31 @@ abstract class GitShaValueSource implements ValueSource<String, ValueSourceParam
     }
 }
 
+abstract class GitRevCountSource implements ValueSource<Integer, ValueSourceParameters.None> {
+    @Inject abstract ExecOperations getExecOperations()
+
+    @Override Integer obtain() {
+        try {
+            def output = new ByteArrayOutputStream()
+
+            execOperations.exec {
+                it.commandLine 'git', 'rev-list', '--first-parent', '--count', 'HEAD'
+                it.standardOutput = output
+            }
+
+            return output.toString().trim().toInteger()
+        } catch (GradleException ignore) {
+            // Git executable unavailable, or we are not building in a git repo. Fall through:
+        }
+        return -1
+    }
+}
+
 // Export closure
 ext.getGitSha = {
     providers.of(GitShaValueSource) {}.get()
+}
+
+ext.getGitRevCount = {
+    providers.of(GitRevCountSource) {}.get()
 }


### PR DESCRIPTION
greenRelease (the nightly release build) should have an incrementing versionCode.

To achieve this, fetch the number of parent revisions from git.

The Bitrise CI system has been generating releases with versionCodes at ~ 8,000, so add 8,000 to the final versionCode to ensure there's no clash.