### PR TITLE
Optimize Proguard rules

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,14 @@ android {
             minifyEnabled true
             shrinkResources true
             proguardFiles 'proguard-rules.pro'
+
+            kotlinOptions {
+                freeCompilerArgs = [
+                    "-Xno-param-assertions",
+                    "-Xno-call-assertions",
+                    "-Xno-receiver-assertions"
+                ]
+            }
         }
     }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,41 +1,52 @@
 # GENERAL OPTIONS
 
-# turn on all optimizations except those that are known to cause problems on Android
--optimizations !code/simplification/cast,!field/*,!class/merging/*
--optimizationpasses 6
 -allowaccessmodification
--dontpreverify
 
--dontusemixedcaseclassnames
--dontskipnonpubliclibraryclasses
--keepattributes *Annotation*
+# Preserve some attributes that may be required for reflection.
+-keepattributes RuntimeVisible*Annotations, AnnotationDefault
 
 # For native methods, see http://proguard.sourceforge.net/manual/examples.html#native
 -keepclasseswithmembernames class * {
     native <methods>;
 }
-# keep setters in Views so that animations can still work.
-# see http://proguard.sourceforge.net/manual/examples.html#beans
--keepclassmembers public class * extends android.view.View {
-    void set*(***);
-    *** get*();
-}
-# We want to keep methods in Activity that could be used in the XML attribute onClick
--keepclassmembers class * extends android.app.Activity {
-    public void *(android.view.View);
-}
-# For enumeration classes, see http://proguard.sourceforge.net/manual/examples.html#enumerations
--keepclassmembers enum * {
-    public static **[] values();
-    public static ** valueOf(java.lang.String);
-}
+
 -keepclassmembers class * implements android.os.Parcelable {
     public static final ** CREATOR;
 }
 
--keepclassmembers class **.R$* {
-    public static <fields>;
+# Preserve annotated Javascript interface methods.
+-keepclassmembers class * {
+    @android.webkit.JavascriptInterface <methods>;
 }
+
+# The support libraries contains references to newer platform versions.
+# Don't warn about those in case this app is linking against an older
+# platform version. We know about them, and they are safe.
+-dontnote androidx.**
+-dontwarn androidx.**
+
+# This class is deprecated, but remains for backward compatibility.
+-dontwarn android.util.FloatMath
+
+# Understand the @Keep support annotation.
+-keep class androidx.annotation.Keep
+
+-keep @androidx.annotation.Keep class * {*;}
+
+-keepclasseswithmembers class * {
+    @androidx.annotation.Keep <methods>;
+}
+
+-keepclasseswithmembers class * {
+    @androidx.annotation.Keep <fields>;
+}
+
+-keepclasseswithmembers class * {
+    @androidx.annotation.Keep <init>(...);
+}
+
+# These classes are duplicated between android.jar and core-lambda-stubs.jar.
+-dontnote java.lang.invoke.**
 
 # TUSKY SPECIFIC OPTIONS
 
@@ -73,10 +84,10 @@
 -keep,allowobfuscation,allowshrinking class kotlin.collections.List
 -keep,allowobfuscation,allowshrinking class kotlin.collections.Map
 -keep,allowobfuscation,allowshrinking class retrofit2.Call
+-keep,allowobfuscation,allowshrinking class at.connyduck.calladapter.networkresult.NetworkResult
 
-# https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md#retrofit
--keepattributes Signature
--keep class kotlin.coroutines.Continuation
+# https://github.com/square/retrofit/pull/3563
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
 
 # preserve line numbers for crash reporting
 -keepattributes SourceFile,LineNumberTable
@@ -93,9 +104,6 @@
     public static *** w(...);
     public static *** v(...);
     public static *** i(...);
-}
--assumenosideeffects class java.lang.String {
-    public static java.lang.String format(...);
 }
 
 # remove some kotlin overhead

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -28,23 +28,6 @@
 # This class is deprecated, but remains for backward compatibility.
 -dontwarn android.util.FloatMath
 
-# Understand the @Keep support annotation.
--keep class androidx.annotation.Keep
-
--keep @androidx.annotation.Keep class * {*;}
-
--keepclasseswithmembers class * {
-    @androidx.annotation.Keep <methods>;
-}
-
--keepclasseswithmembers class * {
-    @androidx.annotation.Keep <fields>;
-}
-
--keepclasseswithmembers class * {
-    @androidx.annotation.Keep <init>(...);
-}
-
 # These classes are duplicated between android.jar and core-lambda-stubs.jar.
 -dontnote java.lang.invoke.**
 
@@ -84,7 +67,6 @@
 -keep,allowobfuscation,allowshrinking class kotlin.collections.List
 -keep,allowobfuscation,allowshrinking class kotlin.collections.Map
 -keep,allowobfuscation,allowshrinking class retrofit2.Call
--keep,allowobfuscation,allowshrinking class at.connyduck.calladapter.networkresult.NetworkResult
 
 # https://github.com/square/retrofit/pull/3563
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
@@ -104,6 +86,9 @@
     public static *** w(...);
     public static *** v(...);
     public static *** i(...);
+}
+-assumenosideeffects class java.lang.String {
+    public static java.lang.String format(...);
 }
 
 # remove some kotlin overhead


### PR DESCRIPTION
Using saner defaults for R8 while reducing the app size even further.
- Add Kotlin compiler options to skip adding assertions in release builds
- Remove `optimizations`, `optimizationpasses` and `dontpreverify` rules that are ignored by R8
- Only keep runtime annotations by default. If other attributes are needed by a specific library, these will already be provided by the library rules (for example Retrofit or coroutines)
- Remove the obsolete rule allowing a View to reflectively call any arbitrary public Activity method accepting a View as argument. This has always been a bad practice and is not used in this project anyway
- Remove the rules related to enums. R8 already optimizes enums properly out-of-the-box and keeping these rules may prevent some of these optimizations
- Add support for the `@Keep` annotation. Even if it's not currently used in the code base, it can be handy in the future
- Add a missing rule to prevent generic signature of `NetworkResult` class from being removed in `MastodonApi` so Retrofit works
- Allow obfuscation and shrinking of `kotlin.coroutines.Continuation`, matching the rule defined in the next release of Retrofit
- Remove the rule forcing the removal of `String.format()`. This method is actually used in the code (and in third-party libraries) for other things than logging so forcing its removal can do more harm than good.