### PR TITLE
fix crash when opening profile image

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.kt
@@ -348,10 +348,12 @@ class ViewMediaActivity : BaseActivity(), HasAndroidInjector, ViewImageFragment.
 
     // Prevent this activity from dimming or sleeping the screen if, and only if, it is playing video or audio
     private fun adjustScreenWakefulness() {
-        if (attachments!![binding.viewPager.currentItem].attachment.type == Attachment.Type.IMAGE) {
-            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        } else {
-            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        attachments?.run {
+            if (get(binding.viewPager.currentItem).attachment.type == Attachment.Type.IMAGE) {
+                window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            } else {
+                window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            }
         }
     }
 


### PR DESCRIPTION
```
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.keylesspalace.tusky.test/com.keylesspalace.tusky.ViewMediaActivity}: java.lang.NullPointerException
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2778)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2856)
	at android.app.ActivityThread.-wrap11(Unknown Source:0)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1589)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loop(Looper.java:164)
	at android.app.ActivityThread.main(ActivityThread.java:6494)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
Caused by: java.lang.NullPointerException
	at com.keylesspalace.tusky.ViewMediaActivity.adjustScreenWakefulness(ViewMediaActivity.kt:351)
	at com.keylesspalace.tusky.ViewMediaActivity.onCreate(ViewMediaActivity.kt:161)
	at android.app.Activity.performCreate(Activity.java:7009)
	at android.app.Activity.performCreate(Activity.java:7000)
	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1214)
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2731)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2856) 
	at android.app.ActivityThread.-wrap11(Unknown Source:0) 
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1589) 
	at android.os.Handler.dispatchMessage(Handler.java:106) 
	at android.os.Looper.loop(Looper.java:164) 
	at android.app.ActivityThread.main(ActivityThread.java:6494) 
	at java.lang.reflect.Method.invoke(Native Method) 
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438) 
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807) 
```