### PR TITLE
Improve detailed status looks

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -151,10 +151,10 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         sensitiveMediaWarning = itemView.findViewById(R.id.status_sensitive_media_warning);
         sensitiveMediaShow = itemView.findViewById(R.id.status_sensitive_media_button);
         mediaLabels = new TextView[]{
-                itemView.findViewById(R.id.status_media_label_0),
-                itemView.findViewById(R.id.status_media_label_1),
-                itemView.findViewById(R.id.status_media_label_2),
-                itemView.findViewById(R.id.status_media_label_3)
+            itemView.findViewById(R.id.status_media_label_0),
+            itemView.findViewById(R.id.status_media_label_1),
+            itemView.findViewById(R.id.status_media_label_2),
+            itemView.findViewById(R.id.status_media_label_3)
         };
         mediaDescriptions = new CharSequence[mediaLabels.length];
         contentWarningDescription = itemView.findViewById(R.id.status_content_warning_description);
@@ -193,7 +193,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
     protected void setDisplayName(@NonNull String name, @Nullable List<Emoji> customEmojis, @NonNull StatusDisplayOptions statusDisplayOptions) {
         CharSequence emojifiedName = CustomEmojiHelper.emojify(
-                name, customEmojis, displayName, statusDisplayOptions.animateEmojis()
+            name, customEmojis, displayName, statusDisplayOptions.animateEmojis()
         );
         displayName.setText(emojifiedName);
     }
@@ -221,7 +221,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
         if (sensitive) {
             CharSequence emojiSpoiler = CustomEmojiHelper.emojify(
-                    spoilerText, emojis, contentWarningDescription, statusDisplayOptions.animateEmojis()
+                spoilerText, emojis, contentWarningDescription, statusDisplayOptions.animateEmojis()
             );
             contentWarningDescription.setText(emojiSpoiler);
             contentWarningDescription.setVisibility(View.VISIBLE);
@@ -271,7 +271,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         Status actionable = status.getActionable();
         Spanned content = status.getContent();
         List<Status.Mention> mentions = actionable.getMentions();
-        List<HashTag> tags =actionable.getTags();
+        List<HashTag> tags = actionable.getTags();
         List<Emoji> emojis = actionable.getEmojis();
         PollViewData poll = PollViewDataKt.toViewData(actionable.getPoll());
 
@@ -304,7 +304,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
     }
 
     private void setAvatar(String url,
-                          @Nullable String rebloggedUrl,
+                           @Nullable String rebloggedUrl,
                            boolean isBot,
                            StatusDisplayOptions statusDisplayOptions) {
 
@@ -315,8 +315,8 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             if (statusDisplayOptions.showBotOverlay() && isBot) {
                 avatarInset.setVisibility(View.VISIBLE);
                 Glide.with(avatarInset)
-                        .load(R.drawable.bot_badge)
-                        .into(avatarInset);
+                    .load(R.drawable.bot_badge)
+                    .into(avatarInset);
             } else {
                 avatarInset.setVisibility(View.GONE);
             }
@@ -330,7 +330,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             avatarInset.setVisibility(View.VISIBLE);
             avatarInset.setBackground(null);
             ImageLoadingHelper.loadAvatar(rebloggedUrl, avatarInset, avatarRadius24dp,
-                    statusDisplayOptions.animateAvatars(), null);
+                statusDisplayOptions.animateAvatars(), null);
 
             avatarRadius = avatarRadius36dp;
         }
@@ -383,8 +383,8 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                 long then = createdAt.getTime();
                 long now = System.currentTimeMillis();
                 return DateUtils.getRelativeTimeSpanString(then, now,
-                        DateUtils.SECOND_IN_MILLIS,
-                        DateUtils.FORMAT_ABBREV_RELATIVE);
+                    DateUtils.SECOND_IN_MILLIS,
+                    DateUtils.FORMAT_ABBREV_RELATIVE);
             }
         }
     }
