### PR TITLE
change SendStatusService type to shortService

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
     <uses-permission android:name="android.permission.VIBRATE" /> <!-- For notifications -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING" />
 
     <application
         android:name=".TuskyApplication"
@@ -197,7 +196,7 @@
         </service>
 
         <service android:name=".service.SendStatusService"
-            android:foregroundServiceType="remoteMessaging"
+            android:foregroundServiceType="shortService"
             android:exported="false" />
 
         <provider

--- a/app/src/main/java/com/keylesspalace/tusky/service/SendStatusService.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/service/SendStatusService.kt
@@ -141,13 +141,21 @@ class SendStatusService : Service(), Injectable {
 
             statusesToSend[sendingNotificationId] = statusToSend
             sendStatus(sendingNotificationId--)
-        } else {
-            if (intent.hasExtra(KEY_CANCEL)) {
-                cancelSending(intent.getIntExtra(KEY_CANCEL, 0))
-            }
+        } else if (intent.hasExtra(KEY_CANCEL)) {
+            cancelSending(intent.getIntExtra(KEY_CANCEL, 0))
         }
 
         return START_NOT_STICKY
+    }
+
+    override fun onTimeout(startId: Int) {
+        // https://developer.android.com/about/versions/14/changes/fgs-types-required#short-service
+        // max time for short service reached on Android 14+, stop sending
+        statusesToSend.forEach { (statusId, _) ->
+            serviceScope.launch {
+                failSending(statusId)
+            }
+        }
     }
 
     private fun sendStatus(statusId: Int) {


### PR DESCRIPTION
This way the `FOREGROUND_SERVICE_REMOTE_MESSAGING` permission is not needed and we should be able to publish on Google Play again. Drawback: The service can get killed after a while (usually 3 mins) on Android 14.
I also tried using [user initiated data transfer jobs](https://developer.android.com/about/versions/14/changes/user-initiated-data-transfers), but that is not available on all api levels, and `WorkManager`, but that is a huge refactoring and sending would probably work differently than before.