### PR TITLE
fix links sometimes being underlined

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -68,7 +68,7 @@ fun setClickableText(view: TextView, content: CharSequence, mentions: List<Menti
     val spannableContent = markupHiddenUrls(view.context, content)
 
     view.text = spannableContent.apply {
-        getSpans(0, content.length, URLSpan::class.java).forEach {
+        getSpans(0, spannableContent.length, URLSpan::class.java).forEach {
             setClickableText(it, this, mentions, tags, listener)
         }
     }


### PR DESCRIPTION
closes #3989 

before:
![before](https://github.com/tuskyapp/Tusky/assets/10157047/a9004b44-dfd3-414d-838e-538df1eee2a7)

after:
![after](https://github.com/tuskyapp/Tusky/assets/10157047/f98790ac-80f1-459a-b726-b14b112fe0b1)
