### PR TITLE
Prevent device from dimming or sleeping screen while video/audio playing

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
@@ -158,8 +158,9 @@ class ViewMediaActivity : BaseActivity(), HasAndroidInjector, ViewImageFragment.
         })
 
         // Prevent this activity from dimming or sleeping the screen if it is playing video or audio
-        if (attachments!![binding.viewPager.currentItem].attachment.type != Attachment.Type.IMAGE)
+        if (attachments!![binding.viewPager.currentItem].attachment.type != Attachment.Type.IMAGE) {
             window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
@@ -35,6 +35,7 @@ import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.view.WindowManager
 import android.webkit.MimeTypeMap
 import android.widget.Toast
 import androidx.core.app.ShareCompat
@@ -155,6 +156,10 @@ class ViewMediaActivity : BaseActivity(), HasAndroidInjector, ViewImageFragment.
                 window.sharedElementEnterTransition.removeListener(this)
             }
         })
+
+        // Prevent this activity from dimming or sleeping the screen if it is playing video or audio
+        if (attachments!![binding.viewPager.currentItem].attachment.type != Attachment.Type.IMAGE)
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {


### PR DESCRIPTION
We got reports on Mastodon that the media3 upgrade broke this previously functional behavior. In my testing, this restores the v23 behavior.

Note, @Gryzor suggested we do this with a Wake Lock. After looking at the docs, I conclude that (1) a wake lock is not what v23 was using, and is not appropriate for video but (2) a wake lock *is* appropriate for audio and possibly other purposes, and we should consider adding one in the v25 timeframe. I will file a followup issue explaining what I mean by this later today.