### PR TITLE
fix ClassCastException in ClickableSpanTextView

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/view/ClickableSpanTextView.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/view/ClickableSpanTextView.kt
@@ -203,7 +203,7 @@ class ClickableSpanTextView @JvmOverloads constructor(
             val endSelection = selectionEnd
 
             val content = text
-            if (startSelection < 0 || endSelection < 0) {
+            if (content is Spannable && (startSelection < 0 || endSelection < 0)) {
                 Selection.setSelection(content as Spannable?, content.length)
             } else if (startSelection != endSelection) {
                 if (event.actionMasked == ACTION_DOWN) {


### PR DESCRIPTION
<details>
  <summary>Stacktrace</summary>
  
  ```
 java.lang.ClassCastException: java.lang.String cannot be cast to android.text.Spannable
				at com.keylesspalace.tusky.view.ClickableSpanTextView.dispatchTouchEvent(ClickableSpanTextView.kt:208)
				at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2968)
				at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2600)
				at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2968)
				at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2600)
				at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2968)
				at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2600)
				at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2968)
				at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2600)
				at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2968)
				at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2600)
				at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2968)
				at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2600)
				at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2968)
				at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2600)
				at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2968)
				at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2600)
				at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2968)
				at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2600)
				at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2968)
				at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2600)
				at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2968)
				at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2600)
				at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2968)
				at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2600)
				at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2968)
				at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2600)
				at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2968)
				at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2600)
				at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2968)
				at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2600)
				at com.android.internal.policy.DecorView.superDispatchTouchEvent(DecorView.java:448)
				at com.android.internal.policy.PhoneWindow.superDispatchTouchEvent(PhoneWindow.java:1829)
				at android.app.Activity.dispatchTouchEvent(Activity.java:3307)
				at androidx.appcompat.view.WindowCallbackWrapper.dispatchTouchEvent(WindowCallbackWrapper.java:70)
				at com.android.internal.policy.DecorView.dispatchTouchEvent(DecorView.java:410)
				at android.view.View.dispatchPointerEvent(View.java:12015)
				at android.view.ViewRootImpl$ViewPostImeInputStage.processPointerEvent(ViewRootImpl.java:4795)
				at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:4609)
				at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:4147)
				at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:4200)
				at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:4166)
				at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:4293)
				at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:4174)
				at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:4350)
				at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:4147)
				at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:4200)
				at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:4166)
				at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:4174)
				at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:4147)
				at android.view.ViewRootImpl.deliverInputEvent(ViewRootImpl.java:6661)
  ```
  
</details>

Could not reproduce with a regular build because I couldn't find the place where we set a string into a ClickableSpanTextView, so I created that scenario manually. It crashed instantly when trying to select text, and with this fix it behaved as expected.