### PR TITLE
make badge for new direct messages blue

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -846,8 +846,9 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
                 else -> getString(tabs[position].text)
             }
             if (tabs[position].id == DIRECT) {
-                tab.orCreateBadge
-                tab.badge?.isVisible = accountManager.activeAccount?.hasDirectMessageBadge ?: false
+                val badge = tab.orCreateBadge
+                badge.isVisible = accountManager.activeAccount?.hasDirectMessageBadge ?: false
+                badge.backgroundColor = MaterialColors.getColor(binding.mainDrawer, com.google.android.material.R.attr.colorPrimary)
                 directMessageTab = tab
             }
         }.also { it.attach() }


### PR DESCRIPTION
This makes the dot badge that we show on the direct messages tab when there are unread messages blue instead of red. I prefer it that way because its more subtle and doesn't look like there is some kind of error.

before / after:

<img src="https://github.com/tuskyapp/Tusky/assets/10157047/f4b241a5-0fa4-4134-9790-18f74caa2dae" width="240"/> <img src="https://github.com/tuskyapp/Tusky/assets/10157047/56788d5c-f19c-4fa5-b83e-e824aed995f4" width="240"/>
