### PR TITLE
enableDecoderFallback for ExoPlayer

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/di/PlayerModule.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/di/PlayerModule.kt
@@ -70,6 +70,8 @@ object PlayerModule {
                     context,
                     MediaCodecSelector.DEFAULT,
                     DefaultRenderersFactory.DEFAULT_ALLOWED_VIDEO_JOINING_TIME_MS,
+                    // enableDecoderFallback = true, helps playing videos even if one decoder fails
+                    true,
                     eventHandler,
                     videoRendererEventListener,
                     DefaultRenderersFactory.MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY
@@ -77,6 +79,8 @@ object PlayerModule {
                 MediaCodecAudioRenderer(
                     context,
                     MediaCodecSelector.DEFAULT,
+                    // enableDecoderFallback = true
+                    true,
                     eventHandler,
                     audioRendererEventListener,
                     audioSink


### PR DESCRIPTION
This helps playing some media even if there is a problem with the primary decoder.
E.g. [this video](https://mastodon.social/@krzyzanowskim/112208964123517040) fails on my Fairphone 4 without this change.


<img src="https://github.com/tuskyapp/Tusky/assets/10157047/215d932c-9ed1-4ee8-8be7-e6ca28ddec23" width="200"/>

<details>
  <summary>Stacktrace</summary>

```
androidx.media3.exoplayer.ExoPlaybackException: MediaCodecVideoRenderer error, index=0, format=Format(1, null, null, video/avc, avc1.640034, -1, null, [1920, 1440, 119.99593, ColorInfo(BT709, Limited range, sRGB, false, 8bit Luma, 8bit Chroma)], [-1, -1]), format_supported=YES
      at androidx.media3.exoplayer.ExoPlayerImplInternal.handleMessage(ExoPlayerImplInternal.java:620)
      at android.os.Handler.dispatchMessage(Handler.java:102)
      at android.os.Looper.loopOnce(Looper.java:201)
      at android.os.Looper.loop(Looper.java:288)
      at android.os.HandlerThread.run(HandlerThread.java:67)
  Caused by: androidx.media3.exoplayer.mediacodec.MediaCodecRenderer$DecoderInitializationException: Decoder init failed: OMX.qcom.video.decoder.avc, Format(1, null, null, video/avc, avc1.640034, -1, null, [1920, 1440, 119.99593, ColorInfo(BT709, Limited range, sRGB, false, 8bit Luma, 8bit Chroma)], [-1, -1])
      at androidx.media3.exoplayer.mediacodec.MediaCodecRenderer.maybeInitCodecWithFallback(MediaCodecRenderer.java:1114)
      at androidx.media3.exoplayer.mediacodec.MediaCodecRenderer.maybeInitCodecOrBypass(MediaCodecRenderer.java:551)
      at androidx.media3.exoplayer.mediacodec.MediaCodecRenderer.onInputFormatChanged(MediaCodecRenderer.java:1560)
      at androidx.media3.exoplayer.video.MediaCodecVideoRenderer.onInputFormatChanged(MediaCodecVideoRenderer.java:1152)
      at androidx.media3.exoplayer.mediacodec.MediaCodecRenderer.readSourceOmittingSampleData(MediaCodecRenderer.java:994)
      at androidx.media3.exoplayer.mediacodec.MediaCodecRenderer.render(MediaCodecRenderer.java:814)
      at androidx.media3.exoplayer.video.MediaCodecVideoRenderer.render(MediaCodecVideoRenderer.java:940)
      at androidx.media3.exoplayer.ExoPlayerImplInternal.doSomeWork(ExoPlayerImplInternal.java:1102)
      at androidx.media3.exoplayer.ExoPlayerImplInternal.handleMessage(ExoPlayerImplInternal.java:541)
      at android.os.Handler.dispatchMessage(Handler.java:102) 
      at android.os.Looper.loopOnce(Looper.java:201) 
      at android.os.Looper.loop(Looper.java:288) 
      at android.os.HandlerThread.run(HandlerThread.java:67) 
  Caused by: android.media.MediaCodec$CodecException: Error 0xfffffff4
      at android.media.MediaCodec.native_configure(Native Method)
      at android.media.MediaCodec.configure(MediaCodec.java:2215)
      at android.media.MediaCodec.configure(MediaCodec.java:2131)
      at androidx.media3.exoplayer.mediacodec.AsynchronousMediaCodecAdapter.initialize(AsynchronousMediaCodecAdapter.java:174)
      at androidx.media3.exoplayer.mediacodec.AsynchronousMediaCodecAdapter.access$100(AsynchronousMediaCodecAdapter.java:54)
      at androidx.media3.exoplayer.mediacodec.AsynchronousMediaCodecAdapter$Factory.createAdapter(AsynchronousMediaCodecAdapter.java:119)
      at androidx.media3.exoplayer.mediacodec.DefaultMediaCodecAdapterFactory.createAdapter(DefaultMediaCodecAdapterFactory.java:117)
      at androidx.media3.exoplayer.mediacodec.MediaCodecRenderer.initCodec(MediaCodecRenderer.java:1195)
      at androidx.media3.exoplayer.mediacodec.MediaCodecRenderer.maybeInitCodecWithFallback(MediaCodecRenderer.java:1103)
      at androidx.media3.exoplayer.mediacodec.MediaCodecRenderer.maybeInitCodecOrBypass(MediaCodecRenderer.java:551) 
      at androidx.media3.exoplayer.mediacodec.MediaCodecRenderer.onInputFormatChanged(MediaCodecRenderer.java:1560) 
      at androidx.media3.exoplayer.video.MediaCodecVideoRenderer.onInputFormatChanged(MediaCodecVideoRenderer.java:1152) 
      at androidx.media3.exoplayer.mediacodec.MediaCodecRenderer.readSourceOmittingSampleData(MediaCodecRenderer.java:994) 
      at androidx.media3.exoplayer.mediacodec.MediaCodecRenderer.render(MediaCodecRenderer.java:814) 
      at androidx.media3.exoplayer.video.MediaCodecVideoRenderer.render(MediaCodecVideoRenderer.java:940) 
      at androidx.media3.exoplayer.ExoPlayerImplInternal.doSomeWork(ExoPlayerImplInternal.java:1102) 
      at androidx.media3.exoplayer.ExoPlayerImplInternal.handleMessage(ExoPlayerImplInternal.java:541) 
      at android.os.Handler.dispatchMessage(Handler.java:102) 
      at android.os.Looper.loopOnce(Looper.java:201) 
      at android.os.Looper.loop(Looper.java:288) 
      at android.os.HandlerThread.run(HandlerThread.java:67) 
```

</details>