### PR TITLE
put back sync network methods / avoid runBlocking

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -53,7 +53,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
 class ComposeViewModel @Inject constructor(
@@ -431,28 +430,24 @@ class ComposeViewModel @Inject constructor(
 
     fun searchAutocompleteSuggestions(token: String): List<AutocompleteResult> {
         return when (token[0]) {
-            '@' -> runBlocking {
-                api.searchAccounts(query = token.substring(1), limit = 10)
-                    .fold({ accounts ->
-                        accounts.map { AutocompleteResult.AccountResult(it) }
-                    }, { e ->
-                        Log.e(TAG, "Autocomplete search for $token failed.", e)
-                        emptyList()
-                    })
-            }
-            '#' -> runBlocking {
-                api.search(
-                    query = token,
-                    type = SearchType.Hashtag.apiParameter,
-                    limit = 10
-                )
-                    .fold({ searchResult ->
-                        searchResult.hashtags.map { AutocompleteResult.HashtagResult(it.name) }
-                    }, { e ->
-                        Log.e(TAG, "Autocomplete search for $token failed.", e)
-                        emptyList()
-                    })
-            }
+            '@' -> api.searchAccountsSync(query = token.substring(1), limit = 10)
+                .fold({ accounts ->
+                    accounts.map { AutocompleteResult.AccountResult(it) }
+                }, { e ->
+                    Log.e(TAG, "Autocomplete search for $token failed.", e)
+                    emptyList()
+                })
+            '#' -> api.searchSync(
+                query = token,
+                type = SearchType.Hashtag.apiParameter,
+                limit = 10
+            )
+                .fold({ searchResult ->
+                    searchResult.hashtags.map { AutocompleteResult.HashtagResult(it.name) }
+                }, { e ->
+                    Log.e(TAG, "Autocomplete search for $token failed.", e)
+                    emptyList()
+                })
             ':' -> {
                 val emojiList = emoji.replayCache.firstOrNull() ?: return emptyList()
                 val incomplete = token.substring(1)

--- a/app/src/main/java/com/keylesspalace/tusky/components/followedtags/FollowedTagsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/followedtags/FollowedTagsViewModel.kt
@@ -14,7 +14,6 @@ import com.keylesspalace.tusky.di.Injectable
 import com.keylesspalace.tusky.entity.HashTag
 import com.keylesspalace.tusky.network.MastodonApi
 import javax.inject.Inject
-import kotlinx.coroutines.runBlocking
 
 class FollowedTagsViewModel @Inject constructor(
     private val api: MastodonApi
@@ -39,19 +38,17 @@ class FollowedTagsViewModel @Inject constructor(
     fun searchAutocompleteSuggestions(
         token: String
     ): List<ComposeAutoCompleteAdapter.AutocompleteResult> {
-        return runBlocking {
-            api.search(query = token, type = SearchType.Hashtag.apiParameter, limit = 10)
-                .fold({ searchResult ->
-                    searchResult.hashtags.map {
-                        ComposeAutoCompleteAdapter.AutocompleteResult.HashtagResult(
-                            it.name
-                        )
-                    }
-                }, { e ->
-                    Log.e(TAG, "Autocomplete search for $token failed.", e)
-                    emptyList()
-                })
-        }
+        return api.searchSync(query = token, type = SearchType.Hashtag.apiParameter, limit = 10)
+            .fold({ searchResult ->
+                searchResult.hashtags.map {
+                    ComposeAutoCompleteAdapter.AutocompleteResult.HashtagResult(
+                        it.name
+                    )
+                }
+            }, { e ->
+                Log.e(TAG, "Autocomplete search for $token failed.", e)
+                emptyList()
+            })
     }
 
     companion object {

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -314,6 +314,12 @@ interface MastodonApi {
         @Query("following") following: Boolean? = null
     ): NetworkResult<List<TimelineAccount>>
 
+    @GET("api/v1/accounts/search")
+    fun searchAccountsSync(
+        @Query("q") query: String,
+        @Query("limit") limit: Int? = null
+    ): NetworkResult<List<TimelineAccount>>
+
     @GET("api/v1/accounts/{id}")
     suspend fun account(@Path("id") accountId: String): NetworkResult<Account>
 
@@ -635,6 +641,16 @@ interface MastodonApi {
 
     @GET("api/v2/search")
     suspend fun search(
+        @Query("q") query: String?,
+        @Query("type") type: String? = null,
+        @Query("resolve") resolve: Boolean? = null,
+        @Query("limit") limit: Int? = null,
+        @Query("offset") offset: Int? = null,
+        @Query("following") following: Boolean? = null
+    ): NetworkResult<SearchResult>
+
+    @GET("api/v2/search")
+    fun searchSync(
         @Query("q") query: String?,
         @Query("type") type: String? = null,
         @Query("resolve") resolve: Boolean? = null,


### PR DESCRIPTION
On non-suspending methods the `NetworkResult` adapter is more efficient as it can go for `retrofit2.Call.execute` immediately and skip all the async business. And `runBlocking` in app code is generally considered a code smell. Sorry I missed that in the review of #4290 @cbeyls 