### PR TITLE
3477 tweak colors for contrast

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -1061,7 +1061,7 @@ class ComposeActivity :
         binding.composeCharactersLeftView.text = String.format(Locale.getDefault(), "%d", remainingLength)
 
         val textColor = if (remainingLength < 0) {
-            getColor(R.color.tusky_red)
+            getColor(R.color.warning_color)
         } else {
             MaterialColors.getColor(
                 binding.composeCharactersLeftView,

--- a/app/src/main/res/values-night/theme_colors.xml
+++ b/app/src/main/res/values-night/theme_colors.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <color name="colorSurface">@color/tusky_grey_30</color>
     <color name="colorPrimaryDark">@color/tusky_grey_25</color>
 
@@ -31,6 +30,6 @@
     <color name="toolbar_icon_background">#CC444B5D</color>
 
     <!-- colors used to show inserted/deleted text -->
-    <color name="view_edits_background_insert">#00731B</color>
-    <color name="view_edits_background_delete">#DF0000</color>
+    <color name="view_edits_background_insert">@color/tusky_green</color>
+    <color name="view_edits_background_delete">@color/tusky_red</color>
 </resources>

--- a/app/src/main/res/values-night/theme_colors.xml
+++ b/app/src/main/res/values-night/theme_colors.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="colorPrimary">@color/tusky_blue</color>
+    <color name="colorSecondary">@color/tusky_blue</color>
     <color name="colorSurface">@color/tusky_grey_30</color>
     <color name="colorPrimaryDark">@color/tusky_grey_25</color>
 

--- a/app/src/main/res/values-night/theme_colors.xml
+++ b/app/src/main/res/values-night/theme_colors.xml
@@ -22,6 +22,8 @@
 
     <color name="favoriteButtonActiveColor">@color/tusky_orange</color>
 
+    <color name="warning_color">@color/tusky_red_lighter</color>
+
     <color name="headerBackgroundFilter">@color/header_background_filter_dark</color>
 
     <bool name="lightNavigationBar">false</bool>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,9 +4,11 @@
     <color name="tusky_blue_light">#56a7e1</color>
     <color name="tusky_orange">#ca8f04</color>
     <color name="tusky_orange_light">#fab207</color>
-    <color name="tusky_green">#19a341</color>
+    <color name="tusky_green">#00731B</color>
     <color name="tusky_green_light">#25d069</color>
+    <color name="tusky_green_lighter">#CCFFD8</color>
     <color name="tusky_red">#DF1553</color>
+    <color name="tusky_red_lighter">#FFC0C0</color>
 
     <color name="white">#fff</color>
     <color name="black">#000</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="tusky_blue">#2b90d9</color>
+    <color name="tusky_blue_darker">#217aba</color>
     <color name="tusky_blue_light">#56a7e1</color>
     <color name="tusky_orange">#ca8f04</color>
     <color name="tusky_orange_light">#fab207</color>
@@ -18,6 +19,7 @@
     <!-- the number roughly corresponds to the % lightness of the grey -->
     <color name="tusky_grey_05">#070b14</color>
     <color name="tusky_grey_10">#16191f</color>
+    <color name="tusky_grey_15">#21222c</color>
     <color name="tusky_grey_20">#282c37</color>
     <color name="tusky_grey_25">#313543</color>
     <color name="tusky_grey_30">#444b5d</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -91,6 +91,23 @@
         <item name="preferenceTheme">@style/TuskyPreferenceTheme</item>
     </style>
 
+    <style name="TuskyBlackThemeBase" parent="TuskyBaseTheme">
+        <item name="colorPrimaryDark">@color/tusky_grey_05</item>
+
+        <item name="android:colorBackground">@color/black</item>
+        <item name="windowBackgroundColor">@color/black</item>
+
+        <item name="colorSurface">@color/tusky_grey_10</item>
+
+        <item name="iconColor">@color/tusky_grey_40</item>
+        <item name="colorBackgroundHighlight">@color/tusky_grey_40</item>
+        <item name="colorBackgroundAccent">@color/tusky_grey_20</item>
+
+        <item name="dividerColor">@color/tusky_grey_20</item>
+    </style>
+
+    <style name="TuskyBlackTheme" parent="TuskyBlackThemeBase" />
+
     <style name="ViewMediaActivity.AppBarLayout" parent="ThemeOverlay.AppCompat">
         <item name="android:colorControlNormal">@color/white</item>
     </style>
@@ -143,24 +160,6 @@
         <item name="boxStrokeColor">@color/text_input_layout_box_stroke_color</item>
         <item name="android:textColorHint">?android:attr/textColorTertiary</item>
     </style>
-
-    <!--Black Application Theme Styles-->
-    <style name="TuskyBlackThemeBase" parent="TuskyBaseTheme">
-        <item name="colorPrimaryDark">@color/tusky_grey_05</item>
-
-        <item name="android:colorBackground">@color/black</item>
-        <item name="windowBackgroundColor">@color/black</item>
-
-        <item name="colorSurface">@color/tusky_grey_10</item>
-
-        <item name="iconColor">@color/tusky_grey_40</item>
-        <item name="colorBackgroundHighlight">@color/tusky_grey_40</item>
-        <item name="colorBackgroundAccent">@color/tusky_grey_20</item>
-
-        <item name="dividerColor">@color/tusky_grey_20</item>
-    </style>
-
-    <style name="TuskyBlackTheme" parent="TuskyBlackThemeBase" />
 
     <style name="TuskyDrawerStyle" parent ="Widget.MaterialDrawerStyle">
         <item name="materialDrawerBackground">?android:colorBackground</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -48,10 +48,10 @@
         <item name="status_text_medium">16sp</item>
         <item name="status_text_large">18sp</item>
 
-        <item name="colorPrimary">@color/tusky_blue</item>
+        <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorOnPrimary">@color/white</item>
 
-        <item name="colorSecondary">@color/tusky_blue</item>
+        <item name="colorSecondary">@color/colorSecondary</item>
         <item name="colorOnSecondary">@color/white</item>
 
         <item name="colorSurface">@color/colorSurface</item>

--- a/app/src/main/res/values/theme_colors.xml
+++ b/app/src/main/res/values/theme_colors.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <color name="colorPrimary">@color/tusky_blue_darker</color>
+    <color name="colorSecondary">@color/tusky_blue_darker</color>
     <color name="colorSurface">@color/tusky_grey_95</color>
     <color name="colorPrimaryDark">@color/tusky_grey_70</color>
 

--- a/app/src/main/res/values/theme_colors.xml
+++ b/app/src/main/res/values/theme_colors.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <color name="colorSurface">@color/tusky_grey_95</color>
     <color name="colorPrimaryDark">@color/tusky_grey_70</color>
 
@@ -31,6 +30,6 @@
     <color name="toolbar_icon_background">#CCEBEFF4</color>
 
     <!-- colors used to show inserted/deleted text -->
-    <color name="view_edits_background_insert">#CCFFD8</color>
-    <color name="view_edits_background_delete">#FFC0C0</color>
+    <color name="view_edits_background_insert">@color/tusky_green_lighter</color>
+    <color name="view_edits_background_delete">@color/tusky_red_lighter</color>
 </resources>

--- a/app/src/main/res/values/theme_colors.xml
+++ b/app/src/main/res/values/theme_colors.xml
@@ -22,6 +22,8 @@
 
     <color name="favoriteButtonActiveColor">@color/tusky_orange_light</color>
 
+    <color name="warning_color">@color/tusky_red</color>
+
     <color name="headerBackgroundFilter">@color/header_background_filter_light</color>
 
     <bool name="lightNavigationBar">true</bool>


### PR DESCRIPTION
Fixes: #3477

This tweaks two colors: 
* for the dark theme a new slightly darker (timeline) background is used.
* for the light theme a darker shade of blue is used as highlight color (`colorPrimary` and `colorSecondary`)

Additional change:
* Use green and red more consistent: use existing colors for the diff display; move the new light variants to colors.xml like all colors

