### PR TITLE
remove RxJava from MastodonApi

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/BottomSheetActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/BottomSheetActivity.kt
@@ -22,16 +22,15 @@ import android.view.View
 import android.widget.LinearLayout
 import android.widget.Toast
 import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.Lifecycle
-import autodispose2.androidx.lifecycle.AndroidLifecycleScopeProvider
-import autodispose2.autoDispose
+import androidx.lifecycle.lifecycleScope
+import at.connyduck.calladapter.networkresult.fold
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.keylesspalace.tusky.components.account.AccountActivity
 import com.keylesspalace.tusky.components.viewthread.ViewThreadActivity
 import com.keylesspalace.tusky.network.MastodonApi
 import com.keylesspalace.tusky.util.looksLikeMastodonUrl
 import com.keylesspalace.tusky.util.openLink
-import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /** this is the base class for all activities that open links
@@ -70,41 +69,39 @@ abstract class BottomSheetActivity : BaseActivity() {
             return
         }
 
-        mastodonApi.searchObservable(
-            query = url,
-            resolve = true
-        ).observeOn(AndroidSchedulers.mainThread())
-            .autoDispose(AndroidLifecycleScopeProvider.from(this, Lifecycle.Event.ON_DESTROY))
-            .subscribe(
-                { (accounts, statuses) ->
-                    if (getCancelSearchRequested(url)) {
-                        return@subscribe
-                    }
-
-                    onEndSearch(url)
-
-                    if (statuses.isNotEmpty()) {
-                        viewThread(statuses[0].id, statuses[0].url)
-                        return@subscribe
-                    }
-                    accounts.firstOrNull { it.url.equals(url, ignoreCase = true) }?.let { account ->
-                        // Some servers return (unrelated) accounts for url searches (#2804)
-                        // Verify that the account's url matches the query
-                        viewAccount(account.id)
-                        return@subscribe
-                    }
-
-                    performUrlFallbackAction(url, lookupFallbackBehavior)
-                },
-                {
-                    if (!getCancelSearchRequested(url)) {
-                        onEndSearch(url)
-                        performUrlFallbackAction(url, lookupFallbackBehavior)
-                    }
-                }
-            )
-
         onBeginSearch(url)
+
+        lifecycleScope.launch {
+            mastodonApi.search(
+                query = url,
+                resolve = true
+            ).fold({ r ->
+                val (accounts, statuses) = r
+                if (getCancelSearchRequested(url)) {
+                    return@fold
+                }
+
+                onEndSearch(url)
+
+                if (statuses.isNotEmpty()) {
+                    viewThread(statuses[0].id, statuses[0].url)
+                    return@fold
+                }
+                accounts.firstOrNull { it.url.equals(url, ignoreCase = true) }?.let { account ->
+                    // Some servers return (unrelated) accounts for url searches (#2804)
+                    // Verify that the account's url matches the query
+                    viewAccount(account.id)
+                    return@fold
+                }
+
+                performUrlFallbackAction(url, lookupFallbackBehavior)
+            }, {
+                if (!getCancelSearchRequested(url)) {
+                    onEndSearch(url)
+                    performUrlFallbackAction(url, lookupFallbackBehavior)
+                }
+            })
+        }
     }
 
     open fun viewThread(statusId: String, url: String?) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
@@ -65,7 +65,6 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.rx3.await
 import retrofit2.HttpException
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
@@ -422,9 +421,9 @@ class NotificationsViewModel @Inject constructor(
                     try {
                         when (action) {
                             is NotificationAction.AcceptFollowRequest ->
-                                timelineCases.acceptFollowRequest(action.accountId).await()
+                                timelineCases.acceptFollowRequest(action.accountId)
                             is NotificationAction.RejectFollowRequest ->
-                                timelineCases.rejectFollowRequest(action.accountId).await()
+                                timelineCases.rejectFollowRequest(action.accountId)
                         }
                         uiSuccess.emit(NotificationActionSuccess.from(action))
                     } catch (e: Exception) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/adapter/StatusesPagingSource.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/adapter/StatusesPagingSource.kt
@@ -18,6 +18,7 @@ package com.keylesspalace.tusky.components.report.adapter
 import android.util.Log
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import at.connyduck.calladapter.networkresult.getOrThrow
 import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.network.MastodonApi
 import kotlinx.coroutines.Dispatchers
@@ -72,17 +73,17 @@ class StatusesPagingSource(
     }
 
     private suspend fun getSingleStatus(statusId: String): Status {
-        return mastodonApi.statusObservable(statusId).await()
+        return mastodonApi.status(statusId).getOrThrow()
     }
 
     private suspend fun getStatusList(minId: String? = null, maxId: String? = null, limit: Int): List<Status> {
-        return mastodonApi.accountStatusesObservable(
+        return mastodonApi.accountStatuses(
             accountId = accountId,
             maxId = maxId,
             sinceId = null,
             minId = minId,
             limit = limit,
             excludeReblogs = true
-        ).await()
+        ).body() ?: throw IllegalStateException("accountStatuses response body is empty")
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledStatusPagingSource.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledStatusPagingSource.kt
@@ -18,9 +18,9 @@ package com.keylesspalace.tusky.components.scheduled
 import android.util.Log
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import at.connyduck.calladapter.networkresult.fold
 import com.keylesspalace.tusky.entity.ScheduledStatus
 import com.keylesspalace.tusky.network.MastodonApi
-import kotlinx.coroutines.rx3.await
 
 class ScheduledStatusPagingSourceFactory(
     private val mastodonApi: MastodonApi
@@ -59,21 +59,19 @@ class ScheduledStatusPagingSource(
                 nextKey = scheduledStatusesCache.lastOrNull()?.id
             )
         } else {
-            try {
-                val result = mastodonApi.scheduledStatuses(
-                    maxId = params.key,
-                    limit = params.loadSize
-                ).await()
-
+            return mastodonApi.scheduledStatuses(
+                maxId = params.key,
+                limit = params.loadSize
+            ).fold({ result ->
                 LoadResult.Page(
                     data = result,
                     prevKey = null,
                     nextKey = result.lastOrNull()?.id
                 )
-            } catch (e: Exception) {
+            }, { e ->
                 Log.w("ScheduledStatuses", "Error loading scheduled statuses", e)
                 LoadResult.Error(e)
-            }
+            })
         }
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -279,28 +279,28 @@ class NetworkTimelineViewModel @Inject constructor(
                 api.hashtagTimeline(firstHashtag, additionalHashtags, null, fromId, uptoId, limit)
             }
             Kind.USER -> api.accountStatuses(
-                id!!,
-                fromId,
-                uptoId,
-                limit,
+                accountId = id!!,
+                maxId = fromId,
+                sinceId = uptoId,
+                limit = limit,
                 excludeReplies = true,
                 onlyMedia = null,
                 pinned = null
             )
             Kind.USER_PINNED -> api.accountStatuses(
-                id!!,
-                fromId,
-                uptoId,
-                limit,
+                accountId = id!!,
+                maxId = fromId,
+                sinceId = uptoId,
+                limit = limit,
                 excludeReplies = null,
                 onlyMedia = null,
                 pinned = true
             )
             Kind.USER_WITH_REPLIES -> api.accountStatuses(
-                id!!,
-                fromId,
-                uptoId,
-                limit,
+                accountId = id!!,
+                maxId = fromId,
+                sinceId = uptoId,
+                limit = limit,
                 excludeReplies = null,
                 onlyMedia = null,
                 pinned = null

--- a/app/src/main/java/com/keylesspalace/tusky/di/NetworkModule.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/di/NetworkModule.kt
@@ -40,7 +40,6 @@ import okhttp3.OkHttp
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
-import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.create
 import java.net.IDN
@@ -119,7 +118,6 @@ class NetworkModule {
         return Retrofit.Builder().baseUrl("https://" + MastodonApi.PLACEHOLDER_DOMAIN)
             .client(httpClient)
             .addConverterFactory(GsonConverterFactory.create(gson))
-            .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
             .addCallAdapterFactory(NetworkResultCallAdapterFactory.create())
             .build()
     }

--- a/app/src/main/java/com/keylesspalace/tusky/usecase/TimelineCases.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/usecase/TimelineCases.kt
@@ -36,7 +36,6 @@ import com.keylesspalace.tusky.entity.Relationship
 import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.network.MastodonApi
 import com.keylesspalace.tusky.util.getServerErrorMessage
-import io.reactivex.rxjava3.core.Single
 import javax.inject.Inject
 
 /**
@@ -136,11 +135,11 @@ class TimelineCases @Inject constructor(
         }
     }
 
-    fun acceptFollowRequest(accountId: String): Single<Relationship> {
+    suspend fun acceptFollowRequest(accountId: String): NetworkResult<Relationship> {
         return mastodonApi.authorizeFollowRequest(accountId)
     }
 
-    fun rejectFollowRequest(accountId: String): Single<Relationship> {
+    suspend fun rejectFollowRequest(accountId: String): NetworkResult<Relationship> {
         return mastodonApi.rejectFollowRequest(accountId)
     }
 

--- a/app/src/test/java/com/keylesspalace/tusky/BottomSheetActivityTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/BottomSheetActivityTest.kt
@@ -16,14 +16,19 @@
 package com.keylesspalace.tusky
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import at.connyduck.calladapter.networkresult.NetworkResult
 import com.keylesspalace.tusky.entity.SearchResult
 import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.entity.TimelineAccount
 import com.keylesspalace.tusky.network.MastodonApi
-import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
-import io.reactivex.rxjava3.core.Single
-import io.reactivex.rxjava3.plugins.RxJavaPlugins
-import io.reactivex.rxjava3.schedulers.TestScheduler
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -35,8 +40,8 @@ import org.mockito.Mockito.eq
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import java.util.Date
-import java.util.concurrent.TimeUnit
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class BottomSheetActivityTest {
 
     @get:Rule
@@ -48,8 +53,7 @@ class BottomSheetActivityTest {
     private val statusQuery = "http://mastodon.foo.bar/@User/345678"
     private val nonexistentStatusQuery = "http://mastodon.foo.bar/@User/345678000"
     private val nonMastodonQuery = "http://medium.com/@correspondent/345678"
-    private val emptyCallback = Single.just(SearchResult(emptyList(), emptyList(), emptyList()))
-    private val testScheduler = TestScheduler()
+    private val emptyResponse = NetworkResult.success(SearchResult(emptyList(), emptyList(), emptyList()))
 
     private val account = TimelineAccount(
         id = "1",
@@ -60,7 +64,7 @@ class BottomSheetActivityTest {
         url = "http://mastodon.foo.bar/@User",
         avatar = ""
     )
-    private val accountSingle = Single.just(SearchResult(listOf(account), emptyList(), emptyList()))
+    private val accountResponse = NetworkResult.success(SearchResult(listOf(account), emptyList(), emptyList()))
 
     private val status = Status(
         id = "1",
@@ -93,31 +97,34 @@ class BottomSheetActivityTest {
         language = null,
         filtered = null
     )
-    private val statusSingle = Single.just(SearchResult(emptyList(), listOf(status), emptyList()))
+    private val statusResponse = NetworkResult.success(SearchResult(emptyList(), listOf(status), emptyList()))
 
     @Before
     fun setup() {
-        RxJavaPlugins.setIoSchedulerHandler { testScheduler }
-        RxAndroidPlugins.setMainThreadSchedulerHandler { testScheduler }
-
+        Dispatchers.setMain(StandardTestDispatcher())
         apiMock = mock {
-            on { searchObservable(eq(accountQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn accountSingle
-            on { searchObservable(eq(statusQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn statusSingle
-            on { searchObservable(eq(nonexistentStatusQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn accountSingle
-            on { searchObservable(eq(nonMastodonQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn emptyCallback
+            onBlocking { search(eq(accountQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn accountResponse
+            onBlocking { search(eq(statusQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn statusResponse
+            onBlocking { search(eq(nonexistentStatusQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn accountResponse
+            onBlocking { search(eq(nonMastodonQuery), eq(null), anyBoolean(), eq(null), eq(null), eq(null)) } doReturn emptyResponse
         }
 
         activity = FakeBottomSheetActivity(apiMock)
     }
 
+    @After
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
     @Test
-    fun beginEndSearch_setIsSearching_isSearchingAfterBegin() {
+    fun beginEndSearch_setIsSearching_isSearchingAfterBegin() = runTest {
         activity.onBeginSearch("https://mastodon.foo.bar/@User")
         assertTrue(activity.isSearching())
     }
 
     @Test
-    fun beginEndSearch_setIsSearching_isNotSearchingAfterEnd() {
+    fun beginEndSearch_setIsSearching_isNotSearchingAfterEnd() = runTest {
         val validUrl = "https://mastodon.foo.bar/@User"
         activity.onBeginSearch(validUrl)
         activity.onEndSearch(validUrl)
@@ -125,7 +132,7 @@ class BottomSheetActivityTest {
     }
 
     @Test
-    fun beginEndSearch_setIsSearching_doesNotCancelSearchWhenResponseFromPreviousSearchIsReceived() {
+    fun beginEndSearch_setIsSearching_doesNotCancelSearchWhenResponseFromPreviousSearchIsReceived() = runTest {
         val validUrl = "https://mastodon.foo.bar/@User"
         val invalidUrl = ""
 
@@ -135,7 +142,7 @@ class BottomSheetActivityTest {
     }
 
     @Test
-    fun cancelActiveSearch() {
+    fun cancelActiveSearch() = runTest {
         val url = "https://mastodon.foo.bar/@User"
 
         activity.onBeginSearch(url)
@@ -144,7 +151,7 @@ class BottomSheetActivityTest {
     }
 
     @Test
-    fun getCancelSearchRequested_detectsURL() {
+    fun getCancelSearchRequested_detectsURL() = runTest {
         val firstUrl = "https://mastodon.foo.bar/@User"
         val secondUrl = "https://mastodon.foo.bar/@meh"
 
@@ -157,46 +164,46 @@ class BottomSheetActivityTest {
     }
 
     @Test
-    fun search_inIdealConditions_returnsRequestedResults_forAccount() {
+    fun search_inIdealConditions_returnsRequestedResults_forAccount() = runTest {
         activity.viewUrl(accountQuery)
-        testScheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS)
+        advanceUntilIdle()
         assertEquals(account.id, activity.accountId)
     }
 
     @Test
-    fun search_inIdealConditions_returnsRequestedResults_forStatus() {
+    fun search_inIdealConditions_returnsRequestedResults_forStatus() = runTest {
         activity.viewUrl(statusQuery)
-        testScheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS)
+        advanceUntilIdle()
         assertEquals(status.id, activity.statusId)
     }
 
     @Test
-    fun search_inIdealConditions_returnsRequestedResults_forNonMastodonURL() {
+    fun search_inIdealConditions_returnsRequestedResults_forNonMastodonURL() = runTest {
         activity.viewUrl(nonMastodonQuery)
-        testScheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS)
+        advanceUntilIdle()
         assertEquals(nonMastodonQuery, activity.link)
     }
 
     @Test
-    fun search_withNoResults_appliesRequestedFallbackBehavior() {
+    fun search_withNoResults_appliesRequestedFallbackBehavior() = runTest {
         for (fallbackBehavior in listOf(PostLookupFallbackBehavior.OPEN_IN_BROWSER, PostLookupFallbackBehavior.DISPLAY_ERROR)) {
             activity.viewUrl(nonMastodonQuery, fallbackBehavior)
-            testScheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS)
+            advanceUntilIdle()
             assertEquals(nonMastodonQuery, activity.link)
             assertEquals(fallbackBehavior, activity.fallbackBehavior)
         }
     }
 
     @Test
-    fun search_doesNotRespectUnrelatedResult() {
+    fun search_doesNotRespectUnrelatedResult() = runTest {
         activity.viewUrl(nonexistentStatusQuery)
-        testScheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS)
+        advanceUntilIdle()
         assertEquals(nonexistentStatusQuery, activity.link)
         assertEquals(null, activity.accountId)
     }
 
     @Test
-    fun search_withCancellation_doesNotLoadUrl_forAccount() {
+    fun search_withCancellation_doesNotLoadUrl_forAccount() = runTest {
         activity.viewUrl(accountQuery)
         assertTrue(activity.isSearching())
         activity.cancelActiveSearch()
@@ -205,21 +212,21 @@ class BottomSheetActivityTest {
     }
 
     @Test
-    fun search_withCancellation_doesNotLoadUrl_forStatus() {
+    fun search_withCancellation_doesNotLoadUrl_forStatus() = runTest {
         activity.viewUrl(accountQuery)
         activity.cancelActiveSearch()
         assertEquals(null, activity.accountId)
     }
 
     @Test
-    fun search_withCancellation_doesNotLoadUrl_forNonMastodonURL() {
+    fun search_withCancellation_doesNotLoadUrl_forNonMastodonURL() = runTest {
         activity.viewUrl(nonMastodonQuery)
         activity.cancelActiveSearch()
         assertEquals(null, activity.searchUrl)
     }
 
     @Test
-    fun search_withPreviousCancellation_completes() {
+    fun search_withPreviousCancellation_completes() = runTest {
         // begin/cancel account search
         activity.viewUrl(accountQuery)
         activity.cancelActiveSearch()
@@ -231,7 +238,7 @@ class BottomSheetActivityTest {
         assertTrue(activity.isSearching())
 
         // return searchResults
-        testScheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS)
+        advanceUntilIdle()
 
         // ensure that the result of the status search was recorded
         // and the account search wasn't

--- a/app/src/test/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModelTestNotificationAction.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModelTestNotificationAction.kt
@@ -18,9 +18,9 @@
 package com.keylesspalace.tusky.components.notifications
 
 import app.cash.turbine.test
+import at.connyduck.calladapter.networkresult.NetworkResult
 import com.google.common.truth.Truth.assertThat
 import com.keylesspalace.tusky.entity.Relationship
-import io.reactivex.rxjava3.core.Single
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -66,7 +66,7 @@ class NotificationsViewModelTestNotificationAction : NotificationsViewModelTestB
     fun `accepting follow request succeeds && emits UiSuccess`() = runTest {
         // Given
         timelineCases.stub {
-            onBlocking { acceptFollowRequest(any()) } doReturn Single.just(relationship)
+            onBlocking { acceptFollowRequest(any()) } doReturn NetworkResult.success(relationship)
         }
 
         viewModel.uiSuccess.test {
@@ -105,7 +105,7 @@ class NotificationsViewModelTestNotificationAction : NotificationsViewModelTestB
     @Test
     fun `rejecting follow request succeeds && emits UiSuccess`() = runTest {
         // Given
-        timelineCases.stub { onBlocking { rejectFollowRequest(any()) } doReturn Single.just(relationship) }
+        timelineCases.stub { onBlocking { rejectFollowRequest(any()) } doReturn NetworkResult.success(relationship) }
 
         viewModel.uiSuccess.test {
             // When

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -133,7 +133,6 @@ mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "
 networkresult-calladapter = { module = "at.connyduck:networkresult-calladapter", version.ref = "networkresult-calladapter" }
 okhttp-core = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
-retrofit-adapter-rxjava3 = { module = "com.squareup.retrofit2:adapter-rxjava3", version.ref = "retrofit" }
 retrofit-converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }
 retrofit-core = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
@@ -163,7 +162,7 @@ glide = ["glide-core", "glide-okhttp3-integration", "glide-animation-plugin"]
 material-drawer = ["material-drawer-core", "material-drawer-iconics"]
 mockito = ["mockito-kotlin", "mockito-inline"]
 okhttp = ["okhttp-core", "okhttp-logging-interceptor"]
-retrofit = ["retrofit-core", "retrofit-converter-gson", "retrofit-adapter-rxjava3"]
+retrofit = ["retrofit-core", "retrofit-converter-gson"]
 room = ["androidx-room-ktx", "androidx-room-paging"]
 rxjava3 = ["rxjava3-core", "rxjava3-android", "rxjava3-kotlin"]
 xmldiff = ["diffx", "xmlwriter"]


### PR DESCRIPTION
This is the second to last step of getting rid of RxJava. It allows us already to remove the Retrofit converter library.

part of #2992 

Also fixes a bug where error handling did not work correctly when unblocking someone in AccountListFragment.