### PR TITLE
Move reviewdog-suggester permissions block to before the job definition

### DIFF
--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -1,5 +1,11 @@
 name: reviewdog-suggester
 on: pull_request
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   ktlint:
     timeout-minutes: 5
@@ -29,7 +35,4 @@ jobs:
         with:
           tool_name: ktlintFormat
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+


### PR DESCRIPTION
The reviewdog-suggester job was failing to leave comments, reporting:

```
reviewdog: This GitHub token doesn't have write permission of Review API [1], 
so reviewdog will report results via logging command [2] and create annotations similar to
github-pr-check reporter as a fallback.
```

Despite a `permissions` block the log showed the permissions as:

```
GITHUB_TOKEN Permissions
  Contents: read
  Issues: read
  Metadata: read
  PullRequests: read
```

Move the `permissions` block to earlier in the file, in case the position is important.