### PR TITLE
feat: Hide self-boosts (#3534)

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/TabFilterPreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/TabFilterPreferencesFragment.kt
@@ -42,6 +42,14 @@ class TabFilterPreferencesFragment : PreferenceFragmentCompat() {
                     setDefaultValue(true)
                     isIconSpaceReserved = false
                 }
+
+                switchPreference {
+                    setTitle(R.string.pref_title_show_self_boosts)
+                    setSummary(R.string.pref_title_show_self_boosts_description)
+                    key = PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS
+                    setDefaultValue(true)
+                    isIconSpaceReserved = false
+                }.apply { dependency = PrefKeys.TAB_FILTER_HOME_BOOSTS }
             }
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
@@ -73,6 +73,7 @@ abstract class TimelineViewModel(
     private var alwaysOpenSpoilers = false
     private var filterRemoveReplies = false
     private var filterRemoveReblogs = false
+    private var filterRemoveSelfReblogs = false
     protected var readingOrder: ReadingOrder = ReadingOrder.OLDEST_FIRST
 
     fun init(
@@ -91,6 +92,8 @@ abstract class TimelineViewModel(
                 !sharedPreferences.getBoolean(PrefKeys.TAB_FILTER_HOME_REPLIES, true)
             filterRemoveReblogs =
                 !sharedPreferences.getBoolean(PrefKeys.TAB_FILTER_HOME_BOOSTS, true)
+            filterRemoveSelfReblogs =
+                !sharedPreferences.getBoolean(PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS, true)
         }
         readingOrder = ReadingOrder.from(sharedPreferences.getString(PrefKeys.READING_ORDER, null))
 
@@ -185,7 +188,8 @@ abstract class TimelineViewModel(
         val status = statusViewData.asStatusOrNull()?.status ?: return Filter.Action.NONE
         return if (
             (status.inReplyToId != null && filterRemoveReplies) ||
-            (status.reblog != null && filterRemoveReblogs)
+            (status.reblog != null && filterRemoveReblogs) ||
+            ((status.account.id == status.reblog?.account?.id) && filterRemoveSelfReblogs)
         ) {
             return Filter.Action.HIDE
         } else {
@@ -209,6 +213,14 @@ abstract class TimelineViewModel(
                 val oldRemoveReblogs = filterRemoveReblogs
                 filterRemoveReblogs = kind == Kind.HOME && !filter
                 if (oldRemoveReblogs != filterRemoveReblogs) {
+                    fullReload()
+                }
+            }
+            PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS -> {
+                val filter = sharedPreferences.getBoolean(PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS, true)
+                val oldRemoveSelfReblogs = filterRemoveSelfReblogs
+                filterRemoveSelfReblogs = kind == Kind.HOME && !filter
+                if (oldRemoveSelfReblogs != filterRemoveSelfReblogs) {
                     fullReload()
                 }
             }

--- a/app/src/main/java/com/keylesspalace/tusky/settings/SettingsConstants.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/settings/SettingsConstants.kt
@@ -106,6 +106,7 @@ object PrefKeys {
 
     const val TAB_FILTER_HOME_REPLIES = "tabFilterHomeReplies_v2" // This was changed once to reset an unintentionally set default.
     const val TAB_FILTER_HOME_BOOSTS = "tabFilterHomeBoosts"
+    const val TAB_SHOW_HOME_SELF_BOOSTS = "tabShowHomeSelfBoosts"
 
     /** UI text scaling factor, stored as float, 100 = 100% = no scaling */
     const val UI_TEXT_SCALE_RATIO = "uiTextScaleRatio"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,6 +138,8 @@
     <string name="action_share_account_username">Share username of account</string>
     <string name="action_hide_reblogs">Hide boosts</string>
     <string name="action_show_reblogs">Show boosts</string>
+    <string name="pref_title_show_self_boosts">Show self-boosts</string>
+    <string name="pref_title_show_self_boosts_description">Someone boosting their own post</string>
     <string name="action_report">Report</string>
     <string name="action_edit">Edit</string>
     <string name="action_delete">Delete</string>


### PR DESCRIPTION
# Overview
Some Mastodon posters have a annoying habit of boosting their own posts some time after they've posted them.
 No need to see the same toot over and over again.

# Changes made
- Add an additional option to the "Filters > Tabs" preference to show these self-boosts (default: on)
    - If "Show boosts" is turned off, self-boosts are automatically hidden.
    
# Screenshot
***screen of "Filters > Tabs" preference***
before | after
:--: | :--:
| <image src="https://github.com/tuskyapp/Tusky/assets/62137820/16ed2f4a-0776-4f60-afe6-29827acf5bbd" width="300"> |<image src="https://github.com/tuskyapp/Tusky/assets/62137820/9d4e1457-f71d-440c-959f-b91f7433b29a" width="300" />

***screen of Home Timeline***
***switch-on(self-boosts are displayed)*** | ***swith-off(self-boosts are not displayed)***
:--: | :--:
| <image src="https://github.com/tuskyapp/Tusky/assets/62137820/3bb80791-a81f-4cbc-98ad-8a14602e53a4" width="300" />|<image src="https://github.com/tuskyapp/Tusky/assets/62137820/a7964da8-d106-4209-b911-460ef8988831" width="300" />

# Related issue
 Fixes #3534