### PR TITLE
Show the correct tab title when opening the activity

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -158,7 +158,6 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
 
     private lateinit var header: AccountHeaderView
 
-    private var notificationTabPosition = 0
     private var onTabSelectedListener: OnTabSelectedListener? = null
 
     private var unreadAnnouncementsCount = 0
@@ -754,8 +753,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
             activeTabLayout.addOnTabSelectedListener(it)
         }
 
-        val activeTabPosition = if (selectNotificationTab) notificationTabPosition else 0
-        supportActionBar?.title = tabs[activeTabPosition].title(this@MainActivity)
+        supportActionBar?.title = tabs[position].title(this@MainActivity)
         binding.mainToolbar.setOnClickListener {
             (tabAdapter.getFragment(activeTabLayout.selectedTabPosition) as? ReselectableFragment)?.onReselect()
         }


### PR DESCRIPTION
The previous code used `notificationTabPosition`, which was never changed, so always 0.

This meant that if you e.g., got to `MainActivity` by clicking on a notification, and the notification tab was current, the title would still show "Home".

Fix that by using the existing `position` variable which represents the currently selected tab, and ensure the correct title is shown.

Fixes #3864.