### PR TITLE
fix crash when rotating caption dialog

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
@@ -43,7 +43,6 @@ private const val MEDIA_DESCRIPTION_CHARACTER_LIMIT = 1500
 
 class CaptionDialog : DialogFragment() {
     private lateinit var listener: Listener
-    private lateinit var input: EditText
 
     private val binding by viewBinding(DialogImageDescriptionBinding::bind)
 
@@ -56,33 +55,29 @@ class CaptionDialog : DialogFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        savedInstanceState?.getString(DESCRIPTION_KEY)?.let {
-            input.setText(it)
-        }
-
-        return inflater.inflate(R.layout.dialog_image_description, container, false)
-    }
+    ) = inflater.inflate(R.layout.dialog_image_description, container, false)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        input = binding.imageDescriptionText
         val imageView = binding.imageDescriptionView
         imageView.maxZoom = 6f
 
-        input.hint = resources.getQuantityString(
+        binding.imageDescriptionText.hint = resources.getQuantityString(
             R.plurals.hint_describe_for_visually_impaired,
             MEDIA_DESCRIPTION_CHARACTER_LIMIT,
             MEDIA_DESCRIPTION_CHARACTER_LIMIT
         )
-        input.filters = arrayOf(InputFilter.LengthFilter(MEDIA_DESCRIPTION_CHARACTER_LIMIT))
-        input.setText(arguments?.getString(EXISTING_DESCRIPTION_ARG))
+        binding.imageDescriptionText.filters = arrayOf(InputFilter.LengthFilter(MEDIA_DESCRIPTION_CHARACTER_LIMIT))
+        binding.imageDescriptionText.setText(arguments?.getString(EXISTING_DESCRIPTION_ARG))
+        savedInstanceState?.getString(DESCRIPTION_KEY)?.let {
+            binding.imageDescriptionText.setText(it)
+        }
 
         binding.cancelButton.setOnClickListener {
             dismiss()
         }
         val localId = arguments?.getInt(LOCAL_ID_ARG) ?: error("Missing localId")
         binding.okButton.setOnClickListener {
-            listener.onUpdateDescription(localId, input.text.toString())
+            listener.onUpdateDescription(localId, binding.imageDescriptionText.text.toString())
             dismiss()
         }
 
@@ -125,7 +120,7 @@ class CaptionDialog : DialogFragment() {
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putString(DESCRIPTION_KEY, input.text.toString())
+        outState.putString(DESCRIPTION_KEY, binding.imageDescriptionText.text.toString())
         super.onSaveInstanceState(outState)
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
@@ -24,7 +24,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import android.widget.EditText
 import android.widget.LinearLayout
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
@@ -67,7 +67,7 @@ class CaptionDialog : DialogFragment() {
         )
         binding.imageDescriptionText.filters = arrayOf(InputFilter.LengthFilter(MEDIA_DESCRIPTION_CHARACTER_LIMIT))
         binding.imageDescriptionText.setText(arguments?.getString(EXISTING_DESCRIPTION_ARG))
-        savedInstanceState?.getString(DESCRIPTION_KEY)?.let {
+        savedInstanceState?.getCharSequence(DESCRIPTION_KEY)?.let {
             binding.imageDescriptionText.setText(it)
         }
 
@@ -119,7 +119,7 @@ class CaptionDialog : DialogFragment() {
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putString(DESCRIPTION_KEY, binding.imageDescriptionText.text.toString())
+        outState.putCharSequence(DESCRIPTION_KEY, binding.imageDescriptionText.text)
         super.onSaveInstanceState(outState)
     }
 


### PR DESCRIPTION
Steps to reproduce: Open the dialog to set a catption on an image. Rotate the screen.

<details>
  <summary>Stacktrace</summary>
  
```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'void android.widget.TextView.setText(java.lang.CharSequence)' on a null object reference
  at com.keylesspalace.tusky.components.compose.dialog.CaptionDialog.onCreateView (CaptionDialog.kt:61)
  at androidx.fragment.app.Fragment.performCreateView (Fragment.java:3114)
  at androidx.fragment.app.DialogFragment.performCreateView (DialogFragment.java:775)
  at androidx.fragment.app.FragmentStateManager.createView (FragmentStateManager.java:557)
  at androidx.fragment.app.FragmentStateManager.moveToExpectedState (FragmentStateManager.java:272)
  at androidx.fragment.app.FragmentStore.moveToExpectedState (FragmentStore.java:114)
  at androidx.fragment.app.FragmentManager.moveToState (FragmentManager.java:1455)
  at androidx.fragment.app.FragmentManager.dispatchStateChange (FragmentManager.java:3034)
  at androidx.fragment.app.FragmentManager.dispatchActivityCreated (FragmentManager.java:2952)
  at androidx.fragment.app.FragmentController.dispatchActivityCreated (FragmentController.java:263)
  at androidx.fragment.app.FragmentActivity.onStart (FragmentActivity.java:350)
  at androidx.appcompat.app.AppCompatActivity.onStart (AppCompatActivity.java:251)
  at android.app.Instrumentation.callActivityOnStart (Instrumentation.java:1543)
  at android.app.Activity.performStart (Activity.java:8682)
  at android.app.ActivityThread.handleStartActivity (ActivityThread.java:4219)
  at android.app.servertransaction.TransactionExecutor.performLifecycleSequence (TransactionExecutor.java:221)
  at android.app.servertransaction.TransactionExecutor.cycleToPath (TransactionExecutor.java:201)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleState (TransactionExecutor.java:173)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:97)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2584)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:226)
  at android.os.Looper.loop (Looper.java:313)
  at android.app.ActivityThread.main (ActivityThread.java:8810)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:604)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1067)
```
  
</details>

Restoring the saved caption after the view was created fixes the problem.