### PR TITLE
Provide specific gradle properties for builds on CI

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -1,0 +1,24 @@
+#
+# Copyright 2023 Tusky Contributors
+#
+# This file is a part of Tusky.
+#
+# This program is free software; you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+# the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Tusky; if not,
+# see <http://www.gnu.org/licenses>.
+#
+
+# CI build workers are ephemeral, so don't benefit from the Gradle daemon
+org.gradle.daemon=false
+org.gradle.parallel=true
+org.gradle.workers.max=2
+
+kotlin.incremental=false
+kotlin.compiler.execution.strategy=in-process

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1
 
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
       - name: Gradle Build Action
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/populate-gradle-build-cache.yml
+++ b/.github/workflows/populate-gradle-build-cache.yml
@@ -20,9 +20,15 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
       - uses: gradle/gradle-build-action@v2
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
-  
+
       - name: Run app:buildGreenDebug
         run: ./gradlew app:buildGreenDebug


### PR DESCRIPTION
Expectation is that these will result in faster builds by disabling options (like the gradle daemon) that benefit long-lived processes but do not benefit ephemeral build workers.