### PR TITLE
fix memory leak in CompositeWithOpaqueBackground

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -335,9 +335,13 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             avatarRadius = avatarRadius36dp;
         }
 
-        ImageLoadingHelper.loadAvatar(url, avatar, avatarRadius,
+        ImageLoadingHelper.loadAvatar(
+            url,
+            avatar,
+            avatarRadius,
             statusDisplayOptions.animateAvatars(),
-            Collections.singletonList(new CompositeWithOpaqueBackground(avatar)));
+            Collections.singletonList(new CompositeWithOpaqueBackground(MaterialColors.getColor(avatar, android.R.attr.colorBackground)))
+        );
     }
 
     protected void setMetaData(@NonNull StatusViewData.Concrete statusViewData, @NonNull StatusDisplayOptions statusDisplayOptions, @NonNull StatusActionListener listener) {


### PR DESCRIPTION
Found with Leak canary: The transformation ends up in Glide's memory cache and leaks whole Activities through the view -> context reference.

This fixes the problem by removing the background detection logic (so the view reference is no longer needed) and setting the background directly instead. Looks exactly as before.