### PR TITLE
Use colorPrimary for the "edit" schedule icon

### DIFF
--- a/app/src/main/res/layout/view_compose_schedule.xml
+++ b/app/src/main/res/layout/view_compose_schedule.xml
@@ -23,7 +23,7 @@
         android:paddingBottom="16dp"
         android:textColor="?android:textColorTertiary"
         android:textSize="?attr/status_text_medium"
-        app:drawableTint="?android:attr/textColorTertiary"
+        app:drawableTint="?attr/colorPrimary"
         app:layout_constraintBottom_toTopOf="@id/invalidScheduleWarning"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1"


### PR DESCRIPTION
The "edit" icon when showing a scheduled status' time was grey, so it's not obvious that this section is clickable.

Use colorPrimary, so it looks more like a button.