### PR TITLE
Fix link to Matrix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ If you have any bug reports, feature requests or questions please open an issue 
 We always welcome new contributors! Please read our [contribution guide](https://github.com/tuskyapp/Tusky/blob/develop/CONTRIBUTING.md) to get started.
 
 ### Development chatroom
-https://riot.im/app/#/room/#Tusky:matrix.org
+https://matrix.to/#/#Tusky:matrix.org


### PR DESCRIPTION
Our Matrix link goes to riot.im. Riot has been renamed to Vector and the riot.im frontpage now redirects to element.io. Since most users will now be using Element not riot.im, the riot link will (although it will partially work) not work as expected.

Vector now recommends Space links use matrix.to, which is a pretty neat site that will forward the space invite to the user's preferred Matrix frontend *even if it is not Element*. So we should use that.