### PR TITLE
Avoid crash on notification worker

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -249,7 +249,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
             } else if (accountRequested && intent.hasExtra(NOTIFICATION_TYPE)) {
                 // user clicked a notification, show follow requests for type FOLLOW_REQUEST,
                 // otherwise show notification tab
-                if (intent.getSerializableExtra(NOTIFICATION_TYPE) == Notification.Type.FOLLOW_REQUEST) {
+                if (intent.getStringExtra(NOTIFICATION_TYPE) == Notification.Type.FOLLOW_REQUEST.name) {
                     val intent = AccountListActivity.newIntent(this, AccountListActivity.Type.FOLLOW_REQUESTS)
                     startActivityWithSlideInAnimation(intent)
                 } else {
@@ -1102,7 +1102,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
         @JvmStatic
         fun openNotificationIntent(context: Context, tuskyAccountId: Long, type: Notification.Type): Intent {
             return accountSwitchIntent(context, tuskyAccountId).apply {
-                putExtra(NOTIFICATION_TYPE, type)
+                putExtra(NOTIFICATION_TYPE, type.name)
             }
         }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationHelper.java
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationHelper.java
@@ -318,7 +318,7 @@ public class NotificationHelper {
 
             // All notifications in this group have the same type, so get it from the first.
             String typeName = members.get(0).getNotification().extras.getString(EXTRA_NOTIFICATION_TYPE, Notification.Type.UNKNOWN.name());
-            Notification.Type notificationType = Notification.Type.byString(typeName);
+            Notification.Type notificationType = Notification.Type.valueOf(typeName);
 
             Intent summaryResultIntent = MainActivity.openNotificationIntent(context, accountId, notificationType);
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationHelper.java
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationHelper.java
@@ -237,7 +237,7 @@ public class NotificationHelper {
         Bundle extras = new Bundle();
         // Add the sending account's name, so it can be used when summarising this notification
         extras.putString(EXTRA_ACCOUNT_NAME, body.getAccount().getName());
-        extras.putSerializable(EXTRA_NOTIFICATION_TYPE, body.getType());
+        extras.putString(EXTRA_NOTIFICATION_TYPE, body.getType().name());
         builder.addExtras(extras);
 
         // Only alert for the first notification of a batch to avoid multiple alerts at once
@@ -317,7 +317,8 @@ public class NotificationHelper {
             // Create a notification that summarises the other notifications in this group
 
             // All notifications in this group have the same type, so get it from the first.
-            Notification.Type notificationType = (Notification.Type)members.get(0).getNotification().extras.getSerializable(EXTRA_NOTIFICATION_TYPE);
+            String typeName = members.get(0).getNotification().extras.getString(EXTRA_NOTIFICATION_TYPE, Notification.Type.UNKNOWN.name());
+            Notification.Type notificationType = Notification.Type.byString(typeName);
 
             Intent summaryResultIntent = MainActivity.openNotificationIntent(context, accountId, notificationType);
 

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Notification.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Notification.kt
@@ -22,6 +22,7 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonParseException
 import com.google.gson.annotations.JsonAdapter
 import com.keylesspalace.tusky.R
+import java.io.Serializable
 
 data class Notification(
     val type: Type,
@@ -33,7 +34,7 @@ data class Notification(
 
     /** From https://docs.joinmastodon.org/entities/Notification/#type */
     @JsonAdapter(NotificationTypeAdapter::class)
-    enum class Type(val presentation: String, @StringRes val uiString: Int) {
+    enum class Type(val presentation: String, @StringRes val uiString: Int) : Serializable {
         UNKNOWN("unknown", R.string.notification_unknown_name),
 
         /** Someone mentioned you */

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Notification.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Notification.kt
@@ -22,7 +22,6 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonParseException
 import com.google.gson.annotations.JsonAdapter
 import com.keylesspalace.tusky.R
-import java.io.Serializable
 
 data class Notification(
     val type: Type,
@@ -34,7 +33,7 @@ data class Notification(
 
     /** From https://docs.joinmastodon.org/entities/Notification/#type */
     @JsonAdapter(NotificationTypeAdapter::class)
-    enum class Type(val presentation: String, @StringRes val uiString: Int) : Serializable {
+    enum class Type(val presentation: String, @StringRes val uiString: Int) {
         UNKNOWN("unknown", R.string.notification_unknown_name),
 
         /** Someone mentioned you */


### PR DESCRIPTION
Not quite sure why/when this happens - every stack trace is not our code, but I do get an ClassNotFoundException for Notification$Type with the new reverted code.

The notification fetching (worker) then stops/crashes so I never get an Android notification.

It might have something to do with https://github.com/tuskyapp/Tusky/pull/3732 ?