### PR TITLE
fix sending posts on Api 34

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
     <uses-permission android:name="android.permission.VIBRATE" /> <!-- For notifications -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING" />
 
     <application
         android:name=".TuskyApplication"
@@ -196,6 +197,7 @@
         </service>
 
         <service android:name=".service.SendStatusService"
+            android:foregroundServiceType="remoteMessaging"
             android:exported="false" />
 
         <provider


### PR DESCRIPTION
```
java.lang.RuntimeException: Unable to start service com.keylesspalace.tusky.service.SendStatusService@1eb9198 with Intent { cmp=com.keylesspalace.tusky.test/com.keylesspalace.tusky.service.SendStatusService (has extras) }: android.app.MissingForegroundServiceTypeException: Starting FGS without a type  callerApp=ProcessRecord{18608f7 22134:com.keylesspalace.tusky.test/u0a193} targetSDK=34
           at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:4839)
           at android.app.ActivityThread.-$$Nest$mhandleServiceArgs(Unknown Source:0)
           at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2289)
           at android.os.Handler.dispatchMessage(Handler.java:106)
           at android.os.Looper.loopOnce(Looper.java:205)
           at android.os.Looper.loop(Looper.java:294)
           at android.app.ActivityThread.main(ActivityThread.java:8177)
           at java.lang.reflect.Method.invoke(Native Method)
           at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
           at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
          Caused by: android.app.MissingForegroundServiceTypeException: Starting FGS without a type  callerApp=ProcessRecord{18608f7 22134:com.keylesspalace.tusky.test/u0a193} targetSDK=34
           at android.app.MissingForegroundServiceTypeException$1.createFromParcel(MissingForegroundServiceTypeException.java:53)
           at android.app.MissingForegroundServiceTypeException$1.createFromParcel(MissingForegroundServiceTypeException.java:49)
           at android.os.Parcel.readParcelableInternal(Parcel.java:4870)
           at android.os.Parcel.readParcelable(Parcel.java:4852)
           at android.os.Parcel.createExceptionOrNull(Parcel.java:3052)
           at android.os.Parcel.createException(Parcel.java:3041)
           at android.os.Parcel.readException(Parcel.java:3024)
           at android.os.Parcel.readException(Parcel.java:2966)
           at android.app.IActivityManager$Stub$Proxy.setServiceForeground(IActivityManager.java:6761)
           at android.app.Service.startForeground(Service.java:775)
           at com.keylesspalace.tusky.service.SendStatusService.onStartCommand(SendStatusService.kt:137)
           at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:4821)
           at android.app.ActivityThread.-$$Nest$mhandleServiceArgs(Unknown Source:0) 
           at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2289) 
           at android.os.Handler.dispatchMessage(Handler.java:106) 
           at android.os.Looper.loopOnce(Looper.java:205) 
           at android.os.Looper.loop(Looper.java:294) 
           at android.app.ActivityThread.main(ActivityThread.java:8177) 
           at java.lang.reflect.Method.invoke(Native Method) 
           at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552) 
           at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971) 
```