### PR TITLE
Fix exception when updating summary notifications

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationHelper.java
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationHelper.java
@@ -238,7 +238,7 @@ public class NotificationHelper {
         Bundle extras = new Bundle();
         // Add the sending account's name, so it can be used when summarising this notification
         extras.putString(EXTRA_ACCOUNT_NAME, body.getAccount().getName());
-        extras.putString(EXTRA_NOTIFICATION_TYPE, body.getType().toString());
+        extras.putSerializable(EXTRA_NOTIFICATION_TYPE, body.getType());
         builder.addExtras(extras);
 
         // Only alert for the first notification of a batch to avoid multiple alerts at once


### PR DESCRIPTION
https://github.com/tuskyapp/Tusky/commit/dc9e9f2aebfd3feb057fee4c3ac72b05cbc75a12 modifed the code that fetched the value of EXTRA_NOTIFICATION_TYPE in an intent, to use getSerializable().

However, the value was being placed in to the intent using putString().

This caused an exception when trying to update the summary notification, so it would never update.

```
java.lang.ClassCastException: java.lang.String cannot be cast to com.keylesspalace.tusky.entity.Notification$Type
    at com.keylesspalace.tusky.components.notifications.NotificationHelper.updateSummaryNotifications(NotificationHelper.java:321)
    at com.keylesspalace.tusky.components.notifications.NotificationFetcher.fetchAndShow(NotificationFetcher.kt:87)
    at com.keylesspalace.tusky.components.notifications.NotificationFetcher$fetchAndShow$1.invokeSuspend(Unknown Source:14)
```

Fix this by placing the value in to the intent using putSerializable(), to match how it will be fetched.