### PR TITLE
Populate gradle build cache on each push to develop

### DIFF
--- a/.github/workflows/populate-gradle-build-cache.yml
+++ b/.github/workflows/populate-gradle-build-cache.yml
@@ -1,0 +1,28 @@
+# Build the app on each push to `develop`, populating the build cache to speed
+# up CI on PRs.
+
+name: Populate build cache
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    name: app:buildGreenDebug
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+  
+      - name: Run app:buildGreenDebug
+        run: ./gradlew app:buildGreenDebug


### PR DESCRIPTION
The build cache is used in ci.yml to speed up builds, but it needs to be populated by building code that's been merged.