### PR TITLE
make sure link preview card is not shown when cw is collapsed

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -1104,7 +1104,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             actionable.getPoll() == null &&
             card != null &&
             !TextUtils.isEmpty(card.getUrl()) &&
-            (!actionable.getSensitive() || expanded) &&
+            (TextUtils.isEmpty(actionable.getSpoilerText()) || expanded) &&
             (!status.isCollapsible() || !status.isCollapsed())) {
 
             cardView.setVisibility(View.VISIBLE);


### PR DESCRIPTION
The sensitive flag indicates sensitive media, but we want to check if there is a contentwarning on the post. I think statuses that have a contentwarning but no sensitive flag are rare so we never noticed this bug.

closes #4201