### PR TITLE
Remove garbage alt text from images attached via Gboard

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -1064,7 +1064,10 @@ class ComposeActivity :
 
         // The Gboard android keyboard attaches this text whenever the user
         // pastes something from the keyboard's suggestion bar.
-        if (description == "Image from Gboard clipboard") {
+        // Due to different end user locales, the exact text may vary, but at
+        // least in version 13.4.08, all of the translations contained the
+        // string "Gboard".
+        if ("Gboard" in description) {
             return null
         }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -1059,16 +1059,16 @@ class ComposeActivity :
 
     private fun sanitizePickMediaDescription(description: String?): String? {
         if (description == null) {
-            return null;
+            return null
         }
 
         // The Gboard android keyboard attaches this text whenever the user
         // pastes something from the keyboard's suggestion bar.
         if (description == "Image from Gboard clipboard") {
-            return null;
+            return null
         }
 
-        return description;
+        return description
     }
 
     private fun pickMedia(uri: Uri, description: String? = null) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -1057,9 +1057,25 @@ class ComposeActivity :
         viewModel.removeMediaFromQueue(item)
     }
 
+    private fun sanitizePickMediaDescription(description: String?): String? {
+        if (description == null) {
+            return null;
+        }
+
+        // The Gboard android keyboard attaches this text whenever the user
+        // pastes something from the keyboard's suggestion bar.
+        if (description == "Image from Gboard clipboard") {
+            return null;
+        }
+
+        return description;
+    }
+
     private fun pickMedia(uri: Uri, description: String? = null) {
+        var sanitizedDescription = sanitizePickMediaDescription(description)
+
         lifecycleScope.launch {
-            viewModel.pickMedia(uri, description).onFailure { throwable ->
+            viewModel.pickMedia(uri, sanitizedDescription).onFailure { throwable ->
                 val errorString = when (throwable) {
                     is FileSizeException -> {
                         val decimalFormat = DecimalFormat("0.##")


### PR DESCRIPTION
Steps to reproduce:

1. install Gboard
   (https://play.google.com/store/apps/details?id=com.google.android.inputmethod.latin)

2. open a direct link to any image in Firefox
3. long-press the image to get a "Copy Image" dialogue (and copy the
   image)
4. compose a new post in Tusky
5. Gboard will suggest to paste the image from clipboard
6. paste image, see that when opening alt text editor, it is filled out
   with this garbage string

Why is this bad? It's not when I just fix the alt text. But it breaks
every mechanism that is supposed to remind me of adding alt text.

It's hard to argue that this is within scope of Tusky but I also don't
see it getting fixed in Gboard, so here we go.