### PR TITLE
Correct backgrounding behavior for both video and audio (does not work)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
     <uses-permission android:name="android.permission.VIBRATE" /> <!-- For notifications -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" /> <!-- For media player -->
 
     <application
         android:name=".TuskyApplication"

--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
@@ -158,8 +158,9 @@ class ViewMediaActivity : BaseActivity(), HasAndroidInjector, ViewImageFragment.
         })
 
         // Prevent this activity from dimming or sleeping the screen if it is playing video or audio
-        if (attachments!![binding.viewPager.currentItem].attachment.type != Attachment.Type.IMAGE)
+        if (attachments!![binding.viewPager.currentItem].attachment.type != Attachment.Type.IMAGE) {
             window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
@@ -159,7 +159,7 @@ class ViewMediaActivity : BaseActivity(), HasAndroidInjector, ViewImageFragment.
 
         // Prevent this activity from dimming or sleeping the screen if it is playing video
         // See also WAKE_MODE in ViewVideoFragment.kt
-        val attachmentType = attachments!![binding.viewPager.currentItem].attachment.type;
+        val attachmentType = attachments!![binding.viewPager.currentItem].attachment.type
         if (attachmentType == Attachment.Type.VIDEO || attachmentType == Attachment.Type.GIFV) {
             window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }

--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
@@ -157,8 +157,10 @@ class ViewMediaActivity : BaseActivity(), HasAndroidInjector, ViewImageFragment.
             }
         })
 
-        // Prevent this activity from dimming or sleeping the screen if it is playing video or audio
-        if (attachments!![binding.viewPager.currentItem].attachment.type != Attachment.Type.IMAGE) {
+        // Prevent this activity from dimming or sleeping the screen if it is playing video
+        // See also WAKE_MODE in ViewVideoFragment.kt
+        val attachmentType = attachments!![binding.viewPager.currentItem].attachment.type;
+        if (attachmentType == Attachment.Type.VIDEO || attachmentType == Attachment.Type.GIFV) {
             window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
@@ -35,6 +35,7 @@ import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.view.WindowManager
 import android.webkit.MimeTypeMap
 import android.widget.Toast
 import androidx.core.app.ShareCompat
@@ -155,6 +156,10 @@ class ViewMediaActivity : BaseActivity(), HasAndroidInjector, ViewImageFragment.
                 window.sharedElementEnterTransition.removeListener(this)
             }
         })
