### PR TITLE
fix Glide IllegalArgumentException in DrawerImageLoader

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -573,7 +573,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
             }
 
             override fun cancel(imageView: ImageView) {
-                Glide.with(imageView).clear(imageView)
+                // nothing to do, Glide already handles cancellation automatically
             }
 
             override fun placeholder(ctx: Context, tag: String?): Drawable {


### PR DESCRIPTION
Turns out that the crash I thought will not occur with #4153 did occur again. 😒 
But this time I managed to reproduce it (faking a slow network for that one request only and then quickly switching activities to get it destroyed) so I'm sure it is fixed, and I did a check for possible side effects but it seems Glide is clever enough to cancel all requests by itself.

<details>
<summary>stacktrace</summary>

```
Exception java.lang.IllegalArgumentException: You cannot start a load for a destroyed activity
  at com.bumptech.glide.manager.RequestManagerRetriever.assertNotDestroyed (RequestManagerRetriever.java:236)
  at com.bumptech.glide.manager.RequestManagerRetriever.get (RequestManagerRetriever.java:110)
  at com.bumptech.glide.manager.RequestManagerRetriever.get (RequestManagerRetriever.java:176)
  at com.bumptech.glide.Glide.with (Glide.java:634)
  at com.keylesspalace.tusky.MainActivity$setupDrawer$2.cancel (MainActivity.kt:573)
  at com.mikepenz.materialdrawer.util.DrawerImageLoader.cancelImage (DrawerImageLoader.java:56)
  at com.mikepenz.materialdrawer.model.BaseDescribeableDrawerItem.unbindView (BaseDescribeableDrawerItem.kt:95)
  at com.mikepenz.materialdrawer.model.BaseDescribeableDrawerItem.unbindView (BaseDescribeableDrawerItem.kt:20)
  at com.mikepenz.fastadapter.listeners.OnBindViewHolderListenerImpl.unBindViewHolder (OnBindViewHolderListenerImpl.java:36)
  at com.mikepenz.fastadapter.FastAdapter.onViewRecycled (FastAdapter.kt:410)
  at androidx.recyclerview.widget.RecyclerView$Recycler.dispatchViewRecycled (RecyclerView.java:7346)
  at androidx.recyclerview.widget.RecyclerView$Recycler.addViewHolderToRecycledViewPool (RecyclerView.java:7108)
  at androidx.recyclerview.widget.RecyclerView$Recycler.recycleViewHolderInternal (RecyclerView.java:7059)
  at androidx.recyclerview.widget.RecyclerView.removeAnimatingView (RecyclerView.java:1556)
  at androidx.recyclerview.widget.RecyclerView$ItemAnimatorRestoreListener.onAnimationFinished (RecyclerView.java:13564)
  at androidx.recyclerview.widget.RecyclerView$ItemAnimator.dispatchAnimationFinished (RecyclerView.java:14066)
  at androidx.recyclerview.widget.SimpleItemAnimator.dispatchChangeFinished (SimpleItemAnimator.java:328)
  at androidx.recyclerview.widget.DefaultItemAnimator.endChangeAnimationIfNecessary (DefaultItemAnimator.java:437)
  at androidx.recyclerview.widget.DefaultItemAnimator.endChangeAnimationIfNecessary (DefaultItemAnimator.java:418)
  at androidx.recyclerview.widget.DefaultItemAnimator.endAnimations (DefaultItemAnimator.java:588)
  at androidx.recyclerview.widget.RecyclerView.onDetachedFromWindow (RecyclerView.java:3383)
  at android.view.View.dispatchDetachedFromWindow (View.java:20898)
  at android.view.ViewGroup.dispatchDetachedFromWindow (ViewGroup.java:3956)
  at android.view.ViewGroup.dispatchDetachedFromWindow (ViewGroup.java:3948)
  at android.view.ViewGroup.dispatchDetachedFromWindow (ViewGroup.java:3948)
  at android.view.ViewGroup.dispatchDetachedFromWindow (ViewGroup.java:3948)
  at android.view.ViewGroup.dispatchDetachedFromWindow (ViewGroup.java:3948)
  at android.view.ViewGroup.dispatchDetachedFromWindow (ViewGroup.java:3948)
  at android.view.ViewGroup.dispatchDetachedFromWindow (ViewGroup.java:3948)
  at android.view.ViewGroup.dispatchDetachedFromWindow (ViewGroup.java:3948)
  at android.view.ViewRootImpl.dispatchDetachedFromWindow (ViewRootImpl.java:5114)
  at android.view.ViewRootImpl.doDie (ViewRootImpl.java:8309)
  at android.view.ViewRootImpl.die (ViewRootImpl.java:8286)
  at android.view.WindowManagerGlobal.removeViewLocked (WindowManagerGlobal.java:538)
  at android.view.WindowManagerGlobal.removeView (WindowManagerGlobal.java:479)
  at android.view.WindowManagerImpl.removeViewImmediate (WindowManagerImpl.java:162)
  at android.app.ActivityThread.handleDestroyActivity (ActivityThread.java:5564)
  at android.app.ActivityThread.handleRelaunchActivityInner (ActivityThread.java:5842)
  at android.app.ActivityThread.handleRelaunchActivity (ActivityThread.java:5758)
  at android.app.servertransaction.ActivityRelaunchItem.execute (ActivityRelaunchItem.java:71)
  at android.app.servertransaction.ActivityTransactionItem.execute (ActivityTransactionItem.java:45)
  at android.app.servertransaction.TransactionExecutor.executeCallbacks (TransactionExecutor.java:135)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:95)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2293)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:226)
  at android.os.Looper.loop (Looper.java:329)
  at android.app.ActivityThread.main (ActivityThread.java:8058)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:548)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1026)
```

</details>