@@ -467,9 +467,9 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             imageView.removeFocalPoint();
 
             Glide.with(imageView)
-                    .load(placeholder)
-                    .centerInside()
-                    .into(imageView);
+                .load(placeholder)
+                .centerInside()
+                .into(imageView);
         } else {
             Focus focus = meta != null ? meta.getFocus() : null;
 
@@ -477,29 +477,29 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                 imageView.setFocalPoint(focus);
 
                 Glide.with(imageView.getContext())
-                        .load(previewUrl)
-                        .placeholder(placeholder)
-                        .centerInside()
-                        .addListener(imageView)
-                        .into(imageView);
+                    .load(previewUrl)
+                    .placeholder(placeholder)
+                    .centerInside()
+                    .addListener(imageView)
+                    .into(imageView);
             } else {
                 imageView.removeFocalPoint();
 
                 Glide.with(imageView)
-                        .load(previewUrl)
-                        .placeholder(placeholder)
-                        .centerInside()
-                        .into(imageView);
+                    .load(previewUrl)
+                    .placeholder(placeholder)
+                    .centerInside()
+                    .into(imageView);
             }
         }
     }
 
     protected void setMediaPreviews(
-            final @NonNull List<Attachment> attachments,
-            boolean sensitive,
-            final @NonNull StatusActionListener listener,
-            boolean showingContent,
-            boolean useBlurhash
+        final @NonNull List<Attachment> attachments,
+        boolean sensitive,
+        final @NonNull StatusActionListener listener,
+        boolean showingContent,
+        boolean useBlurhash
     ) {
 
         mediaPreview.setVisibility(View.VISIBLE);
@@ -518,10 +518,10 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             }
 
             loadImage(
-                    imageView,
-                    showingContent ? previewUrl : null,
-                    attachment.getMeta(),
-                    useBlurhash ? attachment.getBlurhash() : null
+                imageView,
+                showingContent ? previewUrl : null,
+                attachment.getMeta(),
+                useBlurhash ? attachment.getBlurhash() : null
             );
 
             final Attachment.Type type = attachment.getType();
@@ -583,8 +583,8 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
     private void updateMediaLabel(int index, boolean sensitive, boolean showingContent) {
         Context context = itemView.getContext();
         CharSequence label = (sensitive && !showingContent) ?
-                context.getString(R.string.post_sensitive_media_title) :
-                mediaDescriptions[index];
+            context.getString(R.string.post_sensitive_media_title) :
+            mediaDescriptions[index];
         mediaLabels[index].setText(label);
     }
 
