### PR TITLE
fix icon alignment in help text of empty timelines

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/SpanUtils.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/SpanUtils.kt
@@ -1,7 +1,6 @@
 package com.keylesspalace.tusky.util
 
 import android.content.Context
-import android.os.Build
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.Spanned

--- a/app/src/main/java/com/keylesspalace/tusky/util/SpanUtils.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/SpanUtils.kt
@@ -98,8 +98,6 @@ fun highlightSpans(text: Spannable, colour: Int) {
  * Replaces text of the form [iconics name] with their spanned counterparts (ImageSpan).
  */
 fun addDrawables(text: CharSequence, color: Int, size: Int, context: Context): Spannable {
-    val alignment = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) DynamicDrawableSpan.ALIGN_CENTER else DynamicDrawableSpan.ALIGN_BASELINE
-
     val builder = SpannableStringBuilder(text)
 
     val pattern = Pattern.compile("\\[iconics ([0-9a-z_]+)\\]")
@@ -112,7 +110,7 @@ fun addDrawables(text: CharSequence, color: Int, size: Int, context: Context): S
         drawable.setBounds(0, 0, size, size)
         drawable.setTint(color)
 
-        builder.setSpan(ImageSpan(drawable, alignment), matcher.start(), matcher.end(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        builder.setSpan(ImageSpan(drawable, DynamicDrawableSpan.ALIGN_BASELINE), matcher.start(), matcher.end(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
     }
 
     return builder


### PR DESCRIPTION
@Lakoja do you remember why you added that version check? Removing it fixes the bug.

Before / after
<img src="https://github.com/tuskyapp/Tusky/assets/10157047/b2c2f79e-7f30-47fb-89ef-b5e4c31b0d0e" width="200"/> <img src="https://github.com/tuskyapp/Tusky/assets/10157047/3bb746f8-97e7-4d60-a67e-175e02a6d929" width="200"/>

closes #4175 
