### PR TITLE
fix crash when quickly unfollowing hashtags

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/followedtags/FollowedTagsActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/followedtags/FollowedTagsActivity.kt
@@ -149,7 +149,7 @@ class FollowedTagsActivity :
         lifecycleScope.launch {
             api.unfollowTag(tagName).fold(
                 {
-                    viewModel.tags.removeAt(position)
+                    viewModel.tags.removeIf { tag -> tag.name == tagName }
                     Snackbar.make(
                         this@FollowedTagsActivity,
                         binding.followedTagsView,


### PR DESCRIPTION
Steps to reproduce: Quickly unfollow a bunch of hashtags, try clicking unfollow buttons multiple times. If you are faster than the network, the app crashes.

```
java.lang.ArrayIndexOutOfBoundsException: length=20; index=-1
       at java.util.ArrayList.remove(ArrayList.java:506)
       at com.keylesspalace.tusky.components.followedtags.FollowedTagsActivity$unfollow$1.invokeSuspend(FollowedTagsActivity.kt:152)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
       at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
       at android.os.Handler.handleCallback(Handler.java:942)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:201)
       at android.os.Looper.loop(Looper.java:288)
       at android.app.ActivityThread.main(ActivityThread.java:7872)
       at java.lang.reflect.Method.invoke(Native Method)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```