@@ -727,7 +727,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         }
         popup.setOnMenuItemClickListener(item -> {
             listener.onReblog(!buttonState, position);
-            if(!buttonState) {
+            if (!buttonState) {
                 reblogButton.playAnimation();
                 reblogButton.setChecked(true);
             }
@@ -749,7 +749,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         }
         popup.setOnMenuItemClickListener(item -> {
             listener.onFavourite(!buttonState, position);
-            if(!buttonState) {
+            if (!buttonState) {
                 favouriteButton.playAnimation();
                 favouriteButton.setChecked(true);
             }
@@ -775,7 +775,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             setIsReply(actionable.getInReplyToId() != null);
             setReplyCount(actionable.getRepliesCount(), statusDisplayOptions.showStatsInline());
             setAvatar(actionable.getAccount().getAvatar(), status.getRebloggedAvatar(),
-                    actionable.getAccount().getBot(), statusDisplayOptions);
+                actionable.getAccount().getBot(), statusDisplayOptions);
             setReblogged(actionable.getReblogged());
             setFavourited(actionable.getFavourited());
             setBookmarked(actionable.getBookmarked());
@@ -801,7 +801,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             setupCard(status, status.isExpanded(), statusDisplayOptions.cardViewMode(), statusDisplayOptions, listener);
 
             setupButtons(listener, actionable.getAccount().getId(), status.getContent().toString(),
-                    statusDisplayOptions);
+                statusDisplayOptions);
             setRebloggingEnabled(actionable.rebloggingAllowed(), actionable.getVisibility());
 
             setSpoilerAndContent(status, statusDisplayOptions, listener);
@@ -864,21 +864,21 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         Status actionable = status.getActionable();
 
         String description = context.getString(R.string.description_status,
-                actionable.getAccount().getDisplayName(),
-                getContentWarningDescription(context, status),
-                (TextUtils.isEmpty(actionable.getSpoilerText()) || !actionable.getSensitive() || status.isExpanded() ? status.getContent() : ""),
-                getCreatedAtDescription(actionable.getCreatedAt(), statusDisplayOptions),
-                actionable.getEditedAt() != null ? context.getString(R.string.description_post_edited) : "",
-                getReblogDescription(context, status),
-                actionable.getAccount().getUsername(),
-                actionable.getReblogged() ? context.getString(R.string.description_post_reblogged) : "",
-                actionable.getFavourited() ? context.getString(R.string.description_post_favourited) : "",
-                actionable.getBookmarked() ? context.getString(R.string.description_post_bookmarked) : "",
-                getMediaDescription(context, status),
-                getVisibilityDescription(context, actionable.getVisibility()),
-                getFavsText(context, actionable.getFavouritesCount()),
-                getReblogsText(context, actionable.getReblogsCount()),
-                getPollDescription(status, context, statusDisplayOptions)
+            actionable.getAccount().getDisplayName(),
+            getContentWarningDescription(context, status),
+            (TextUtils.isEmpty(actionable.getSpoilerText()) || !actionable.getSensitive() || status.isExpanded() ? status.getContent() : ""),
+            getCreatedAtDescription(actionable.getCreatedAt(), statusDisplayOptions),
+            actionable.getEditedAt() != null ? context.getString(R.string.description_post_edited) : "",
+            getReblogDescription(context, status),
+            actionable.getAccount().getUsername(),
+            actionable.getReblogged() ? context.getString(R.string.description_post_reblogged) : "",
+            actionable.getFavourited() ? context.getString(R.string.description_post_favourited) : "",
+            actionable.getBookmarked() ? context.getString(R.string.description_post_bookmarked) : "",
+            getMediaDescription(context, status),
+            getVisibilityDescription(context, actionable.getVisibility()),
+            getFavsText(context, actionable.getFavouritesCount()),
+            getReblogsText(context, actionable.getReblogsCount()),
+            getPollDescription(status, context, statusDisplayOptions)
         );
         itemView.setContentDescription(description);
     }
@@ -888,7 +888,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         Status reblog = status.getRebloggingStatus();
         if (reblog != null) {
             return context
-                    .getString(R.string.post_boosted_format, reblog.getAccount().getUsername());
+                .getString(R.string.post_boosted_format, reblog.getAccount().getUsername());
         } else {
             return "";
         }
@@ -900,18 +900,18 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             return "";
         }
         StringBuilder mediaDescriptions = CollectionsKt.fold(
-                status.getActionable().getAttachments(),
-                new StringBuilder(),
-                (builder, a) -> {
-                    if (a.getDescription() == null) {
-                        String placeholder =
-                                context.getString(R.string.description_post_media_no_description_placeholder);
-                        return builder.append(placeholder);
-                    } else {
-                        builder.append("; ");
-                        return builder.append(a.getDescription());
-                    }
-                });
+            status.getActionable().getAttachments(),
+            new StringBuilder(),
+            (builder, a) -> {
+                if (a.getDescription() == null) {
+                    String placeholder =
+                        context.getString(R.string.description_post_media_no_description_placeholder);
+                    return builder.append(placeholder);
+                } else {
+                    builder.append("; ");
+                    return builder.append(a.getDescription());
+                }
+            });
         return context.getString(R.string.description_post_media, mediaDescriptions);
     }
 
