### PR TITLE
put r8 rules for enums back in to fix crash in AccountListActivity

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -10,6 +10,12 @@
     native <methods>;
 }
 
+# For enumeration classes, see http://proguard.sourceforge.net/manual/examples.html#enumerations
+-keepclassmembers,allowoptimization enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
 -keepclassmembers class * implements android.os.Parcelable {
     public static final ** CREATOR;
 }


### PR DESCRIPTION
Regression from #4291 // cc @cbeyls 

<details>
  <summary>Stacktrace</summary>
  
  ```
Process: com.keylesspalace.tusky, PID: 31230
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.keylesspalace.tusky/com.keylesspalace.tusky.components.accountlist.AccountListActivity}: java.lang.RuntimeException: java.lang.NoSuchMethodException: h4.a.values []
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3635)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3792)
	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103)
	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2210)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.app.ActivityThread.main(ActivityThread.java:7839)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
Caused by: java.lang.RuntimeException: java.lang.NoSuchMethodException: h4.a.values []
	at java.lang.Enum.enumValues(Enum.java:270)
	at java.lang.Enum.access$000(Enum.java:61)
	at java.lang.Enum$1.create(Enum.java:277)
	at java.lang.Enum$1.create(Enum.java:275)
	at libcore.util.BasicLruCache.get(BasicLruCache.java:63)
	at java.lang.Enum.getSharedConstants(Enum.java:289)
	at java.lang.Enum.valueOf(Enum.java:243)
	at java.io.ObjectInputStream.readEnum(ObjectInputStream.java:1841)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1409)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:427)
	at android.os.Parcel.readSerializable(Parcel.java:3507)
	at android.os.Parcel.readValue(Parcel.java:3277)
	at android.os.Parcel.readArrayMapInternal(Parcel.java:3623)
	at android.os.BaseBundle.initializeFromParcelLocked(BaseBundle.java:292)
	at android.os.BaseBundle.unparcel(BaseBundle.java:236)
	at android.os.BaseBundle.getSerializable(BaseBundle.java:1268)
	at android.os.Bundle.getSerializable(Bundle.java:1104)
	at android.content.Intent.getSerializableExtra(Intent.java:8575)
	at com.keylesspalace.tusky.components.accountlist.AccountListActivity.onCreate(SourceFile:23)
	at android.app.Activity.performCreate(Activity.java:8051)
	at android.app.Activity.performCreate(Activity.java:8031)
	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1329)
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3608)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3792) 
	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103) 
	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135) 
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95) 
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2210) 
	at android.os.Handler.dispatchMessage(Handler.java:106) 
	at android.os.Looper.loopOnce(Looper.java:201) 
	at android.os.Looper.loop(Looper.java:288) 
	at android.app.ActivityThread.main(ActivityThread.java:7839) 
	at java.lang.reflect.Method.invoke(Native Method) 
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548) 
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003) 
Caused by: java.lang.NoSuchMethodException: h4.a.values []
	at java.lang.Class.getMethod(Class.java:2103)
	at java.lang.Class.getDeclaredMethod(Class.java:2081)
	at java.lang.Enum.enumValues(Enum.java:267)
	at java.lang.Enum.access$000(Enum.java:61) 
	at java.lang.Enum$1.create(Enum.java:277) 
	at java.lang.Enum$1.create(Enum.java:275) 
	at libcore.util.BasicLruCache.get(BasicLruCache.java:63) 
	at java.lang.Enum.getSharedConstants(Enum.java:289) 
	at java.lang.Enum.valueOf(Enum.java:243) 
	at java.io.ObjectInputStream.readEnum(ObjectInputStream.java:1841) 
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1409) 
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:427) 
	at android.os.Parcel.readSerializable(Parcel.java:3507) 
	at android.os.Parcel.readValue(Parcel.java:3277) 
	at android.os.Parcel.readArrayMapInternal(Parcel.java:3623) 
	at android.os.BaseBundle.initializeFromParcelLocked(BaseBundle.java:292) 
	at android.os.BaseBundle.unparcel(BaseBundle.java:236) 
	at android.os.BaseBundle.getSerializable(BaseBundle.java:1268) 
	at android.os.Bundle.getSerializable(Bundle.java:1104) 
	at android.content.Intent.getSerializableExtra(Intent.java:8575) 
	at com.keylesspalace.tusky.components.accountlist.AccountListActivity.onCreate(SourceFile:23) 
	at android.app.Activity.performCreate(Activity.java:8051) 
	at android.app.Activity.performCreate(Activity.java:8031) 
	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1329) 
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3608) 
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3792) 
	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103) 
	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135) 
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95) 
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2210) 
	at android.os.Handler.dispatchMessage(Handler.java:106) 
	at android.os.Looper.loopOnce(Looper.java:201) 
	at android.os.Looper.loop(Looper.java:288) 
	at android.app.ActivityThread.main(ActivityThread.java:7839) 
	at java.lang.reflect.Method.invoke(Native Method) 
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548) 
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003) 
  ```
</details>

closes #4297 