### PR TITLE
fix deserializing Akkoma cards

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/entity/Card.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Card.kt
@@ -22,12 +22,12 @@ import com.squareup.moshi.JsonClass
 data class Card(
     val url: String,
     val title: String,
-    val description: String,
-    @Json(name = "author_name") val authorName: String,
+    val description: String = "",
+    @Json(name = "author_name") val authorName: String = "",
     val image: String? = null,
     val type: String,
-    val width: Int,
-    val height: Int,
+    val width: Int = 0,
+    val height: Int = 0,
     val blurhash: String? = null,
     @Json(name = "embed_url") val embedUrl: String? = null
 ) {


### PR DESCRIPTION
Akkoma does not always set all attributes for Cards and when they are loaded from the database, the app crashes. When they are loaded from the network, Tusky displays an error. Adding more default values fixes the problem.

```
com.squareup.moshi.JsonDataException: Required value 'authorName' (JSON name 'author_name') missing at $
    at com.squareup.moshi.internal.Util.missingProperty(Util.java:660)
    at com.keylesspalace.tusky.entity.CardJsonAdapter.fromJson(CardJsonAdapter.kt:122)
    at com.keylesspalace.tusky.entity.CardJsonAdapter.fromJson(CardJsonAdapter.kt:22)
    at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
    at com.squareup.moshi.JsonAdapter.fromJson(JsonAdapter.java:70)
    at com.keylesspalace.tusky.components.timeline.TimelineTypeMappersKt.toViewData(TimelineTypeMappers.kt:168)
    at com.keylesspalace.tusky.components.timeline.viewmodel.CachedTimelineViewModel$statuses$2$1.invoke(CachedTimelineViewModel.kt:110)
    at com.keylesspalace.tusky.components.timeline.viewmodel.CachedTimelineViewModel$statuses$2$1.invoke(CachedTimelineViewModel.kt:108)
    at androidx.paging.PagingDataTransforms$map$2$1$1.invokeSuspend(PagingDataTransforms.kt:58)
    at androidx.paging.PagingDataTransforms$map$2$1$1.invoke(Unknown Source:8)
    at androidx.paging.PagingDataTransforms$map$2$1$1.invoke(Unknown Source:2)
    at androidx.paging.PageEvent$Insert.map(PageEvent.kt:128)
    at androidx.paging.PagingDataTransforms$map$2$1.invokeSuspend(PagingDataTransforms.kt:58)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:585)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:802)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:706)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:693)
    Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@de2cbd5, Dispatchers.Main.immediate]
```

closes #4393 