### PR TITLE
Account: hide option to mute own domain (it is a no-op).

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
@@ -772,13 +772,16 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvide
             loadedAccount?.let { loadedAccount ->
                 val muteDomain = menu.findItem(R.id.action_mute_domain)
                 domain = getDomain(loadedAccount.url)
-                if (domain.isEmpty()) {
+                when {
                     // If we can't get the domain, there's no way we can mute it anyway...
-                    menu.removeItem(R.id.action_mute_domain)
-                } else {
-                    if (blockingDomain) {
+                    // If the account is from our own domain, muting it is no-op
+                    domain.isEmpty() || viewModel.isFromOwnDomain -> {
+                        menu.removeItem(R.id.action_mute_domain)
+                    }
+                    blockingDomain -> {
                         muteDomain.title = getString(R.string.action_unmute_domain, domain)
-                    } else {
+                    }
+                    else -> {
                         muteDomain.title = getString(R.string.action_mute_domain, domain)
                     }
                 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountViewModel.kt
@@ -19,6 +19,7 @@ import com.keylesspalace.tusky.util.Error
 import com.keylesspalace.tusky.util.Loading
 import com.keylesspalace.tusky.util.Resource
 import com.keylesspalace.tusky.util.Success
+import com.keylesspalace.tusky.util.getDomain
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -40,6 +41,7 @@ class AccountViewModel @Inject constructor(
 
     lateinit var accountId: String
     var isSelf = false
+    var isFromOwnDomain = false
 
     private var noteUpdateJob: Job? = null
 
@@ -65,6 +67,8 @@ class AccountViewModel @Inject constructor(
                             accountData.postValue(Success(account))
                             isDataLoading = false
                             isRefreshing.postValue(false)
+
+                            isFromOwnDomain = getDomain(account.url) == accountManager.activeAccount?.domain
                         },
                         { t ->
                             Log.w(TAG, "failed obtaining account", t)

--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountViewModel.kt
@@ -28,7 +28,7 @@ import javax.inject.Inject
 class AccountViewModel @Inject constructor(
     private val mastodonApi: MastodonApi,
     private val eventHub: EventHub,
-    private val accountManager: AccountManager
+    accountManager: AccountManager
 ) : ViewModel() {
 
     val accountData = MutableLiveData<Resource<Account>>()
@@ -41,9 +41,13 @@ class AccountViewModel @Inject constructor(
 
     lateinit var accountId: String
     var isSelf = false
+
+    /** True if the viewed account has the same domain as the active account */
     var isFromOwnDomain = false
 
     private var noteUpdateJob: Job? = null
+
+    private val activeAccount = accountManager.activeAccount!!
 
     init {
         viewModelScope.launch {
@@ -68,7 +72,7 @@ class AccountViewModel @Inject constructor(
                             isDataLoading = false
                             isRefreshing.postValue(false)
 
-                            isFromOwnDomain = getDomain(account.url) == accountManager.activeAccount?.domain
+                            isFromOwnDomain = getDomain(account.url) == activeAccount.domain
                         },
                         { t ->
                             Log.w(TAG, "failed obtaining account", t)
@@ -302,7 +306,7 @@ class AccountViewModel @Inject constructor(
 
     fun setAccountInfo(accountId: String) {
         this.accountId = accountId
-        this.isSelf = accountManager.activeAccount?.accountId == accountId
+        this.isSelf = activeAccount.accountId == accountId
         reload(false)
     }
 


### PR DESCRIPTION
Fixes #3798.

I was not sure if I should put the domain comparison in the `Activity` (since it seems to keep some state and there is code there already accessing `AccountManager`) or in `ViewModel` (to me, this is the "right place" for it to be, being more encapsulated and easier to test, were this class already tested).

How do you feel about converting the cascading `if/else` to a `when` statement?

Also, should I do a case insensitive comparison, as in https://github.com/tuskyapp/Tusky/pull/3931? I opted not to, as the problematic case there was about casing for the username/handle, not the domain portion.