### PR TITLE
fix swipe-refresh spinner showing forever when refreshing AccountActivity

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountViewModel.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
@@ -46,7 +47,7 @@ class AccountViewModel @Inject constructor(
     val noteSaved: StateFlow<Boolean> = _noteSaved.asStateFlow()
 
     private val _isRefreshing = MutableSharedFlow<Boolean>(1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
-    val isRefreshing: SharedFlow<Boolean> = _isRefreshing
+    val isRefreshing: SharedFlow<Boolean> = _isRefreshing.asSharedFlow()
 
     private var isDataLoading = false
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountViewModel.kt
@@ -21,8 +21,11 @@ import com.keylesspalace.tusky.util.Success
 import com.keylesspalace.tusky.util.getDomain
 import javax.inject.Inject
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -42,8 +45,8 @@ class AccountViewModel @Inject constructor(
     private val _noteSaved = MutableStateFlow(false)
     val noteSaved: StateFlow<Boolean> = _noteSaved.asStateFlow()
 
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+    private val _isRefreshing = MutableSharedFlow<Boolean>(1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    val isRefreshing: SharedFlow<Boolean> = _isRefreshing
 
     private var isDataLoading = false
 
@@ -84,13 +87,13 @@ class AccountViewModel @Inject constructor(
 
                             _accountData.value = Success(account)
                             isDataLoading = false
-                            _isRefreshing.value = false
+                            _isRefreshing.emit(false)
                         },
                         { t ->
                             Log.w(TAG, "failed obtaining account", t)
                             _accountData.value = Error(cause = t)
                             isDataLoading = false
-                            _isRefreshing.value = false
+                            _isRefreshing.emit(false)
                         }
                     )
             }


### PR DESCRIPTION
The flow must emit every update even if the values are the same, so use SharedFlow instead of StateFlow.

Regression from https://github.com/tuskyapp/Tusky/pull/4337 cc @Goooler 