@@ -969,29 +969,21 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                 }
             }
             args[4] = getPollInfoText(System.currentTimeMillis(), poll, statusDisplayOptions,
-                    context);
+                context);
             return context.getString(R.string.description_poll, args);
         }
     }
 
     @NonNull
     protected CharSequence getFavsText(@NonNull Context context, int count) {
-        if (count > 0) {
-            String countString = numberFormat.format(count);
-            return HtmlCompat.fromHtml(context.getResources().getQuantityString(R.plurals.favs, count, countString), HtmlCompat.FROM_HTML_MODE_LEGACY);
-        } else {
-            return "";
-        }
+        String countString = numberFormat.format(count);
+        return HtmlCompat.fromHtml(context.getResources().getQuantityString(R.plurals.favs, count, countString), HtmlCompat.FROM_HTML_MODE_LEGACY);
     }
 
     @NonNull
-    protected CharSequence getReblogsText(@NonNull Context context, int count) {
-        if (count > 0) {
-            String countString = numberFormat.format(count);
-            return HtmlCompat.fromHtml(context.getResources().getQuantityString(R.plurals.reblogs, count, countString), HtmlCompat.FROM_HTML_MODE_LEGACY);
-        } else {
-            return "";
-        }
+    protected CharSequence getReblogsText   (@NonNull Context context, int count) {
+        String countString = numberFormat.format(count);
+        return HtmlCompat.fromHtml(context.getResources().getQuantityString(R.plurals.reblogs, count, countString), HtmlCompat.FROM_HTML_MODE_LEGACY);
     }
 
     private void setupPoll(PollViewData poll, List<Emoji> emojis,
@@ -1014,26 +1006,26 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                 }
             };
             pollAdapter.setup(
-                    poll.getOptions(),
-                    poll.getVotesCount(),
-                    poll.getVotersCount(),
-                    emojis,
-                    PollAdapter.RESULT,
-                    viewThreadListener,
-                    statusDisplayOptions.animateEmojis()
+                poll.getOptions(),
+                poll.getVotesCount(),
+                poll.getVotersCount(),
+                emojis,
+                PollAdapter.RESULT,
+                viewThreadListener,
+                statusDisplayOptions.animateEmojis()
             );
 
             pollButton.setVisibility(View.GONE);
         } else {
             // voting possible
             pollAdapter.setup(
-                    poll.getOptions(),
-                    poll.getVotesCount(),
-                    poll.getVotersCount(),
-                    emojis,
-                    poll.getMultiple() ? PollAdapter.MULTIPLE : PollAdapter.SINGLE,
-                    null,
-                    statusDisplayOptions.animateEmojis()
+                poll.getOptions(),
+                poll.getVotesCount(),
+                poll.getVotersCount(),
+                emojis,
+                poll.getMultiple() ? PollAdapter.MULTIPLE : PollAdapter.SINGLE,
+                null,
+                statusDisplayOptions.animateEmojis()
             );
 
             pollButton.setVisibility(View.VISIBLE);
@@ -1086,11 +1078,11 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
     }
 
     protected void setupCard(
-            final @NonNull StatusViewData.Concrete status,
-            boolean expanded,
-            final @NonNull CardViewMode cardViewMode,
-            final @NonNull StatusDisplayOptions statusDisplayOptions,
-            final @NonNull StatusActionListener listener
+        final @NonNull StatusViewData.Concrete status,
+        boolean expanded,
+        final @NonNull CardViewMode cardViewMode,
+        final @NonNull StatusDisplayOptions statusDisplayOptions,
+        final @NonNull StatusActionListener listener
     ) {
         if (cardView == null) {
             return;
@@ -1128,14 +1120,14 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             if (statusDisplayOptions.mediaPreviewEnabled() && !actionable.getSensitive() && !TextUtils.isEmpty(card.getImage())) {
 
                 int radius = cardImage.getContext().getResources()
-                        .getDimensionPixelSize(R.dimen.card_radius);
+                    .getDimensionPixelSize(R.dimen.card_radius);
                 ShapeAppearanceModel.Builder cardImageShape = ShapeAppearanceModel.builder();
 
                 if (card.getWidth() > card.getHeight()) {
                     cardView.setOrientation(LinearLayout.VERTICAL);
 
                     cardImage.getLayoutParams().height = cardImage.getContext().getResources()
-                            .getDimensionPixelSize(R.dimen.card_image_vertical_height);
+                        .getDimensionPixelSize(R.dimen.card_image_vertical_height);
                     cardImage.getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
                     cardInfo.getLayoutParams().height = ViewGroup.LayoutParams.MATCH_PARENT;
                     cardInfo.getLayoutParams().width = ViewGroup.LayoutParams.WRAP_CONTENT;
@@ -1145,7 +1137,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                     cardView.setOrientation(LinearLayout.HORIZONTAL);
                     cardImage.getLayoutParams().height = ViewGroup.LayoutParams.MATCH_PARENT;
                     cardImage.getLayoutParams().width = cardImage.getContext().getResources()
-                            .getDimensionPixelSize(R.dimen.card_image_horizontal_width);
+                        .getDimensionPixelSize(R.dimen.card_image_horizontal_width);
                     cardInfo.getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
                     cardInfo.getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
                     cardImageShape.setTopLeftCorner(CornerFamily.ROUNDED, radius);
@@ -1157,40 +1149,40 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                 cardImage.setScaleType(ImageView.ScaleType.CENTER_CROP);
 
                 RequestBuilder<Drawable> builder = Glide.with(cardImage.getContext())
-                        .load(card.getImage())
-                        .dontTransform();
+                    .load(card.getImage())
+                    .dontTransform();
                 if (statusDisplayOptions.useBlurhash() && !TextUtils.isEmpty(card.getBlurhash())) {
                     builder = builder.placeholder(decodeBlurHash(card.getBlurhash()));
                 }
                 builder.into(cardImage);
             } else if (statusDisplayOptions.useBlurhash() && !TextUtils.isEmpty(card.getBlurhash())) {
                 int radius = cardImage.getContext().getResources()
-                        .getDimensionPixelSize(R.dimen.card_radius);
+                    .getDimensionPixelSize(R.dimen.card_radius);
 
                 cardView.setOrientation(LinearLayout.HORIZONTAL);
                 cardImage.getLayoutParams().height = ViewGroup.LayoutParams.MATCH_PARENT;
                 cardImage.getLayoutParams().width = cardImage.getContext().getResources()
-                        .getDimensionPixelSize(R.dimen.card_image_horizontal_width);
+                    .getDimensionPixelSize(R.dimen.card_image_horizontal_width);
                 cardInfo.getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
                 cardInfo.getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
 
                 ShapeAppearanceModel cardImageShape = ShapeAppearanceModel.builder()
-                        .setTopLeftCorner(CornerFamily.ROUNDED, radius)
-                        .setBottomLeftCorner(CornerFamily.ROUNDED, radius)
-                        .build();
+                    .setTopLeftCorner(CornerFamily.ROUNDED, radius)
+                    .setBottomLeftCorner(CornerFamily.ROUNDED, radius)
+                    .build();
                 cardImage.setShapeAppearanceModel(cardImageShape);
 
                 cardImage.setScaleType(ImageView.ScaleType.CENTER_CROP);
 
                 Glide.with(cardImage.getContext())
-                        .load(decodeBlurHash(card.getBlurhash()))
-                        .dontTransform()
-                        .into(cardImage);
+                    .load(decodeBlurHash(card.getBlurhash()))
+                    .dontTransform()
+                    .into(cardImage);
             } else {
                 cardView.setOrientation(LinearLayout.HORIZONTAL);
                 cardImage.getLayoutParams().height = ViewGroup.LayoutParams.MATCH_PARENT;
                 cardImage.getLayoutParams().width = cardImage.getContext().getResources()
-                        .getDimensionPixelSize(R.dimen.card_image_horizontal_width);
+                    .getDimensionPixelSize(R.dimen.card_image_horizontal_width);
                 cardInfo.getLayoutParams().height = ViewGroup.LayoutParams.WRAP_CONTENT;
                 cardInfo.getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
 
@@ -1199,8 +1191,8 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                 cardImage.setScaleType(ImageView.ScaleType.CENTER);
 
                 Glide.with(cardImage.getContext())
-                        .load(R.drawable.card_image_placeholder)
-                        .into(cardImage);
+                    .load(R.drawable.card_image_placeholder)
+                    .into(cardImage);
             }
 
             View.OnClickListener visitLink = v -> listener.onViewUrl(card.getUrl());
@@ -1208,8 +1200,8 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             cardView.setOnClickListener(visitLink);
             // View embedded photos in our image viewer instead of opening the browser
             cardImage.setOnClickListener(card.getType().equals(Card.TYPE_PHOTO) && !TextUtils.isEmpty(card.getEmbedUrl()) ?
-                    v -> cardView.getContext().startActivity(ViewMediaActivity.newSingleImageIntent(cardView.getContext(), card.getEmbedUrl())) :
-                    visitLink);
+                v -> cardView.getContext().startActivity(ViewMediaActivity.newSingleImageIntent(cardView.getContext(), card.getEmbedUrl())) :
+                visitLink);
 
             cardView.setClipToOutline(true);
         } else {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
@@ -57,8 +57,8 @@ public class StatusDetailedViewHolder extends StatusBaseViewHolder {
 
         if (visibilityIcon != null) {
             ImageSpan visibilityIconSpan = new ImageSpan(
-                    visibilityIcon,
-                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q ? DynamicDrawableSpan.ALIGN_CENTER : DynamicDrawableSpan.ALIGN_BASELINE
+                visibilityIcon,
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q ? DynamicDrawableSpan.ALIGN_CENTER : DynamicDrawableSpan.ALIGN_BASELINE
             );
             sb.setSpan(visibilityIconSpan, 0, visibilityString.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
@@ -67,7 +67,6 @@ public class StatusDetailedViewHolder extends StatusBaseViewHolder {
 
         Date createdAt = status.getCreatedAt();
         if (createdAt != null) {
-
             sb.append(" ");
             sb.append(dateFormat.format(createdAt));
         }
@@ -105,7 +104,6 @@ public class StatusDetailedViewHolder extends StatusBaseViewHolder {
         Status.Application app = status.getApplication();
 
         if (app != null) {
-
             sb.append(metadataJoiner);
 
             if (app.getWebsite() != null) {
@@ -121,25 +119,8 @@ public class StatusDetailedViewHolder extends StatusBaseViewHolder {
     }
 
     private void setReblogAndFavCount(int reblogCount, int favCount, StatusActionListener listener) {
-
-        if (reblogCount > 0) {
-            reblogs.setText(getReblogsText(reblogs.getContext(), reblogCount));
-            reblogs.setVisibility(View.VISIBLE);
-        } else {
-            reblogs.setVisibility(View.GONE);
-        }
-        if (favCount > 0) {
-            favourites.setText(getFavsText(favourites.getContext(), favCount));
-            favourites.setVisibility(View.VISIBLE);
-        } else {
-            favourites.setVisibility(View.GONE);
-        }
-
-        if (reblogs.getVisibility() == View.GONE && favourites.getVisibility() == View.GONE) {
-            infoDivider.setVisibility(View.GONE);
-        } else {
-            infoDivider.setVisibility(View.VISIBLE);
-        }
+        reblogs.setText(getReblogsText(reblogs.getContext(), reblogCount));
+        favourites.setText(getFavsText(favourites.getContext(), favCount));
 
         reblogs.setOnClickListener(v -> {
             int position = getBindingAdapterPosition();
@@ -162,8 +143,8 @@ public class StatusDetailedViewHolder extends StatusBaseViewHolder {
                                 @Nullable Object payloads) {
         // We never collapse statuses in the detail view
         StatusViewData.Concrete uncollapsedStatus = (status.isCollapsible() && status.isCollapsed()) ?
-                status.copyWithCollapsed(false) :
-                status;
+            status.copyWithCollapsed(false) :
+            status;
 
         super.setupWithStatus(uncollapsedStatus, listener, statusDisplayOptions, payloads);
         setupCard(uncollapsedStatus, status.isExpanded(), CardViewMode.FULL_WIDTH, statusDisplayOptions, listener); // Always show card for detailed status
@@ -172,7 +153,7 @@ public class StatusDetailedViewHolder extends StatusBaseViewHolder {
 
             if (!statusDisplayOptions.hideStats()) {
                 setReblogAndFavCount(actionable.getReblogsCount(),
-                        actionable.getFavouritesCount(), listener);
+                    actionable.getFavouritesCount(), listener);
             } else {
                 hideQuantitativeStats();
             }
@@ -204,7 +185,7 @@ public class StatusDetailedViewHolder extends StatusBaseViewHolder {
         }
 
         final Drawable visibilityDrawable = AppCompatResources.getDrawable(
-                this.metaInfo.getContext(), visibilityIcon
+            this.metaInfo.getContext(), visibilityIcon
         );
         if (visibilityDrawable == null) {
             return null;
@@ -212,10 +193,10 @@ public class StatusDetailedViewHolder extends StatusBaseViewHolder {
 
         final int size = (int) this.metaInfo.getTextSize();
         visibilityDrawable.setBounds(
-                0,
-                0,
-                size,
-                size
+            0,
+            0,
+            size,
+            size
         );
         visibilityDrawable.setTint(this.metaInfo.getCurrentTextColor());
 

--- a/app/src/main/res/layout/item_status_detailed.xml
+++ b/app/src/main/res/layout/item_status_detailed.xml
@@ -283,17 +283,11 @@
         app:layout_constraintTop_toBottomOf="@id/status_poll_description"
         tools:text="21 Dec 2018 18:45" />
 
-    <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/status_counters_barrier"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:barrierDirection="bottom"
-        app:constraint_referenced_ids="status_reblogs,status_favourites" />
-
     <View
-        android:id="@+id/status_buttons_divider"
+        android:id="@+id/status_info_divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
+        android:layout_below="@id/status_meta_info"
         android:layout_marginStart="14dp"
         android:layout_marginTop="6dp"
         android:layout_marginEnd="14dp"
@@ -303,18 +297,56 @@
         android:paddingEnd="16dp"
         app:layout_constraintTop_toBottomOf="@id/status_meta_info" />
 
+    <TextView
+        android:id="@+id/status_reblogs"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:background="?attr/selectableItemBackground"
+        android:importantForAccessibility="no"
+        android:textSize="?attr/status_text_medium"
+        app:layout_constraintStart_toStartOf="@id/status_info_divider"
+        app:layout_constraintTop_toBottomOf="@id/status_info_divider"
+        tools:text="4 Boosts"
+        tools:visibility="visible" />
+
+    <TextView
+        android:id="@+id/status_favourites"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="6dp"
+        android:background="?attr/selectableItemBackground"
+        android:importantForAccessibility="no"
+        android:textSize="?attr/status_text_medium"
+        app:layout_constraintStart_toEndOf="@id/status_reblogs"
+        app:layout_constraintTop_toBottomOf="@id/status_info_divider"
+        app:layout_goneMarginStart="0dp"
+        tools:text="8 Favorites"
+        tools:visibility="visible" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/status_counters_barrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="status_reblogs,status_favourites" />
+
+
     <ImageButton
         android:id="@+id/status_reply"
         style="@style/TuskyImageButton"
         android:layout_width="52dp"
         android:layout_height="48dp"
+        android:layout_marginTop="4dp"
         android:contentDescription="@string/action_reply"
         android:importantForAccessibility="no"
         android:padding="4dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/status_inset"
         app:layout_constraintHorizontal_chainStyle="spread_inside"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/status_buttons_divider"
+        app:layout_constraintTop_toBottomOf="@id/status_counters_barrier"
         app:srcCompat="@drawable/ic_reply_24dp" />
 
     <at.connyduck.sparkbutton.SparkButton
@@ -381,46 +413,5 @@
         app:layout_constraintStart_toEndOf="@id/status_bookmark"
         app:layout_constraintTop_toTopOf="@id/status_reply"
         app:srcCompat="@drawable/ic_more_horiz_24dp" />
-
-    <View
-        android:id="@+id/status_info_divider"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_below="@id/status_meta_info"
-        android:layout_marginStart="14dp"
-        android:layout_marginEnd="14dp"
-        android:background="?android:attr/listDivider"
-        android:importantForAccessibility="no"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        app:layout_constraintTop_toBottomOf="@id/status_reply" />
-
-    <TextView
-        android:id="@+id/status_reblogs"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:background="?attr/selectableItemBackground"
-        android:importantForAccessibility="no"
-        android:padding="4dp"
-        android:textSize="?attr/status_text_medium"
-        app:layout_constraintStart_toStartOf="@id/status_info_divider"
-        app:layout_constraintTop_toBottomOf="@id/status_info_divider"
-        tools:text="4 reblogs"
-        tools:visibility="visible" />
-
-    <TextView
-        android:id="@+id/status_favourites"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
-        android:background="?attr/selectableItemBackground"
-        android:importantForAccessibility="no"
-        android:padding="4dp"
-        android:textSize="?attr/status_text_medium"
-        app:layout_constraintStart_toEndOf="@id/status_reblogs"
-        app:layout_constraintTop_toBottomOf="@id/status_info_divider"
-        app:layout_goneMarginStart="0dp"
-        tools:text="8 favs"
-        tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_status_detailed.xml
+++ b/app/src/main/res/layout/item_status_detailed.xml
@@ -286,7 +286,7 @@
     <View
         android:id="@+id/status_info_divider"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
+        android:layout_height="0.5dp"
         android:layout_below="@id/status_meta_info"
         android:layout_marginStart="14dp"
         android:layout_marginTop="6dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -546,11 +546,13 @@
     <string name="failed_to_unpin">Failed to Unpin</string>
 
     <plurals name="favs">
+        <item quantity="zero"><b>%1$s</b> Favorites</item>
         <item quantity="one">&lt;b>%1$s&lt;/b> Favorite</item>
         <item quantity="other">&lt;b>%1$s&lt;/b> Favorites</item>
     </plurals>
 
     <plurals name="reblogs">
+        <item quantity="zero"><b>%s</b> Boosts</item>
         <item quantity="one">&lt;b>%s&lt;/b> Boost</item>
         <item quantity="other">&lt;b>%s&lt;/b> Boosts</item>
     </plurals>


### PR DESCRIPTION
#4205 did change how the counters for the detailed posts behave and for a good reason I believe.

However I find the changed order very confusing and not aesthetically pleasing.

I have tried a few options, including reserving space for it but it was confusing (when counters are not displayed there would be a danging separator or if we show separator together with it it would be confusing as well).

I propose we simply show the counters independent on the counts. I know we try to de-emphasize the counters but I believe this is fine to do in detailed view.

One disadvantage is that we need translators to update the translations.

Additionally I've done two spacing changes: I removed a separator between the counters and the buttons, removed padding around the counters and increased the space between the counters and the buttons instead. I believe it's better to use space than separators. This also makes the space above/below the media/counters separator balanced.

In the second commit I've also made the metadata/counters separators thinner, I think it looks better.

here's the combined version:

![proposal_final](https://github.com/tuskyapp/Tusky/assets/3099142/ea9d4c0c-fe6a-4f2e-8427-673b2a833e6b)
