### PR TITLE
Filters> Tabs: use checkbox instead of switch

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/TabFilterPreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/TabFilterPreferencesFragment.kt
@@ -19,9 +19,9 @@ import android.os.Bundle
 import androidx.preference.PreferenceFragmentCompat
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.settings.PrefKeys
-import com.keylesspalace.tusky.settings.checkBoxPreference
 import com.keylesspalace.tusky.settings.makePreferenceScreen
 import com.keylesspalace.tusky.settings.preferenceCategory
+import com.keylesspalace.tusky.settings.switchPreference
 
 class TabFilterPreferencesFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -29,14 +29,14 @@ class TabFilterPreferencesFragment : PreferenceFragmentCompat() {
             preferenceCategory(R.string.title_home) { category ->
                 category.isIconSpaceReserved = false
 
-                checkBoxPreference {
+                switchPreference {
                     setTitle(R.string.pref_title_show_boosts)
                     key = PrefKeys.TAB_FILTER_HOME_BOOSTS
                     setDefaultValue(true)
                     isIconSpaceReserved = false
                 }
 
-                checkBoxPreference {
+                switchPreference {
                     setTitle(R.string.pref_title_show_replies)
                     key = PrefKeys.TAB_FILTER_HOME_REPLIES
                     setDefaultValue(true)

--- a/app/src/main/java/com/keylesspalace/tusky/settings/SettingsDSL.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/settings/SettingsDSL.kt
@@ -6,7 +6,6 @@ import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.annotation.StringRes
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.LifecycleOwner
-import androidx.preference.CheckBoxPreference
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.Preference
@@ -81,15 +80,6 @@ inline fun PreferenceParent.validatedEditTextPreference(
             }
         }
     }
-    builder(pref)
-    addPref(pref)
-    return pref
-}
-
-inline fun PreferenceParent.checkBoxPreference(
-    builder: CheckBoxPreference.() -> Unit
-): CheckBoxPreference {
-    val pref = CheckBoxPreference(context)
     builder(pref)
     addPref(pref)
     return pref


### PR DESCRIPTION
Nowhere else in the preferences are checkboxes used.

Also removed the now unused extension function.

Fixes #3535.

| Before | After |
|--------|--------|
| <img src="https://github.com/tuskyapp/Tusky/assets/1063155/41f61713-3a59-4eb5-a625-992a7c39f426" width=320 /> | <img src="https://github.com/tuskyapp/Tusky/assets/1063155/8823e652-a6d3-405a-8901-ffa538f0fdfd" width=320 />|