### PR TITLE
Better screen transitions

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
@@ -60,6 +60,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import static com.keylesspalace.tusky.settings.PrefKeys.APP_THEME;
+import static com.keylesspalace.tusky.util.ActivityExtensions.supportsOverridingActivityTransitions;
 
 public abstract class BaseActivity extends AppCompatActivity implements Injectable {
 
@@ -78,7 +79,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && getIntent().getBooleanExtra(OPEN_WITH_SLIDE_IN, false)) {
+        if (supportsOverridingActivityTransitions() && activityTransitionWasRequested()) {
             overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, R.anim.activity_open_enter, R.anim.activity_open_exit);
             overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, R.anim.actitivity_close_enter, R.anim.activity_close_exit);
         }
@@ -109,6 +110,10 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
         }
 
         requesters = new HashMap<>();
+    }
+
+    private boolean activityTransitionWasRequested() {
+        return getIntent().getBooleanExtra(OPEN_WITH_SLIDE_IN, false);
     }
 
     @Override
@@ -189,7 +194,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
     public void finish() {
         super.finish();
         // if this activity was opened with slide-in, close it with slide out
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE && getIntent().getBooleanExtra(OPEN_WITH_SLIDE_IN, false)) {
+        if (!supportsOverridingActivityTransitions() && activityTransitionWasRequested()) {
             overridePendingTransition(R.anim.actitivity_close_enter, R.anim.activity_close_exit);
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
@@ -79,8 +79,8 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
         super.onCreate(savedInstanceState);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && getIntent().getBooleanExtra(OPEN_WITH_SLIDE_IN, false)) {
-            overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, R.anim.slide_from_right, R.anim.slide_to_left);
-            overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, R.anim.slide_from_left, R.anim.slide_to_right);
+            overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, R.anim.activity_open_enter, R.anim.activity_open_exit);
+            overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, R.anim.actitivity_close_enter, R.anim.activity_close_exit);
         }
 
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
@@ -190,7 +190,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
         super.finish();
         // if this activity was opened with slide-in, close it with slide out
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE && getIntent().getBooleanExtra(OPEN_WITH_SLIDE_IN, false)) {
-            overridePendingTransition(R.anim.slide_from_left, R.anim.slide_to_right);
+            overridePendingTransition(R.anim.actitivity_close_enter, R.anim.activity_close_exit);
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -109,6 +109,7 @@ import com.keylesspalace.tusky.util.hide
 import com.keylesspalace.tusky.util.reduceSwipeSensitivity
 import com.keylesspalace.tusky.util.show
 import com.keylesspalace.tusky.util.startActivityWithSlideInAnimation
+import com.keylesspalace.tusky.util.supportsOverridingActivityTransitions
 import com.keylesspalace.tusky.util.unsafeLazy
 import com.keylesspalace.tusky.util.updateShortcut
 import com.keylesspalace.tusky.util.viewBinding
@@ -978,7 +979,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, HasAndroidInje
         }
         startActivity(intent)
         finish()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        if (supportsOverridingActivityTransitions()) {
             overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, R.anim.explode, R.anim.explode)
         } else {
             @Suppress("DEPRECATION")

--- a/app/src/main/java/com/keylesspalace/tusky/components/login/LoginActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/login/LoginActivity.kt
@@ -126,7 +126,7 @@ class LoginActivity : BaseActivity(), Injectable {
     override fun finish() {
         super.finish()
         if (isAdditionalLogin() || isAccountMigration()) {
-            overridePendingTransition(R.anim.slide_from_left, R.anim.slide_to_right)
+            overridePendingTransition(R.anim.actitivity_close_enter, R.anim.activity_close_exit)
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesActivity.kt
@@ -115,10 +115,10 @@ class PreferencesActivity :
         fragment.setTargetFragment(caller, 0)
         supportFragmentManager.commit {
             setCustomAnimations(
-                R.anim.slide_from_right,
-                R.anim.slide_to_left,
-                R.anim.slide_from_left,
-                R.anim.slide_to_right
+                R.anim.activity_open_enter,
+                R.anim.activity_open_exit,
+                R.anim.actitivity_close_enter,
+                R.anim.activity_close_exit
             )
             replace(R.id.fragment_container, fragment)
             addToBackStack(null)

--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/TabFilterPreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/TabFilterPreferencesFragment.kt
@@ -16,7 +16,11 @@
 package com.keylesspalace.tusky.components.preference
 
 import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import androidx.preference.PreferenceFragmentCompat
+import com.google.android.material.color.MaterialColors
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.di.Injectable
 import com.keylesspalace.tusky.settings.AccountPreferenceDataStore
@@ -30,6 +34,17 @@ class TabFilterPreferencesFragment : PreferenceFragmentCompat(), Injectable {
 
     @Inject
     lateinit var accountPreferenceDataStore: AccountPreferenceDataStore
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        // Give view a background color so transitions show up correctly
+        return super.onCreateView(inflater, container, savedInstanceState).also { view ->
+            view.setBackgroundColor(MaterialColors.getColor(view, android.R.attr.colorBackground))
+        }
+    }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         makePreferenceScreen {

--- a/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadFragment.kt
@@ -429,10 +429,10 @@ class ViewThreadFragment :
 
         parentFragmentManager.commit {
             setCustomAnimations(
-                R.anim.slide_from_right,
-                R.anim.slide_to_left,
-                R.anim.slide_from_left,
-                R.anim.slide_to_right
+                R.anim.activity_open_enter,
+                R.anim.activity_open_exit,
+                R.anim.actitivity_close_enter,
+                R.anim.activity_close_exit
             )
             replace(R.id.fragment_container, viewEditsFragment, "ViewEditsFragment_$id")
             addToBackStack(null)

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.kt
@@ -84,7 +84,7 @@ abstract class SFragment : Fragment(), Injectable {
 
     override fun startActivity(intent: Intent) {
         super.startActivity(intent)
-        requireActivity().overridePendingTransition(R.anim.slide_from_right, R.anim.slide_to_left)
+        requireActivity().overridePendingTransition(R.anim.activity_open_enter, R.anim.activity_open_exit)
     }
 
     override fun onAttach(context: Context) {

--- a/app/src/main/java/com/keylesspalace/tusky/util/ActivityExensions.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ActivityExensions.kt
@@ -16,6 +16,6 @@ fun Activity.startActivityWithSlideInAnimation(intent: Intent) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
         // the old api needs to be called by the activity that starts the transition
         @Suppress("DEPRECATION")
-        overridePendingTransition(R.anim.slide_from_right, R.anim.slide_to_left)
+        overridePendingTransition(R.anim.activity_open_enter, R.anim.activity_open_exit)
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/util/ActivityExensions.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ActivityExensions.kt
@@ -13,9 +13,13 @@ fun Activity.startActivityWithSlideInAnimation(intent: Intent) {
     // so we pass a flag that BaseActivity will respect.
     intent.putExtra(BaseActivity.OPEN_WITH_SLIDE_IN, true)
     startActivity(intent)
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+    if (!supportsOverridingActivityTransitions()) {
         // the old api needs to be called by the activity that starts the transition
         @Suppress("DEPRECATION")
         overridePendingTransition(R.anim.activity_open_enter, R.anim.activity_open_exit)
     }
+}
+
+fun supportsOverridingActivityTransitions(): Boolean {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 }

--- a/app/src/main/res/anim/actitivity_close_enter.xml
+++ b/app/src/main/res/anim/actitivity_close_enter.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="false">
+    <!--
+        No-op.
+
+        If we had extend we could do a bit of a fancy translate but without it it we will have a
+        weird gap at the gap of the screen.
+
+        We put no-op alpha translation because otherwise Android will compose the other part of the
+        transition over the black background.
+    -->
+    <alpha
+        android:fromAlpha="1.0"
+        android:toAlpha="1.0"
+        android:fillEnabled="true"
+        android:fillBefore="true"
+        android:fillAfter="true"
+        android:interpolator="@android:anim/linear_interpolator"
+        android:startOffset="0"
+        android:duration="450" />
+</set>

--- a/app/src/main/res/anim/activity_close_exit.xml
+++ b/app/src/main/res/anim/activity_close_exit.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="false"
+    android:zAdjustment="top">
+    <alpha
+        android:fromAlpha="1.0"
+        android:toAlpha="0.0"
+        android:fillEnabled="true"
+        android:fillBefore="true"
+        android:fillAfter="true"
+        android:interpolator="@android:anim/linear_interpolator"
+        android:startOffset="35"
+        android:duration="83" />
+
+    <translate
+        android:fromXDelta="0"
+        android:toXDelta="10%"
+        android:fillEnabled="true"
+        android:fillBefore="true"
+        android:fillAfter="true"
+        android:interpolator="@anim/fast_out_extra_slow_in"
+        android:startOffset="0"
+        android:duration="450" />
+
+</set>

--- a/app/src/main/res/anim/activity_open_enter.xml
+++ b/app/src/main/res/anim/activity_open_enter.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="false">
+    <alpha
+        android:fromAlpha="0.0"
+        android:toAlpha="1.0"
+        android:fillEnabled="true"
+        android:fillBefore="true"
+        android:fillAfter="true"
+        android:interpolator="@android:anim/linear_interpolator"
+        android:startOffset="50"
+        android:duration="83" />
+
+    <translate
+        android:fromXDelta="10%"
+        android:toXDelta="0"
+        android:fillEnabled="true"
+        android:fillBefore="true"
+        android:fillAfter="true"
+        android:interpolator="@anim/fast_out_extra_slow_in"
+        android:duration="450" />
+
+</set>

--- a/app/src/main/res/anim/activity_open_exit.xml
+++ b/app/src/main/res/anim/activity_open_exit.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shareInterpolator="false">
+    <!--
+        No-op.
+
+        If we had extend we could do a bit of a fancy translate but without it it we will have a
+        weird gap at the gap of the screen.
+
+        We put no-op alpha translation because otherwise Android will compose the other part of the
+        transition over the black background.
+    -->
+    <alpha
+        android:fromAlpha="1.0"
+        android:toAlpha="1.0"
+        android:fillEnabled="true"
+        android:fillBefore="true"
+        android:fillAfter="true"
+        android:interpolator="@android:anim/linear_interpolator"
+        android:startOffset="0"
+        android:duration="450" />
+</set>

--- a/app/src/main/res/anim/fast_out_extra_slow_in.xml
+++ b/app/src/main/res/anim/fast_out_extra_slow_in.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2017 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+<pathInterpolator xmlns:android="http://schemas.android.com/apk/res/android"
+    android:pathData="M 0,0 C 0.05, 0, 0.133333, 0.06, 0.166666, 0.4 C 0.208333, 0.82, 0.25, 1, 1, 1"/>

--- a/app/src/main/res/anim/slide_from_left.xml
+++ b/app/src/main/res/anim/slide_from_left.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<set xmlns:android="http://schemas.android.com/apk/res/android">
-    <translate android:fromXDelta="-100%p" android:toXDelta="0"
-        android:interpolator="@android:anim/accelerate_decelerate_interpolator"
-        android:duration="300"/>
-</set>

--- a/app/src/main/res/anim/slide_from_right.xml
+++ b/app/src/main/res/anim/slide_from_right.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<set xmlns:android="http://schemas.android.com/apk/res/android">
-    <translate android:fromXDelta="100%p" android:toXDelta="0"
-        android:interpolator="@android:anim/accelerate_decelerate_interpolator"
-        android:duration="300"/>
-</set>

--- a/app/src/main/res/anim/slide_to_left.xml
+++ b/app/src/main/res/anim/slide_to_left.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<set xmlns:android="http://schemas.android.com/apk/res/android">
-    <translate android:fromXDelta="0" android:toXDelta="-100%p"
-        android:interpolator="@android:anim/accelerate_decelerate_interpolator"
-        android:duration="300"/>
-</set>

--- a/app/src/main/res/anim/slide_to_right.xml
+++ b/app/src/main/res/anim/slide_to_right.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<set xmlns:android="http://schemas.android.com/apk/res/android">
-    <translate android:fromXDelta="0" android:toXDelta="100%p"
-        android:interpolator="@android:anim/accelerate_decelerate_interpolator"
-        android:duration="300"/>
-</set>


### PR DESCRIPTION
I mostly took Android 13 transitions and removed the sliding for the "deeper"/background one because "extend" animations are not available until Android 13.

Here are the original ones: https://cs.android.com/android/platform/superproject/+/android-13.0.0_r8:frameworks/base/core/res/res/anim/;bpv=1

Initially I've made separate versions fro Android 13+ that are close to the original but I think it's not worth it to keep both.


https://github.com/tuskyapp/Tusky/assets/3099142/616fc40c-f944-45b4-bf6f-167f62d30493

