### PR TITLE
fix warnings in test runs

### DIFF
--- a/app/src/test/java/com/keylesspalace/tusky/MainActivityTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/MainActivityTest.kt
@@ -18,6 +18,7 @@ import com.keylesspalace.tusky.entity.Notification
 import com.keylesspalace.tusky.entity.TimelineAccount
 import java.util.Date
 import kotlinx.coroutines.test.TestScope
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -58,6 +59,11 @@ class MainActivityTest {
     @Before
     fun setup() {
         WorkManagerTestInitHelper.initializeTestWorkManager(context)
+    }
+
+    @After
+    fun teardown() {
+        WorkManagerTestInitHelper.closeWorkDatabase()
     }
 
     @Test

--- a/app/src/test/java/com/keylesspalace/tusky/components/compose/ComposeActivityTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/compose/ComposeActivityTest.kt
@@ -35,6 +35,7 @@ import com.keylesspalace.tusky.di.ViewModelFactory
 import com.keylesspalace.tusky.entity.Instance
 import com.keylesspalace.tusky.entity.InstanceConfiguration
 import com.keylesspalace.tusky.entity.InstanceV1
+import com.keylesspalace.tusky.entity.SearchResult
 import com.keylesspalace.tusky.entity.StatusConfiguration
 import com.keylesspalace.tusky.network.MastodonApi
 import java.util.Locale
@@ -49,6 +50,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -123,6 +125,9 @@ class ComposeActivityTest {
                     NetworkResult.success(instance)
                 }
             }
+            onBlocking { search(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doReturn NetworkResult.success(
+                SearchResult(emptyList(), emptyList(), emptyList())
+            )
         }
 
         val instanceDaoMock: InstanceDao = mock {

--- a/app/src/test/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModelTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModelTest.kt
@@ -77,7 +77,9 @@ class ViewThreadViewModelTest {
     fun setup() {
         shadowOf(getMainLooper()).idle()
 
-        api = mock()
+        api = mock {
+            onBlocking { getFilters() } doReturn NetworkResult.success(emptyList())
+        }
         eventHub = EventHub()
         val filterModel = FilterModel()
         val timelineCases = TimelineCases(api, eventHub)


### PR DESCRIPTION
Found while working on #4026 but not directly related.

Two cases of unmocked methods and one of unclosed resource.