### PR TITLE
set greenDebug as default flavor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,9 @@ android {
         buildConfigField("String", "SUPPORT_ACCOUNT_URL", "\"$SUPPORT_ACCOUNT_URL\"")
     }
     buildTypes {
+        debug {
+            getIsDefault().set(true)
+        }
         release {
             minifyEnabled true
             shrinkResources true
@@ -55,6 +58,7 @@ android {
             resValue "string", "app_name", APP_NAME + " Test"
             applicationIdSuffix ".test"
             versionNameSuffix "-" + gitSha
+            getIsDefault().set(true)
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ android {
     }
     buildTypes {
         debug {
-            getIsDefault().set(true)
+            isDefault true
         }
         release {
             minifyEnabled true
@@ -58,7 +58,7 @@ android {
             resValue "string", "app_name", APP_NAME + " Test"
             applicationIdSuffix ".test"
             versionNameSuffix "-" + gitSha
-            getIsDefault().set(true)
+            isDefault true
         }
     }
 


### PR DESCRIPTION
I had it happen multiple times recently that I was testing green Tusky but Android Studio actually put blue Tusky on my device and I wasted a lot of time until I found out 😣
This change should tell it that greenDebug is the preferred flavor for developing.