### PR TITLE
2512: Allow more than 5 tabs

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/TabPreferenceActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/TabPreferenceActivity.kt
@@ -164,18 +164,12 @@ class TabPreferenceActivity : BaseActivity(), Injectable, ItemInteractionListene
             toggleFab(false)
         }
 
-        binding.maxTabsInfo.text = resources.getQuantityString(R.plurals.max_tab_number_reached, MAX_TAB_COUNT, MAX_TAB_COUNT)
-
         updateAvailableTabs()
 
         onBackPressedDispatcher.addCallback(onFabDismissedCallback)
     }
 
     override fun onTabAdded(tab: TabData) {
-        if (currentTabs.size >= MAX_TAB_COUNT) {
-            return
-        }
-
         toggleFab(false)
 
         if (tab.id == HASHTAG) {
@@ -395,8 +389,6 @@ class TabPreferenceActivity : BaseActivity(), Injectable, ItemInteractionListene
         addableTabs.add(createTabDataFromId(LIST))
 
         addTabAdapter.updateData(addableTabs)
-
-        binding.maxTabsInfo.visible(addableTabs.size == 0 || currentTabs.size >= MAX_TAB_COUNT)
         currentTabsAdapter.setRemoveButtonVisible(currentTabs.size > MIN_TAB_COUNT)
     }
 
@@ -429,6 +421,5 @@ class TabPreferenceActivity : BaseActivity(), Injectable, ItemInteractionListene
 
     companion object {
         private const val MIN_TAB_COUNT = 2
-        private const val MAX_TAB_COUNT = 5
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/util/AdaptiveTabLayout.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/AdaptiveTabLayout.kt
@@ -1,0 +1,46 @@
+package com.keylesspalace.tusky.util
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.ViewGroup
+import com.google.android.material.tabs.TabLayout
+
+/**
+ * Switches the tab display mode depending on available size: start out with "scrollable" but
+ * if there is enough room switch to "fixed" (an re-measure).
+ *
+ * Idea taken from https://stackoverflow.com/a/44894143
+ */
+class AdaptiveTabLayout : TabLayout {
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(
+        context,
+        attrs,
+        defStyleAttr
+    )
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        tabMode = MODE_SCROLLABLE // make sure to only measure the "minimum width"
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+
+        if (tabCount < 2) {
+            return
+        }
+
+        try {
+            val tabLayout = getChildAt(0) as ViewGroup
+            var widthOfAllTabs = 0
+            for (i in 0 until tabLayout.childCount) {
+                widthOfAllTabs += tabLayout.getChildAt(i).measuredWidth
+            }
+            if (widthOfAllTabs <= measuredWidth) {
+                // fill all space if there is enough room
+                tabMode = MODE_FIXED
+                super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/app/src/main/java/com/keylesspalace/tusky/util/AdaptiveTabLayout.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/AdaptiveTabLayout.kt
@@ -25,19 +25,15 @@ class AdaptiveTabLayout @JvmOverloads constructor(
             return
         }
 
-        try {
-            val tabLayout = getChildAt(0) as ViewGroup
-            var widthOfAllTabs = 0
-            for (i in 0 until tabLayout.childCount) {
-                widthOfAllTabs += tabLayout.getChildAt(i).measuredWidth
-            }
-            if (widthOfAllTabs <= measuredWidth) {
-                // fill all space if there is enough room
-                tabMode = MODE_FIXED
-                super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
+        val tabLayout = getChildAt(0) as ViewGroup
+        var widthOfAllTabs = 0
+        for (i in 0 until tabLayout.childCount) {
+            widthOfAllTabs += tabLayout.getChildAt(i).measuredWidth
+        }
+        if (widthOfAllTabs <= measuredWidth) {
+            // fill all space if there is enough room
+            tabMode = MODE_FIXED
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec)
         }
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/util/AdaptiveTabLayout.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/AdaptiveTabLayout.kt
@@ -11,14 +11,11 @@ import com.google.android.material.tabs.TabLayout
  *
  * Idea taken from https://stackoverflow.com/a/44894143
  */
-class AdaptiveTabLayout : TabLayout {
-    constructor(context: Context) : super(context)
-    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
-    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(
-        context,
-        attrs,
-        defStyleAttr
-    )
+class AdaptiveTabLayout @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : TabLayout(context, attrs, defStyleAttr) {
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         tabMode = MODE_SCROLLABLE // make sure to only measure the "minimum width"

--- a/app/src/main/java/com/keylesspalace/tusky/view/AdaptiveTabLayout.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/view/AdaptiveTabLayout.kt
@@ -1,4 +1,4 @@
-package com.keylesspalace.tusky.util
+package com.keylesspalace.tusky.view
 
 import android.content.Context
 import android.util.AttributeSet
@@ -6,8 +6,10 @@ import android.view.ViewGroup
 import com.google.android.material.tabs.TabLayout
 
 /**
+ * Workaround for "auto" mode not behaving as expected.
+ *
  * Switches the tab display mode depending on available size: start out with "scrollable" but
- * if there is enough room switch to "fixed" (an re-measure).
+ * if there is enough room switch to "fixed" (and re-measure).
  *
  * Idea taken from https://stackoverflow.com/a/44894143
  */

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -38,14 +38,14 @@
                 app:contentInsetStartWithNavigation="0dp"
                 app:navigationContentDescription="@string/action_open_drawer">
 
-                <com.google.android.material.tabs.TabLayout
+                <com.keylesspalace.tusky.util.AdaptiveTabLayout
                     android:id="@+id/tabLayout"
                     style="@style/TuskyTabAppearance"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:tabGravity="fill"
                     app:tabMaxWidth="0dp"
-                    app:tabMode="fixed" />
+                    app:tabMode="scrollable" />
             </androidx.appcompat.widget.Toolbar>
 
         </com.google.android.material.appbar.AppBarLayout>
@@ -67,13 +67,13 @@
             app:contentInsetStartWithNavigation="0dp"
             app:fabAlignmentMode="end">
 
-            <com.google.android.material.tabs.TabLayout
+            <com.keylesspalace.tusky.util.AdaptiveTabLayout
                 android:id="@+id/bottomTabLayout"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
                 app:tabGravity="fill"
                 app:tabIndicatorGravity="top"
-                app:tabMode="fixed" />
+                app:tabMode="scrollable" />
 
         </com.google.android.material.bottomappbar.BottomAppBar>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -38,7 +38,7 @@
                 app:contentInsetStartWithNavigation="0dp"
                 app:navigationContentDescription="@string/action_open_drawer">
 
-                <com.keylesspalace.tusky.util.AdaptiveTabLayout
+                <com.keylesspalace.tusky.view.AdaptiveTabLayout
                     android:id="@+id/tabLayout"
                     style="@style/TuskyTabAppearance"
                     android:layout_width="match_parent"
@@ -67,7 +67,7 @@
             app:contentInsetStartWithNavigation="0dp"
             app:fabAlignmentMode="end">
 
-            <com.keylesspalace.tusky.util.AdaptiveTabLayout
+            <com.keylesspalace.tusky.view.AdaptiveTabLayout
                 android:id="@+id/bottomTabLayout"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"

--- a/app/src/main/res/layout/activity_tab_preference.xml
+++ b/app/src/main/res/layout/activity_tab_preference.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -52,14 +51,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:overScrollMode="never" />
-
-            <TextView
-                android:id="@+id/maxTabsInfo"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:lineSpacingMultiplier="1.1"
-                android:padding="8dp"
-                tools:text="@string/max_tab_number_reached" />
 
             <TextView
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -559,10 +559,6 @@
     <string name="conversation_1_recipients">%1$s</string>
     <string name="conversation_2_recipients">%1$s and %2$s</string>
     <string name="conversation_more_recipients">%1$s, %2$s and %3$d more</string>
-    <plurals name="max_tab_number_reached">
-        <item quantity="one">maximum of %1$d tab reached</item>
-        <item quantity="other">maximum of %1$d tabs reached</item>
-    </plurals>
 
     <string name="description_post_media">
         Media: %s


### PR DESCRIPTION
Fixes #2512 

![grafik](https://github.com/tuskyapp/Tusky/assets/1618905/f8199d10-e26a-4f14-93c3-95cb890ea663)

Can add an arbitrary number of tabs.
Graphical behavior is unchanged for small numbers: the whole space if filled with the tabs - they are enlarged if needed.

If there are more the mode switches to "scrollable".
This does not, however, look very differently (see screenshot with the current tab scrolled out).