### PR TITLE
Refactor permissions requests to use ActivityResultContract

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
@@ -19,7 +19,6 @@ import android.app.ActivityManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -34,8 +33,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
 import androidx.preference.PreferenceManager;
 
 import com.google.android.material.color.MaterialColors;
@@ -46,14 +43,11 @@ import com.keylesspalace.tusky.db.AccountEntity;
 import com.keylesspalace.tusky.db.AccountManager;
 import com.keylesspalace.tusky.di.Injectable;
 import com.keylesspalace.tusky.interfaces.AccountSelectionListener;
-import com.keylesspalace.tusky.interfaces.PermissionRequester;
 import com.keylesspalace.tusky.settings.AppTheme;
 import com.keylesspalace.tusky.settings.PrefKeys;
 import com.keylesspalace.tusky.util.ActivityExtensions;
 import com.keylesspalace.tusky.util.ThemeUtils;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -70,9 +64,6 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
     @Inject
     @NonNull
     public AccountManager accountManager;
-
-    private static final int REQUESTER_NONE = Integer.MAX_VALUE;
-    private HashMap<Integer, PermissionRequester> requesters;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -107,8 +98,6 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
         if(requiresLogin()) {
             redirectIfNotLoggedIn();
         }
-
-        requesters = new HashMap<>();
     }
 
     private boolean activityTransitionWasRequested() {
@@ -272,37 +261,5 @@ public abstract class BaseActivity extends AppCompatActivity implements Injectab
 
         startActivity(intent);
         finish();
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (requesters.containsKey(requestCode)) {
-            PermissionRequester requester = requesters.remove(requestCode);
-            requester.onRequestPermissionsResult(permissions, grantResults);
-        }
-    }
-
-    public void requestPermissions(@NonNull String[] permissions, @NonNull PermissionRequester requester) {
-        ArrayList<String> permissionsToRequest = new ArrayList<>();
-        for(String permission: permissions) {
-            if (ContextCompat.checkSelfPermission(this, permission) != PackageManager.PERMISSION_GRANTED) {
-                permissionsToRequest.add(permission);
-            }
-        }
-        if (permissionsToRequest.isEmpty()) {
-            int[] permissionsAlreadyGranted = new int[permissions.length];
-            requester.onRequestPermissionsResult(permissions, permissionsAlreadyGranted);
-            return;
-        }
-
-        int newKey = requester == null ? REQUESTER_NONE : requesters.size();
-        if (newKey != REQUESTER_NONE) {
-            requesters.put(newKey, requester);
-        }
-        String[] permissionsCopy = new String[permissionsToRequest.size()];
-        permissionsToRequest.toArray(permissionsCopy);
-        ActivityCompat.requestPermissions(this, permissionsCopy, newKey);
-
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchStatusesFragment.kt
@@ -21,16 +21,18 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
+import android.os.Bundle
 import android.os.Environment
 import android.util.Log
 import android.view.View
 import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.PopupMenu
 import androidx.core.app.ActivityOptionsCompat
+import androidx.core.content.getSystemService
 import androidx.core.view.ViewCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.paging.PagingData
@@ -41,7 +43,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import at.connyduck.calladapter.networkresult.fold
 import at.connyduck.calladapter.networkresult.onFailure
 import com.google.android.material.snackbar.Snackbar
-import com.keylesspalace.tusky.BaseActivity
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.ViewMediaActivity
 import com.keylesspalace.tusky.components.compose.ComposeActivity
@@ -78,6 +79,34 @@ class SearchStatusesFragment : SearchFragment<StatusViewData.Concrete>(), Status
 
     private val searchAdapter
         get() = super.adapter as SearchStatusesAdapter
+
+    private var pendingMediaDownloads: List<String>? = null
+
+    private val downloadAllMediaPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
+                pendingMediaDownloads?.let { downloadAllMedia(it) }
+            } else {
+                Toast.makeText(
+                    context,
+                    R.string.error_media_download_permission,
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+            pendingMediaDownloads = null
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        pendingMediaDownloads = savedInstanceState?.getStringArrayList(PENDING_MEDIA_DOWNLOADS_STATE_KEY)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        pendingMediaDownloads?.let {
+            outState.putStringArrayList(PENDING_MEDIA_DOWNLOADS_STATE_KEY, ArrayList(it))
+        }
+    }
 
     override fun createAdapter(): PagingDataAdapter<StatusViewData.Concrete, *> {
         val preferences = PreferenceManager.getDefaultSharedPreferences(
@@ -234,10 +263,6 @@ class SearchStatusesFragment : SearchFragment<StatusViewData.Concrete>(), Status
         searchAdapter.peek(position)?.let {
             viewModel.untranslate(it)
         }
-    }
-
-    companion object {
-        fun newInstance() = SearchStatusesFragment()
     }
 
     private fun reply(status: StatusViewData.Concrete) {
@@ -499,37 +524,31 @@ class SearchStatusesFragment : SearchFragment<StatusViewData.Concrete>(), Status
         )
     }
 
-    private fun downloadAllMedia(status: Status) {
+    private fun downloadAllMedia(mediaUrls: List<String>) {
         Toast.makeText(context, R.string.downloading_media, Toast.LENGTH_SHORT).show()
-        for ((_, url) in status.attachments) {
-            val uri = Uri.parse(url)
-            val filename = uri.lastPathSegment
+        val downloadManager: DownloadManager = requireContext().getSystemService()!!
 
-            val downloadManager = requireActivity().getSystemService(
-                Context.DOWNLOAD_SERVICE
-            ) as DownloadManager
+        for (url in mediaUrls) {
+            val uri = Uri.parse(url)
             val request = DownloadManager.Request(uri)
-            request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, filename)
+            request.setDestinationInExternalPublicDir(
+                Environment.DIRECTORY_DOWNLOADS,
+                uri.lastPathSegment
+            )
             downloadManager.enqueue(request)
         }
     }
 
     private fun requestDownloadAllMedia(status: Status) {
+        if (status.attachments.isEmpty()) {
+            return
+        }
+        val mediaUrls = status.attachments.map { it.url }
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-            val permissions = arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-            (activity as BaseActivity).requestPermissions(permissions) { _, grantResults ->
-                if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    downloadAllMedia(status)
-                } else {
-                    Toast.makeText(
-                        context,
-                        R.string.error_media_download_permission,
-                        Toast.LENGTH_SHORT
-                    ).show()
-                }
-            }
+            pendingMediaDownloads = mediaUrls
+            downloadAllMediaPermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
         } else {
-            downloadAllMedia(status)
+            downloadAllMedia(mediaUrls)
         }
     }
 
