### PR TITLE
Revert "Enable gradle build cache for Bitrise builds"

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -18,9 +18,6 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@8.0: {}
     - cache-pull@2.7: {}
-    - activate-build-cache-for-gradle:
-        inputs:
-        - push: 'true'
     - install-missing-android-tools:
         inputs:
         - gradlew_path: $PROJECT_LOCATION/gradlew
@@ -60,7 +57,6 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone: {}
     - cache-pull@2.7: {}
-    - activate-build-cache-for-gradle: {}
     - install-missing-android-tools:
         inputs:
         - gradlew_path: $PROJECT_LOCATION/gradlew
@@ -100,9 +96,6 @@ workflows:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone: {}
     - cache-pull@2.7: {}
-    - activate-build-cache-for-gradle:
-        inputs:
-        - push: 'true'
     - install-missing-android-tools@3.1:
         inputs:
         - gradlew_path: $PROJECT_LOCATION/gradlew


### PR DESCRIPTION
Reverts tuskyapp/Tusky#3840. Turns out this needs to be enabled at Bitrise, and it's not on our plan. So every build is running this extra workflow, but it's not providing any benefit, just slowing things down.