### PR TITLE
Kotlin - Enable trailing comma

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,11 +7,13 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.{java,kt}]
 # Disable wildcard imports
-[*.{java, kt}]
 ij_kotlin_name_count_to_use_star_import = 999
 ij_kotlin_name_count_to_use_star_import_for_members = 999
 ij_java_class_count_to_use_import_on_demand = 999
+# Enable trailing comma
+ktlint_disabled_rules=trailing-comma-on-call-site,trailing-comma-on-declaration-site
 
 [*.{yml,yaml}]
 indent_size = 2

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/Screen.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/Screen.kt
@@ -20,5 +20,5 @@ enum class Screen {
     Note,
     Done,
     Back,
-    Finish
+    Finish,
 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledStatusActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledStatusActivity.kt
@@ -163,8 +163,8 @@ class ScheduledStatusActivity :
                 visibility = item.params.visibility,
                 scheduledAt = item.scheduledAt,
                 sensitive = item.params.sensitive,
-                kind = ComposeActivity.ComposeKind.EDIT_SCHEDULED
-            )
+                kind = ComposeActivity.ComposeKind.EDIT_SCHEDULED,
+            ),
         )
         startActivity(intent)
     }


### PR DESCRIPTION
Trailing commas on Kotlin sources [has many advantages](https://pinterest.github.io/ktlint/0.49.0/rules/standard/#trailing-comma-on-call-site):
- It makes version-control diffs cleaner – as all the focus is on the changed value.
- It makes it easy to add and reorder elements – there is no need to add or delete the comma if you manipulate elements.
- It simplifies code generation, for example, for object initializers. The last element can also have a comma.

This PR doesn't go as far as require it, but tweaks KtLint to at least allow it.

The two `.kt` files prove that the KtLint rules have been properly disabled.
