### PR TITLE
Exoplayer: Increase space between rewind, pause, ffwd buttons

### DIFF
--- a/app/src/main/res/layout/exo_player_control_view.xml
+++ b/app/src/main/res/layout/exo_player_control_view.xml
@@ -47,8 +47,9 @@
 
         <include layout="@layout/exo_player_control_rewind_button" />
 
+        <!-- Changes from media3 default: Different style to add more margins -->
         <ImageButton android:id="@id/exo_play_pause"
-            style="@style/ExoStyledControls.Button.Center.PlayPause"/>
+            style="@style/TuskyExoPlayerPlayPause"/>
 
         <include layout="@layout/exo_player_control_ffwd_button" />
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -179,4 +179,10 @@
         <item name="materialDrawerMaskDrawable">@drawable/materialdrawer_shape_small</item>
         <item name="materialDrawerDrawCircularShadow">false</item>
     </style>
+
+    <!-- Used in exo_player_control_view.xml. Unmodified values are 5dp each -->
+    <style name="TuskyExoPlayerPlayPause" parent="ExoStyledControls.Button.Center.PlayPause">
+        <item name="android:layout_marginLeft">20dp</item>
+        <item name="android:layout_marginRight">20dp</item>
+    </style>
 </resources>


### PR DESCRIPTION
I [posted our new video player layout] on Mastodon for comments and multiple people said the buttons were too close together. I agree. I added some space (I eyeballed it, I made it bigger until it felt too big and then I narrowed it), I think we have now increased the space from 10dp to 25dp. I added the space by wrapping the buttons in LinearLayouts, because they are <include>s and could theoretically insert more than one button.

Concerns: If the "next"/"prev" buttons ever become active, the space will not be correctly applied to those. We can fix that if it ever comes up (we don't display those buttons). If people think the buttons should be placed even further apart we can do this by just increasing the number in styles.xml.

This is what it looks like now. See previous look and comparison with 23.0 in #4071

<img width=400 src="https://files.mastodon.social/media_attachments/files/111/293/547/524/867/101/original/91b83e1717111444.png">