### PR TITLE
Use case-insensitive checks when comparing account URLs in search

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/BottomSheetActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/BottomSheetActivity.kt
@@ -87,7 +87,7 @@ abstract class BottomSheetActivity : BaseActivity() {
                         viewThread(statuses[0].id, statuses[0].url)
                         return@subscribe
                     }
-                    accounts.firstOrNull { it.url == url }?.let { account ->
+                    accounts.firstOrNull { it.url.equals(url, ignoreCase = true) }?.let { account ->
                         // Some servers return (unrelated) accounts for url searches (#2804)
                         // Verify that the account's url matches the query
                         viewAccount(account.id)


### PR DESCRIPTION
Fixes #3929