### PR TITLE
Disable Toot button when bottom sheets are open

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -772,8 +772,10 @@ class ComposeActivity :
             addMediaBehavior.state = BottomSheetBehavior.STATE_HIDDEN
             emojiBehavior.state = BottomSheetBehavior.STATE_HIDDEN
             scheduleBehavior.setState(BottomSheetBehavior.STATE_HIDDEN)
+            binding.composeTootButton.isEnabled = false
         } else {
             composeOptionsBehavior.setState(BottomSheetBehavior.STATE_HIDDEN)
+            binding.composeTootButton.isEnabled = true
         }
     }
 
@@ -791,8 +793,10 @@ class ComposeActivity :
             composeOptionsBehavior.state = BottomSheetBehavior.STATE_HIDDEN
             addMediaBehavior.state = BottomSheetBehavior.STATE_HIDDEN
             emojiBehavior.setState(BottomSheetBehavior.STATE_HIDDEN)
+            binding.composeTootButton.isEnabled = false
         } else {
             scheduleBehavior.setState(BottomSheetBehavior.STATE_HIDDEN)
+            binding.composeTootButton.isEnabled = true
         }
     }
 
@@ -807,8 +811,10 @@ class ComposeActivity :
                     composeOptionsBehavior.state = BottomSheetBehavior.STATE_HIDDEN
                     addMediaBehavior.state = BottomSheetBehavior.STATE_HIDDEN
                     scheduleBehavior.setState(BottomSheetBehavior.STATE_HIDDEN)
+                    binding.composeTootButton.isEnabled = false
                 } else {
                     emojiBehavior.setState(BottomSheetBehavior.STATE_HIDDEN)
+                    binding.composeTootButton.isEnabled = true
                 }
             }
         }
@@ -820,8 +826,10 @@ class ComposeActivity :
             composeOptionsBehavior.state = BottomSheetBehavior.STATE_HIDDEN
             emojiBehavior.state = BottomSheetBehavior.STATE_HIDDEN
             scheduleBehavior.setState(BottomSheetBehavior.STATE_HIDDEN)
+            binding.composeTootButton.isEnabled = false
         } else {
             addMediaBehavior.setState(BottomSheetBehavior.STATE_HIDDEN)
+            binding.composeTootButton.isEnabled = true
         }
     }
 


### PR DESCRIPTION
When the bottom sheets (pick media, set visibility, choose emoji, view/edit scheduled post time) are open the user is going to be clicking near the bottom of the screen.

This is very close to the "Toot" button, so there's a risk that the user inadvertently posts, instead of e.g., choosing an emoji, or trying to change the scheduled time.

Disable the button while the sheets are open so that the user can't post by mistake, re-enable when the sheets are closed.