### PR TITLE
Apply window insets to SwipeRefreshLayout in AccountActivity to not obscure spinner

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
@@ -318,6 +318,10 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvide
                 bottom = bottom,
                 left = left
             )
+            binding.swipeToRefreshLayout.setProgressViewEndTarget(
+                false,
+                top + resources.getDimensionPixelSize(R.dimen.account_swiperefresh_distance)
+            )
 
             WindowInsetsCompat.CONSUMED
         }

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -73,4 +73,6 @@
     <dimen name="profile_badge_icon_start_padding">8dp</dimen>
     <dimen name="profile_badge_icon_end_padding">0dp</dimen>
 
+    <dimen name="account_swiperefresh_distance">64dp</dimen>
+
 </resources>


### PR DESCRIPTION
before & after

<img src="https://github.com/tuskyapp/Tusky/assets/10157047/b029f5ff-9b17-48be-b306-a2e7e03ef6f7" width="240"/>
<img src="https://github.com/tuskyapp/Tusky/assets/10157047/ea9d3aa8-1f76-4709-9677-f478e2e0064a" width="240"/>
