### PR TITLE
Revert "Migrate to Hilt KSP compiler (#4136)"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.google.ksp)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.kotlin.parcelize)
 }
 
@@ -146,7 +147,7 @@ dependencies {
     implementation libs.bundles.autodispose
 
     implementation libs.bundles.dagger
-    ksp libs.bundles.dagger.processors
+    kapt libs.bundles.dagger.processors
 
     implementation libs.sparkbutton
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.google.ksp) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.kapt) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.ktlint) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ autodispose = "2.2.1"
 bouncycastle = "1.70"
 conscrypt = "2.5.2"
 coroutines = "1.7.3"
-dagger = "2.49"
+dagger = "2.48.1"
 diffx = "1.1.1"
 emoji2 = "1.3.0"
 espresso = "3.5.1"
@@ -59,6 +59,7 @@ xmlwriter = "1.0.4"
 android-application = { id = "com.android.application", version.ref = "agp" }
 google-ksp = "com.google.devtools.ksp:1.9.22-1.0.16"
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 ktlint = "org.jlleitschuh.gradle.ktlint:12.0.3"
 


### PR DESCRIPTION
This reverts commit 649424730133188da585cd47063b00c4f01ff3e8.

Seems like dagger/ksp is still a bit buggy, I'm getting one of these errors every other build, so lets revert this for now.

https://github.com/google/dagger/issues/4181
https://github.com/google/ksp/issues/1196