### PR TITLE
feat: explicitly enable the share-button in Chrome Custom Tabs

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -350,6 +350,7 @@ fun openLinkInCustomTab(uri: Uri, context: Context) {
         .build()
     val customTabsIntent = CustomTabsIntent.Builder()
         .setDefaultColorSchemeParams(colorSchemeParams)
+        .setShareState(CustomTabsIntent.SHARE_STATE_ON)
         .setShowTitle(true)
         .build()
 


### PR DESCRIPTION
Chrome defaults to showing it anyways, but Firefox doesn't. By enabling this feature, users across both browsers will now have the same experience.

closes tuskyapp/Tusky/issues/4137