@@ -627,5 +646,11 @@ class SearchStatusesFragment : SearchFragment<StatusViewData.Concrete>(), Status
                 }
             )
         }
+    }
+
+    companion object {
+        private const val PENDING_MEDIA_DOWNLOADS_STATE_KEY = "pending_media_downloads"
+
+        fun newInstance() = SearchStatusesFragment()
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/interfaces/PermissionRequester.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/interfaces/PermissionRequester.kt
@@ -1,5 +1,0 @@
-package com.keylesspalace.tusky.interfaces
-
-fun interface PermissionRequester {
-    fun onRequestPermissionsResult(permissions: Array<String>, grantResults: IntArray)
-}


### PR DESCRIPTION
The app currently uses a custom callback system for requesting permissions, located in `BaseActivity`.
This code doesn't work when the activity gets re-created before the permission is granted: the callback will be lost with the Activity and no action will be performed after the permission is granted.

To avoid these issues while still simplifying the code, Google recommends to use the ActivityResultContract APIs to request permissions, which allow to register persistent callbacks. This pull request removes the legacy API and replaces the calls with `registerForActivityResult(ActivityResultContracts.RequestPermission())`.

- `ActivityResultContracts.RequestPermission` will check if the permission is already granted and call the callback synchronously when possible. So this check doesn't need to be performed anymore.
- In `SearchStatusesFragment` and `SFragment`, the download action to launch after granting the permission requires an argument (a list of media URLs). This argument is temporarily stored in a Fragment field and saved and restored as part of the instance state, so the action can properly resume after an Activity re-creation.