### PR TITLE
feat: Change name of Preferences > Filters > Tabs and move them to Account Preferences(#3536)

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.kt
@@ -146,6 +146,13 @@ class TuskyApplication : Application(), HasAndroidInjector {
                 editor.putString(APP_THEME, AppTheme.NIGHT.value)
             }
         }
+
+        if (oldVersion < 2023112001) {
+            editor.remove(PrefKeys.TAB_FILTER_HOME_REPLIES)
+            editor.remove(PrefKeys.TAB_FILTER_HOME_BOOSTS)
+            editor.remove(PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS)
+        }
+
         editor.putInt(PrefKeys.SCHEMA_VERSION, newVersion)
         editor.apply()
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/AccountPreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/AccountPreferencesFragment.kt
@@ -267,8 +267,7 @@ class AccountPreferencesFragment : PreferenceFragmentCompat(), Injectable {
                     preferenceDataStore = accountPreferenceDataStore
                 }
             }
-
-            preferenceCategory(R.string.pref_title_timeline_filters) {
+            preferenceCategory(R.string.pref_title_per_timeline_preferences) {
                 preference {
                     setTitle(R.string.pref_title_post_tabs)
                     fragment = TabFilterPreferencesFragment::class.qualifiedName

--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/AccountPreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/AccountPreferencesFragment.kt
@@ -267,6 +267,13 @@ class AccountPreferencesFragment : PreferenceFragmentCompat(), Injectable {
                     preferenceDataStore = accountPreferenceDataStore
                 }
             }
+
+            preferenceCategory(R.string.pref_title_timeline_filters) {
+                preference {
+                    setTitle(R.string.pref_title_post_tabs)
+                    fragment = TabFilterPreferencesFragment::class.qualifiedName
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesFragment.kt
@@ -246,13 +246,6 @@ class PreferencesFragment : PreferenceFragmentCompat(), Injectable {
                 }
             }
 
-            preferenceCategory(R.string.pref_title_timeline_filters) {
-                preference {
-                    setTitle(R.string.pref_title_post_tabs)
-                    fragment = TabFilterPreferencesFragment::class.qualifiedName
-                }
-            }
-
             preferenceCategory(R.string.pref_title_wellbeing_mode) {
                 switchPreference {
                     title = getString(R.string.limit_notifications)

--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/TabFilterPreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/TabFilterPreferencesFragment.kt
@@ -18,12 +18,19 @@ package com.keylesspalace.tusky.components.preference
 import android.os.Bundle
 import androidx.preference.PreferenceFragmentCompat
 import com.keylesspalace.tusky.R
+import com.keylesspalace.tusky.di.Injectable
+import com.keylesspalace.tusky.settings.AccountPreferenceDataStore
 import com.keylesspalace.tusky.settings.PrefKeys
 import com.keylesspalace.tusky.settings.makePreferenceScreen
 import com.keylesspalace.tusky.settings.preferenceCategory
 import com.keylesspalace.tusky.settings.switchPreference
+import javax.inject.Inject
 
-class TabFilterPreferencesFragment : PreferenceFragmentCompat() {
+class TabFilterPreferencesFragment : PreferenceFragmentCompat(), Injectable {
+
+    @Inject
+    lateinit var accountPreferenceDataStore: AccountPreferenceDataStore
+
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         makePreferenceScreen {
             preferenceCategory(R.string.title_home) { category ->
@@ -32,14 +39,14 @@ class TabFilterPreferencesFragment : PreferenceFragmentCompat() {
                 switchPreference {
                     setTitle(R.string.pref_title_show_boosts)
                     key = PrefKeys.TAB_FILTER_HOME_BOOSTS
-                    setDefaultValue(true)
+                    preferenceDataStore = accountPreferenceDataStore
                     isIconSpaceReserved = false
                 }
 
                 switchPreference {
                     setTitle(R.string.pref_title_show_replies)
                     key = PrefKeys.TAB_FILTER_HOME_REPLIES
-                    setDefaultValue(true)
+                    preferenceDataStore = accountPreferenceDataStore
                     isIconSpaceReserved = false
                 }
 
@@ -47,7 +54,7 @@ class TabFilterPreferencesFragment : PreferenceFragmentCompat() {
                     setTitle(R.string.pref_title_show_self_boosts)
                     setSummary(R.string.pref_title_show_self_boosts_description)
                     key = PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS
-                    setDefaultValue(true)
+                    preferenceDataStore = accountPreferenceDataStore
                     isIconSpaceReserved = false
                 }.apply { dependency = PrefKeys.TAB_FILTER_HOME_BOOSTS }
             }

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
@@ -89,11 +89,11 @@ abstract class TimelineViewModel(
         if (kind == Kind.HOME) {
             // Note the variable is "true if filter" but the underlying preference/settings text is "true if show"
             filterRemoveReplies =
-                !sharedPreferences.getBoolean(PrefKeys.TAB_FILTER_HOME_REPLIES, true)
+                !(accountManager.activeAccount?.isShowHomeBoosts ?: true)
             filterRemoveReblogs =
-                !sharedPreferences.getBoolean(PrefKeys.TAB_FILTER_HOME_BOOSTS, true)
+                !(accountManager.activeAccount?.isShowHomeReplies ?: true)
             filterRemoveSelfReblogs =
-                !sharedPreferences.getBoolean(PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS, true)
+                !(accountManager.activeAccount?.isShowHomeSelfBoosts ?: true)
         }
         readingOrder = ReadingOrder.from(sharedPreferences.getString(PrefKeys.READING_ORDER, null))
 
@@ -201,7 +201,7 @@ abstract class TimelineViewModel(
     private fun onPreferenceChanged(key: String) {
         when (key) {
             PrefKeys.TAB_FILTER_HOME_REPLIES -> {
-                val filter = sharedPreferences.getBoolean(PrefKeys.TAB_FILTER_HOME_REPLIES, true)
+                val filter = accountManager.activeAccount?.isShowHomeReplies ?: true
                 val oldRemoveReplies = filterRemoveReplies
                 filterRemoveReplies = kind == Kind.HOME && !filter
                 if (oldRemoveReplies != filterRemoveReplies) {
@@ -209,7 +209,7 @@ abstract class TimelineViewModel(
                 }
             }
             PrefKeys.TAB_FILTER_HOME_BOOSTS -> {
-                val filter = sharedPreferences.getBoolean(PrefKeys.TAB_FILTER_HOME_BOOSTS, true)
+                val filter = accountManager.activeAccount?.isShowHomeBoosts ?: true
                 val oldRemoveReblogs = filterRemoveReblogs
                 filterRemoveReblogs = kind == Kind.HOME && !filter
                 if (oldRemoveReblogs != filterRemoveReblogs) {
@@ -217,7 +217,7 @@ abstract class TimelineViewModel(
                 }
             }
             PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS -> {
-                val filter = sharedPreferences.getBoolean(PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS, true)
+                val filter = accountManager.activeAccount?.isShowHomeSelfBoosts ?: true
                 val oldRemoveSelfReblogs = filterRemoveSelfReblogs
                 filterRemoveSelfReblogs = kind == Kind.HOME && !filter
                 if (oldRemoveSelfReblogs != filterRemoveSelfReblogs) {

--- a/app/src/main/java/com/keylesspalace/tusky/db/AccountEntity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/AccountEntity.kt
@@ -107,7 +107,11 @@ data class AccountEntity(
     var locked: Boolean = false,
 
     @ColumnInfo(defaultValue = "0")
-    var hasDirectMessageBadge: Boolean = false
+    var hasDirectMessageBadge: Boolean = false,
+
+    var isShowHomeBoosts: Boolean = true,
+    var isShowHomeReplies: Boolean = true,
+    var isShowHomeSelfBoosts: Boolean = true,
 ) {
 
     val identifier: String

--- a/app/src/main/java/com/keylesspalace/tusky/db/AppDatabase.java
+++ b/app/src/main/java/com/keylesspalace/tusky/db/AppDatabase.java
@@ -42,7 +42,7 @@ import java.io.File;
         TimelineAccountEntity.class,
         ConversationEntity.class
     },
-    version = 54,
+    version = 55,
     autoMigrations = {
         @AutoMigration(from = 48, to = 49),
         @AutoMigration(from = 49, to = 50, spec = AppDatabase.MIGRATION_49_50.class),
@@ -684,6 +684,15 @@ public abstract class AppDatabase extends RoomDatabase {
         @Override
         public void migrate(@NonNull SupportSQLiteDatabase database) {
             database.execSQL("UPDATE `AccountEntity` SET `tabpreferences` = REPLACE(tabpreferences, 'Trending:', 'TrendingTags:')");
+        }
+    };
+
+    public static final Migration MIGRATION_54_55 = new Migration(54, 55) {
+        @Override
+        public void migrate(@NonNull SupportSQLiteDatabase database) {
+            database.execSQL("ALTER TABLE `AccountEntity` ADD COLUMN `isShowHomeBoosts` INTEGER NOT NULL DEFAULT 1");
+            database.execSQL("ALTER TABLE `AccountEntity` ADD COLUMN `isShowHomeReplies` INTEGER NOT NULL DEFAULT 1");
+            database.execSQL("ALTER TABLE `AccountEntity` ADD COLUMN `isShowHomeSelfBoosts` INTEGER NOT NULL DEFAULT 1");
         }
     };
 }

--- a/app/src/main/java/com/keylesspalace/tusky/db/AppDatabase.java
+++ b/app/src/main/java/com/keylesspalace/tusky/db/AppDatabase.java
@@ -42,7 +42,7 @@ import java.io.File;
         TimelineAccountEntity.class,
         ConversationEntity.class
     },
-    version = 55,
+    version = 56,
     autoMigrations = {
         @AutoMigration(from = 48, to = 49),
         @AutoMigration(from = 49, to = 50, spec = AppDatabase.MIGRATION_49_50.class),
@@ -687,7 +687,7 @@ public abstract class AppDatabase extends RoomDatabase {
         }
     };
 
-    public static final Migration MIGRATION_54_55 = new Migration(54, 55) {
+    public static final Migration MIGRATION_54_56 = new Migration(54, 56) {
         @Override
         public void migrate(@NonNull SupportSQLiteDatabase database) {
             database.execSQL("ALTER TABLE `AccountEntity` ADD COLUMN `isShowHomeBoosts` INTEGER NOT NULL DEFAULT 1");

--- a/app/src/main/java/com/keylesspalace/tusky/di/AppModule.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/di/AppModule.kt
@@ -68,7 +68,7 @@ class AppModule {
                 AppDatabase.MIGRATION_38_39, AppDatabase.MIGRATION_39_40, AppDatabase.MIGRATION_40_41,
                 AppDatabase.MIGRATION_41_42, AppDatabase.MIGRATION_42_43, AppDatabase.MIGRATION_43_44,
                 AppDatabase.MIGRATION_44_45, AppDatabase.MIGRATION_45_46, AppDatabase.MIGRATION_46_47,
-                AppDatabase.MIGRATION_47_48, AppDatabase.MIGRATION_52_53, AppDatabase.MIGRATION_54_55,
+                AppDatabase.MIGRATION_47_48, AppDatabase.MIGRATION_52_53, AppDatabase.MIGRATION_54_56,
             )
             .build()
     }

--- a/app/src/main/java/com/keylesspalace/tusky/di/AppModule.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/di/AppModule.kt
@@ -68,7 +68,7 @@ class AppModule {
                 AppDatabase.MIGRATION_38_39, AppDatabase.MIGRATION_39_40, AppDatabase.MIGRATION_40_41,
                 AppDatabase.MIGRATION_41_42, AppDatabase.MIGRATION_42_43, AppDatabase.MIGRATION_43_44,
                 AppDatabase.MIGRATION_44_45, AppDatabase.MIGRATION_45_46, AppDatabase.MIGRATION_46_47,
-                AppDatabase.MIGRATION_47_48, AppDatabase.MIGRATION_52_53
+                AppDatabase.MIGRATION_47_48, AppDatabase.MIGRATION_52_53, AppDatabase.MIGRATION_54_55,
             )
             .build()
     }

--- a/app/src/main/java/com/keylesspalace/tusky/di/FragmentBuildersModule.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/di/FragmentBuildersModule.kt
@@ -24,6 +24,7 @@ import com.keylesspalace.tusky.components.domainblocks.DomainBlocksFragment
 import com.keylesspalace.tusky.components.preference.AccountPreferencesFragment
 import com.keylesspalace.tusky.components.preference.NotificationPreferencesFragment
 import com.keylesspalace.tusky.components.preference.PreferencesFragment
+import com.keylesspalace.tusky.components.preference.TabFilterPreferencesFragment
 import com.keylesspalace.tusky.components.report.fragments.ReportDoneFragment
 import com.keylesspalace.tusky.components.report.fragments.ReportNoteFragment
 import com.keylesspalace.tusky.components.report.fragments.ReportStatusesFragment
@@ -103,4 +104,7 @@ abstract class FragmentBuildersModule {
 
     @ContributesAndroidInjector
     abstract fun viewVideoFragment(): ViewVideoFragment
+
+    @ContributesAndroidInjector
+    abstract fun tabFilterPreferencesFragment(): TabFilterPreferencesFragment
 }

--- a/app/src/main/java/com/keylesspalace/tusky/settings/AccountPreferenceDataStore.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/settings/AccountPreferenceDataStore.kt
@@ -22,6 +22,9 @@ class AccountPreferenceDataStore @Inject constructor(
             PrefKeys.ALWAYS_SHOW_SENSITIVE_MEDIA -> account.alwaysShowSensitiveMedia
             PrefKeys.ALWAYS_OPEN_SPOILER -> account.alwaysOpenSpoiler
             PrefKeys.MEDIA_PREVIEW_ENABLED -> account.mediaPreviewEnabled
+            PrefKeys.TAB_FILTER_HOME_BOOSTS -> account.isShowHomeBoosts
+            PrefKeys.TAB_FILTER_HOME_REPLIES -> account.isShowHomeReplies
+            PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS -> account.isShowHomeSelfBoosts
             else -> defValue
         }
     }
@@ -31,6 +34,9 @@ class AccountPreferenceDataStore @Inject constructor(
             PrefKeys.ALWAYS_SHOW_SENSITIVE_MEDIA -> account.alwaysShowSensitiveMedia = value
             PrefKeys.ALWAYS_OPEN_SPOILER -> account.alwaysOpenSpoiler = value
             PrefKeys.MEDIA_PREVIEW_ENABLED -> account.mediaPreviewEnabled = value
+            PrefKeys.TAB_FILTER_HOME_BOOSTS -> account.isShowHomeBoosts = value
+            PrefKeys.TAB_FILTER_HOME_REPLIES -> account.isShowHomeReplies = value
+            PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS -> account.isShowHomeSelfBoosts = value
         }
 
         accountManager.saveAccount(account)

--- a/app/src/main/java/com/keylesspalace/tusky/settings/SettingsConstants.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/settings/SettingsConstants.kt
@@ -45,7 +45,7 @@ enum class AppTheme(val value: String) {
  *
  * - Adding a new preference that does not change the interpretation of an existing preference
  */
-const val SCHEMA_VERSION = 2023082301
+const val SCHEMA_VERSION = 2023112001
 
 /** The schema version for fresh installs */
 const val NEW_INSTALL_SCHEMA_VERSION = 0

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,7 +297,7 @@
     <string name="pref_title_appearance_settings">Appearance</string>
     <string name="pref_title_app_theme">App theme</string>
     <string name="pref_title_timelines">Timelines</string>
-    <string name="pref_title_timeline_filters">Filters</string>
+    <string name="pref_title_timeline_filters">Per-timeline preferences</string>
 
     <string name="app_them_dark">Dark</string>
     <string name="app_theme_light">Light</string>
@@ -316,7 +316,7 @@
     <string name="pref_title_animate_custom_emojis">Animate custom emojis</string>
 
     <string name="pref_title_post_filter">Timeline filtering</string>
-    <string name="pref_title_post_tabs">Tabs</string>
+    <string name="pref_title_post_tabs">Home timeline</string>
     <string name="pref_title_show_boosts">Show boosts</string>
     <string name="pref_title_show_replies">Show replies</string>
     <string name="pref_title_show_media_preview">Download media previews</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,7 +297,8 @@
     <string name="pref_title_appearance_settings">Appearance</string>
     <string name="pref_title_app_theme">App theme</string>
     <string name="pref_title_timelines">Timelines</string>
-    <string name="pref_title_timeline_filters">Per-timeline preferences</string>
+    <string name="pref_title_timeline_filters">Filters</string>
+    <string name="pref_title_per_timeline_preferences">Per-timeline preferences</string>
 
     <string name="app_them_dark">Dark</string>
     <string name="app_theme_light">Light</string>


### PR DESCRIPTION
# Overview
In the previous code, when you open preferences, there is a section headed "Filters" with a section called "Tabs"

This is confusing.

# Changes
- Change the section title from "Filters" to "Per-timeline preferences."
- Change the current "Tabs" section to "Home timeline" since it is only for home timelines

# Screenshots
account preference screen | detail screen
:--: | :--:
|<image src="https://github.com/tuskyapp/Tusky/assets/62137820/12694f24-b7e3-4ba3-90f5-53740e9c4269" width="250" />|<image src="https://github.com/tuskyapp/Tusky/assets/62137820/796e9ac1-76d6-43ef-a087-a1cd2d899ef8" width="250" />

# Note
- Maybe string resources should have a new property? (for translation)

# Related link
 Fixes #3536

