### PR TITLE
Detect Bookwyrm URL formats

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -284,6 +284,8 @@ fun openLinkInCustomTab(uri: Uri, context: Context) {
 // https://gts.foo.bar/@goblin/statuses/01GH9XANCJ0TA8Y95VE9H3Y0Q2
 // https://gts.foo.bar/@goblin
 // https://foo.microblog.pub/o/5b64045effd24f48a27d7059f6cb38f5
+// https://bookwyrm.foo.bar/user/User
+// https://bookwyrm.foo.bar/user/User/comment/123456
 fun looksLikeMastodonUrl(urlString: String): Boolean {
     val uri: URI
     try {
@@ -304,6 +306,8 @@ fun looksLikeMastodonUrl(urlString: String): Boolean {
             it.matches("^/@[^/]+/\\d+$".toRegex()) ||
             it.matches("^/users/[^/]+/statuses/\\d+$".toRegex()) ||
             it.matches("^/users/\\w+$".toRegex()) ||
+            it.matches("^/user/[^/]+/comment/\\d+$".toRegex()) ||
+            it.matches("^/user/\\w+$".toRegex()) ||
             it.matches("^/notice/[a-zA-Z0-9]+$".toRegex()) ||
             it.matches("^/objects/[-a-f0-9]+$".toRegex()) ||
             it.matches("^/notes/[a-z0-9]+$".toRegex()) ||

--- a/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
@@ -348,7 +348,6 @@ class LinkHelperTest {
                     arrayOf("https://pleroma.foo.bar/users/", false),
                     arrayOf("https://pleroma.foo.bar/users/meow/", false),
                     arrayOf("https://pleroma.foo.bar/users/@meow", false),
-                    arrayOf("https://pleroma.foo.bar/user/2345", false),
                     arrayOf("https://pleroma.foo.bar/notices/123456", false),
                     arrayOf("https://pleroma.foo.bar/notice/@neverhappen/", false),
                     arrayOf("https://pleroma.foo.bar/object/abcdef-123-abcd-9876543", false),

--- a/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/util/LinkHelperTest.kt
@@ -367,7 +367,9 @@ class LinkHelperTest {
                     arrayOf("https://pixelfed.social/connyduck", true),
                     arrayOf("https://gts.foo.bar/@goblin/statuses/01GH9XANCJ0TA8Y95VE9H3Y0Q2", true),
                     arrayOf("https://gts.foo.bar/@goblin", true),
-                    arrayOf("https://foo.microblog.pub/o/5b64045effd24f48a27d7059f6cb38f5", true)
+                    arrayOf("https://foo.microblog.pub/o/5b64045effd24f48a27d7059f6cb38f5", true),
+                    arrayOf("https://bookwyrm.foo.bar/user/User", true),
+                    arrayOf("https://bookwyrm.foo.bar/user/User/comment/123456", true)
                 )
             }
         }


### PR DESCRIPTION
While helping test an issue with [Bookwyrm](https://github.com/bookwyrm-social/bookwyrm) I noticed that the URL formats used by that project aren't checked as possible profile or post links. They're quite close to a couple of others, so I just copied close examples and edited a couple of terms.

It's pretty minor, I just used a previous commit as a reference. Let me know if it needs anything more though. I've only quickly tested it on a local build with a couple of links against a live Bookwyrm and it picks them up as expected now.