### PR TITLE
Prevent device from dimming or sleeping screen while video/audio playing (but really)

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
@@ -158,8 +158,9 @@ class ViewMediaActivity : BaseActivity(), HasAndroidInjector, ViewImageFragment.
         })
 
         // Prevent this activity from dimming or sleeping the screen if it is playing video or audio
-        if (attachments!![binding.viewPager.currentItem].attachment.type != Attachment.Type.IMAGE)
+        if (attachments!![binding.viewPager.currentItem].attachment.type != Attachment.Type.IMAGE) {
             window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
@@ -125,6 +125,7 @@ class ViewMediaActivity : BaseActivity(), HasAndroidInjector, ViewImageFragment.
         binding.viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 binding.toolbar.title = getPageTitle(position)
+                adjustScreenWakefulness()
             }
         })
 
@@ -157,10 +158,7 @@ class ViewMediaActivity : BaseActivity(), HasAndroidInjector, ViewImageFragment.
             }
         })
 
-        // Prevent this activity from dimming or sleeping the screen if it is playing video or audio
-        if (attachments!![binding.viewPager.currentItem].attachment.type != Attachment.Type.IMAGE) {
-            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        }
+        adjustScreenWakefulness()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -346,6 +344,15 @@ class ViewMediaActivity : BaseActivity(), HasAndroidInjector, ViewImageFragment.
         downloadManager.enqueue(request)
 
         shareFile(file, mimeType)
+    }
+
+    // Prevent this activity from dimming or sleeping the screen if, and only if, it is playing video or audio
+    private fun adjustScreenWakefulness() {
+        if (attachments!![binding.viewPager.currentItem].attachment.type == Attachment.Type.IMAGE) {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        } else {
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
     }
 
     override fun androidInjector() = androidInjector

--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
@@ -35,6 +35,7 @@ import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.view.WindowManager
 import android.webkit.MimeTypeMap
 import android.widget.Toast
 import androidx.core.app.ShareCompat
@@ -155,6 +156,10 @@ class ViewMediaActivity : BaseActivity(), HasAndroidInjector, ViewImageFragment.
                 window.sharedElementEnterTransition.removeListener(this)
             }
         })
+
+        // Prevent this activity from dimming or sleeping the screen if it is playing video or audio
+        if (attachments!![binding.viewPager.currentItem].attachment.type != Attachment.Type.IMAGE)
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {


### PR DESCRIPTION
For reasons not totally clear to me, Github marked #4160 as "merged" and will not let me reopen it.

I believe this should be included for 24.1 because it fixes a 24.0 regression in the media player.

I have tested this newest commit in a number of ways, and in my testing I find (1) when viewing an image, it sleeps after about a minute (2) when viewing video, it stays awake indefinitely (3) this is true whether the image/video was opened directly, or reached by swiping from another attachment. I have not tested swiping to/from audio but I am confident it will work the same.