+
+        // Prevent this activity from dimming or sleeping the screen if it is playing video or audio
+        if (attachments!![binding.viewPager.currentItem].attachment.type != Attachment.Type.IMAGE)
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewVideoFragment.kt
@@ -341,7 +341,11 @@ class ViewVideoFragment : ViewMediaFragment(), Injectable {
                 addListener(mediaPlayerListener)
                 repeatMode = Player.REPEAT_MODE_ONE
                 playWhenReady = true
-                setWakeMode(WAKE_MODE_LOCAL)
+                // When playing audio, allow the screen to sleep but not the CPU.
+                // See also KEEP_SCREEN_ON in ViewMediaActivity.kt.
+                if (isAudio) {
+                    setWakeMode(WAKE_MODE_LOCAL)
+                }
                 seekTo(savedSeekPosition)
                 prepare()
                 player = this


### PR DESCRIPTION
See #4161 for full explanation.

This is a followup to #4160. It causes keep-screen-alive to *only* occur for videos (and GIFVs), and for audio attachments it uses [setWakeMode](https://developer.android.com/reference/androidx/media3/exoplayer/ExoPlayer.Builder?hl=en#setWakeMode(int)) (with the required permission added to AndroidManifest.xml). This patch does not work. I can confirm we are hitting the setWakeMode branch\*, but when the screen goes to sleep the audio also stops. The documentation says that setWakeMode "should be used together with a foreground [android.app.Service](https://developer.android.com/reference/android/app/Service.html) for use cases where playback occurs and the screen is off (e.g. background audio playback)", and we have a foreground service but there is no specific provision to switch the audio playback from the activity to the foreground service. I do not know what to do from here.

If the foreground service could assume audio playback, would that mean we could allow audio attachments to keep playing even after the user switches to another app? I think that would be pretty neat.

\* I added a log.d to the setWakeMode if, and it printed. I looked in the logcat and there were no warnings around the setWakeMode indicating a permission denial or anything. One minute later I see in the log:

`ActivityTrigger activityPauseTrigger`

I then immediately see a bunch of audio-related messages I can't decipher, such as:

```
2023-12-10 20:42:26.887  6141-6315  Avrcp_ext               pid-6141                             D  AudioManager Player: AudioPlaybackConfiguration piid:55 deviceId:0 type:android.media.SoundPool u/pid:1000/1445 state:idle attr:AudioAttributes: usage=USAGE_ASSISTANCE_SONIFICATION content=CONTENT_TYPE_SONIFICATION flags=0x800 tags= bundle=null sessionId:0
2023-12-10 20:42:26.887  6141-6315  Avrcp_ext               pid-6141                             D  AudioManager Player: AudioPlaybackConfiguration piid:71 deviceId:0 type:android.media.SoundPool u/pid:1027/4928 state:idle attr:AudioAttributes: usage=USAGE_ASSISTANCE_SONIFICATION content=CONTENT_TYPE_SONIFICATION flags=0x800 tags= bundle=null sessionId:0
2023-12-10 20:42:26.887  6141-6315  Avrcp_ext               pid-6141                             D  AudioManager Player: AudioPlaybackConfiguration piid:503 deviceId:3 type:android.media.AudioTrack u/pid:10749/14450 state:paused attr:AudioAttributes: usage=USAGE_MEDIA content=CONTENT_TYPE_UNKNOWN flags=0xA00 tags= bundle=null sessionId:633
2023-12-10 20:42:26.887  6141-6315  Avrcp_ext               pid-6141                             D  AudioManager Player: AudioPlaybackConfiguration piid:63 deviceId:0 type:android.media.SoundPool u/pid:10303/2655 state:idle attr:AudioAttributes: usage=USAGE_ASSISTANCE_SONIFICATION content=CONTENT_TYPE_SONIFICATION flags=0x800 tags= bundle=null sessionId:0
2023-12-10 20:42:26.887  6141-6315  Avrcp_ext               pid-6141                             D  AudioManager isPlaying: false, mAudioPlaybackIsActive = true
2023-12-10 20:42:26.887  6141-6315  Avrcp_ext               pid-6141                             D  AudioManager Reset Active Player
2023-12-10 20:42:26.887  6141-6315  Avrcp_ext               pid-6141                             V  updateCurrentMediaState: mMediaController: null
2023-12-10 20:42:26.888  6141-6315  Avrcp_ext               pid-6141                             W  isMusicActive: true getBluetoothPlayState: 1 A2dp State: 11 mAudioPlaybackIsActive: false
2023-12-10 20:42:26.888  6141-6315  Avrcp_ext               pid-6141                             W  updateCurrentMediaState: isPlaying = true
2023-12-10 20:42:26.888  6141-6315  Avrcp_ext               pid-6141                             V  Media update: id [MediaAttributes: none] : [MediaAttributes: none]
2023-12-10 20:42:26.888  6141-6315  Avrcp_ext               pid-6141                             D  isPackageNameValid: browsedPackage = isValid = false
2023-12-10 20:42:26.888  6141-6315  Avrcp_ext               pid-6141                             V  updatePlaybackState, state: PlaybackState {state=3, position=-1, buffered position=0, speed=1.0, updated=96108045, actions=0, custom actions=[], active item id=-1, error=null} device: null
```
There were more similar messages after this but I didn't catch them all before they cleared. Various objects claiming both that the music is playing and is not playing.