### PR TITLE
4063: Make dialog size more stable

### DIFF
--- a/app/src/main/res/layout/dialog_image_description.xml
+++ b/app/src/main/res/layout/dialog_image_description.xml
@@ -2,6 +2,7 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -32,7 +33,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="start"
-            android:hint="@string/hint_description"
+            tools:hint="Description"
             android:importantForAutofill="no"
             android:inputType="textCapSentences|textMultiLine|textAutoCorrect" />
 

--- a/app/src/main/res/layout/dialog_image_description.xml
+++ b/app/src/main/res/layout/dialog_image_description.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -11,28 +12,53 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:contentDescription="@string/post_media_image"/>
+        android:contentDescription="@string/post_media_image" />
 
     <com.google.android.material.textfield.TextInputLayout
         style="@style/TuskyTextInput"
+
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
         android:layout_marginStart="?dialogPreferredPadding"
-        android:layout_marginTop="?dialogPreferredPadding"
         android:layout_marginEnd="?dialogPreferredPadding"
-        app:hintEnabled="false"
+        android:layout_marginTop="?dialogPreferredPadding"
         app:counterEnabled="false"
-        app:counterTextColor="?android:textColorTertiary">
+        app:counterTextColor="?android:textColorTertiary"
+        app:hintEnabled="false">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/imageDescriptionText"
-            android:inputType="textCapSentences|textMultiLine|textAutoCorrect"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:hint="@string/hint_description"
             android:gravity="start"
-            android:importantForAutofill="no" />
+            android:hint="@string/hint_description"
+            android:importantForAutofill="no"
+            android:inputType="textCapSentences|textMultiLine|textAutoCorrect" />
 
     </com.google.android.material.textfield.TextInputLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="0"
+        android:orientation="horizontal"
+        android:gravity="end"
+        android:layout_marginStart="?dialogPreferredPadding"
+        android:layout_marginEnd="?dialogPreferredPadding">
+
+        <Button
+            android:id="@+id/cancelButton"
+            style="@style/TuskyButton.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@android:string/cancel" />
+
+        <Button
+            android:id="@+id/okButton"
+            style="@style/TuskyButton.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@android:string/ok" />
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -234,7 +234,6 @@
     <string name="hint_display_name">Display name</string>
     <string name="hint_note">Bio</string>
     <string name="hint_search">Search…</string>
-    <string name="hint_description">Description</string>
     <string name="hint_media_description_missing">Media should have a description.</string>
 
     <string name="search_no_results">No results</string>


### PR DESCRIPTION
Fixes: #4063

Switching from an AlertDialog to only a DialogFragment.

I didn't get the AlertDialog to be sized correctly.
It also opens now directly with the right (full screen) size. When the imageView fails to load (i.e. with an audio file) it will be hidden.

This changes the button layout somewhat.

One observation: The placeholder text "... visually impaired..." is not quite right as a description for an audio file is not intended for the visually impaired. But I couldn't think of a better text just yet.

![grafik](https://github.com/tuskyapp/Tusky/assets/1618905/fd49d5bd-b86c-4659-abb9-f1776cbb2a55)
