### PR TITLE
Prompt the user before deleting a Filter. (#3736)

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
@@ -1,7 +1,7 @@
 package com.keylesspalace.tusky.components.filters
 
 import android.content.Context
-import android.content.DialogInterface
+import android.content.DialogInterface.BUTTON_POSITIVE
 import android.os.Bundle
 import android.view.View
 import android.widget.AdapterView
@@ -84,7 +84,7 @@ class EditFilterActivity : BaseActivity() {
         binding.filterSaveButton.setOnClickListener { saveChanges() }
         binding.filterDeleteButton.setOnClickListener {
             lifecycleScope.launch {
-                if (showDeleteFilterDialog(filter.title) == DialogInterface.BUTTON_POSITIVE) deleteFilter()
+                if (showDeleteFilterDialog(filter.title) == BUTTON_POSITIVE) deleteFilter()
             }
         }
         binding.filterDeleteButton.visible(originalFilter != null)

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
@@ -81,7 +81,7 @@ class EditFilterActivity : BaseActivity() {
 
         binding.actionChip.setOnClickListener { showAddKeywordDialog() }
         binding.filterSaveButton.setOnClickListener { saveChanges() }
-        binding.filterDeleteButton.setOnClickListener { deleteFilter() }
+        binding.filterDeleteButton.setOnClickListener { showDeleteFilterDialog() }
         binding.filterDeleteButton.visible(originalFilter != null)
 
         for (switch in contextSwitches.keys) {
@@ -246,6 +246,16 @@ class EditFilterActivity : BaseActivity() {
                 )
             }
             .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun showDeleteFilterDialog() {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.filter_delete_title)
+            .setMessage(getString(R.string.filter_delete_text, filter.title))
+            .setPositiveButton(R.string.filter_delete_positive_action) { _, _ -> deleteFilter() }
+            .setNegativeButton(android.R.string.cancel) { dialog, _ -> dialog.cancel() }
+            .setCancelable(true)
             .show()
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
@@ -1,6 +1,7 @@
 package com.keylesspalace.tusky.components.filters
 
 import android.content.Context
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
 import android.widget.AdapterView
@@ -81,7 +82,11 @@ class EditFilterActivity : BaseActivity() {
 
         binding.actionChip.setOnClickListener { showAddKeywordDialog() }
         binding.filterSaveButton.setOnClickListener { saveChanges() }
-        binding.filterDeleteButton.setOnClickListener { showDeleteFilterDialog() }
+        binding.filterDeleteButton.setOnClickListener {
+            lifecycleScope.launch {
+                if (showDeleteFilterDialog(filter.title) == DialogInterface.BUTTON_POSITIVE) deleteFilter()
+            }
+        }
         binding.filterDeleteButton.visible(originalFilter != null)
 
         for (switch in contextSwitches.keys) {
@@ -246,16 +251,6 @@ class EditFilterActivity : BaseActivity() {
                 )
             }
             .setNegativeButton(android.R.string.cancel, null)
-            .show()
-    }
-
-    private fun showDeleteFilterDialog() {
-        AlertDialog.Builder(this)
-            .setTitle(R.string.filter_delete_title)
-            .setMessage(getString(R.string.filter_delete_text, filter.title))
-            .setPositiveButton(R.string.filter_delete_positive_action) { _, _ -> deleteFilter() }
-            .setNegativeButton(android.R.string.cancel) { dialog, _ -> dialog.cancel() }
-            .setCancelable(true)
             .show()
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/FilterExtensions.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/FilterExtensions.kt
@@ -1,0 +1,29 @@
+package com.keylesspalace.tusky.components.filters
+
+import android.app.Activity
+import androidx.appcompat.app.AlertDialog
+import com.keylesspalace.tusky.R
+import com.keylesspalace.tusky.util.await
+
+/*
+ * Copyright 2023 Tusky Contributors
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+internal suspend fun Activity.showDeleteFilterDialog(filterTitle: String) = AlertDialog.Builder(this)
+    .setMessage(getString(R.string.dialog_delete_filter_text, filterTitle))
+    .setCancelable(true)
+    .create()
+    .await(R.string.dialog_delete_filter_positive_action, android.R.string.cancel)

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/FilterExtensions.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/FilterExtensions.kt
@@ -1,10 +1,3 @@
-package com.keylesspalace.tusky.components.filters
-
-import android.app.Activity
-import androidx.appcompat.app.AlertDialog
-import com.keylesspalace.tusky.R
-import com.keylesspalace.tusky.util.await
-
 /*
  * Copyright 2023 Tusky Contributors
  *
@@ -21,6 +14,13 @@ import com.keylesspalace.tusky.util.await
  * You should have received a copy of the GNU General Public License along with Tusky; if not,
  * see <http://www.gnu.org/licenses>.
  */
+
+package com.keylesspalace.tusky.components.filters
+
+import android.app.Activity
+import androidx.appcompat.app.AlertDialog
+import com.keylesspalace.tusky.R
+import com.keylesspalace.tusky.util.await
 
 internal suspend fun Activity.showDeleteFilterDialog(filterTitle: String) = AlertDialog.Builder(this)
     .setMessage(getString(R.string.dialog_delete_filter_text, filterTitle))

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersActivity.kt
@@ -107,7 +107,7 @@ class FiltersActivity : BaseActivity(), FiltersListener {
     override fun deleteFilter(filter: Filter) {
         lifecycleScope.launch {
             if (showDeleteFilterDialog(filter.title) == BUTTON_POSITIVE) {
-                viewModel.deleteFilter(filter,binding.root)
+                viewModel.deleteFilter(filter, binding.root)
             }
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersActivity.kt
@@ -1,9 +1,9 @@
 package com.keylesspalace.tusky.components.filters
 
+import android.content.DialogInterface.BUTTON_POSITIVE
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
-import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.lifecycleScope
 import com.keylesspalace.tusky.BaseActivity
 import com.keylesspalace.tusky.R
@@ -105,13 +105,11 @@ class FiltersActivity : BaseActivity(), FiltersListener {
     }
 
     override fun deleteFilter(filter: Filter) {
-        AlertDialog.Builder(this)
-            .setTitle(R.string.filter_delete_title)
-            .setMessage(getString(R.string.filter_delete_text, filter.title))
-            .setPositiveButton(R.string.filter_delete_positive_action) { _, _ -> viewModel.deleteFilter(filter, binding.root) }
-            .setNegativeButton(android.R.string.cancel) { dialog, _ -> dialog.cancel() }
-            .setCancelable(true)
-            .show()
+        lifecycleScope.launch {
+            if (showDeleteFilterDialog(filter.title) == BUTTON_POSITIVE) {
+                viewModel.deleteFilter(filter,binding.root)
+            }
+        }
     }
 
     override fun updateFilter(updatedFilter: Filter) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersActivity.kt
@@ -3,6 +3,7 @@ package com.keylesspalace.tusky.components.filters
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.lifecycleScope
 import com.keylesspalace.tusky.BaseActivity
 import com.keylesspalace.tusky.R
@@ -104,7 +105,13 @@ class FiltersActivity : BaseActivity(), FiltersListener {
     }
 
     override fun deleteFilter(filter: Filter) {
-        viewModel.deleteFilter(filter, binding.root)
+        AlertDialog.Builder(this)
+            .setTitle(R.string.filter_delete_title)
+            .setMessage(getString(R.string.filter_delete_text, filter.title))
+            .setPositiveButton(R.string.filter_delete_positive_action) { _, _ -> viewModel.deleteFilter(filter, binding.root) }
+            .setNegativeButton(android.R.string.cancel) { dialog, _ -> dialog.cancel() }
+            .setCancelable(true)
+            .show()
     }
 
     override fun updateFilter(updatedFilter: Filter) {

--- a/app/src/main/java/com/keylesspalace/tusky/util/AlertDialogExtensions.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/AlertDialogExtensions.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 Tusky Contributors
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>.
+ */
+
+package com.keylesspalace.tusky.util
+
+import android.content.DialogInterface
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/**
+ * Wait for the alert dialog buttons to be clicked, return the ID of the clicked button
+ *
+ * @param positiveText Text to show on the positive button
+ * @param negativeText Optional text to show on the negative button
+ * @param neutralText Optional text to show on the neutral button
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+suspend fun AlertDialog.await(
+    positiveText: String,
+    negativeText: String? = null,
+    neutralText: String? = null
+) = suspendCancellableCoroutine<Int> { cont ->
+    val listener = DialogInterface.OnClickListener { _, which ->
+        cont.resume(which) { dismiss() }
+    }
+
+    setButton(AlertDialog.BUTTON_POSITIVE, positiveText, listener)
+    negativeText?.let { setButton(AlertDialog.BUTTON_NEGATIVE, it, listener) }
+    neutralText?.let { setButton(AlertDialog.BUTTON_NEUTRAL, it, listener) }
+
+    setOnCancelListener { cont.cancel() }
+    cont.invokeOnCancellation { dismiss() }
+    show()
+}
+
+/**
+ * @see [AlertDialog.await]
+ */
+suspend fun AlertDialog.await(
+    @StringRes positiveTextResource: Int,
+    @StringRes negativeTextResource: Int? = null,
+    @StringRes neutralTextResource: Int? = null
+) = await(
+    context.getString(positiveTextResource),
+    negativeTextResource?.let { context.getString(it) },
+    neutralTextResource?.let { context.getString(it) }
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -818,4 +818,7 @@
     <string name="about_copy">Copy version and device information</string>
     <string name="about_copied">Copied version and device information</string>
     <string name="error_media_playback">Playback failed: %s</string>
+    <string name="filter_delete_title">Delete Filter</string>
+    <string name="filter_delete_text">Are you sure you want to delete the filter \'%1$s\'?</string>
+    <string name="filter_delete_positive_action">Yes, delete</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -818,7 +818,6 @@
     <string name="about_copy">Copy version and device information</string>
     <string name="about_copied">Copied version and device information</string>
     <string name="error_media_playback">Playback failed: %s</string>
-    <string name="filter_delete_title">Delete Filter</string>
-    <string name="filter_delete_text">Are you sure you want to delete the filter \'%1$s\'?</string>
-    <string name="filter_delete_positive_action">Yes, delete</string>
+    <string name="dialog_delete_filter_text">Delete filter \'%1$s\'?"</string>
+    <string name="dialog_delete_filter_positive_action">Delete</string>
 </resources>


### PR DESCRIPTION
### Objective
* Prevent users from accidentally deleting filters by prompting them to confirm.

### Description
* The code to delete a filter is untouched, I simply inserted the AlertDialog in the middle (where it applies).
* Added corresponding Strings.

### Issue
#3736 

### Screenshot

<details>
  <summary>Screenshots</summary>
  
![image](https://github.com/tuskyapp/Tusky/assets/15253/80d0358d-6828-41c9-ab03-b33d19a6f415)

![image](https://github.com/tuskyapp/Tusky/assets/15253/dddd28bb-bdda-417e-9753-96af799b257b)

</details> 

