### PR TITLE
Make CW description selectable

### DIFF
--- a/app/src/main/res/layout/item_status_detailed.xml
+++ b/app/src/main/res/layout/item_status_detailed.xml
@@ -89,6 +89,7 @@
         android:importantForAccessibility="no"
         android:lineSpacingMultiplier="1.1"
         android:textColor="?android:textColorPrimary"
+        android:textIsSelectable="true"
         android:textSize="?attr/status_text_large"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
While the status text in the detailed layout was selectable, CW description wasn't.

Also made both CW and text selectable when viewing edits.

Fixed layouts:
- `item_status_detailed.xml`: from the bug report
- ~~`item_status_edit.xml`: I deemed it worth it to fix it there too~~

Reviewed but not made selectable:
- `item_status.xml`: as tapping on the view opens the detailed view and adding a long press to select gesture could make UX confusing
- `item_status_notification.xml`: as tapping on the notification launches the app

Fixes #3826.

<img src="https://github.com/tuskyapp/Tusky/assets/1063155/98496ba1-b349-4397-8241-9a6c2b4255de" width=320 />

<img src="https://github.com/tuskyapp/Tusky/assets/1063155/6341454a-c286-48f9-88c9-f4834aff86fe" width=320 />

