### PR TITLE
[v25.1] fix crash when exceeding max shortcut number

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/ShareShortcutHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ShareShortcutHelper.kt
@@ -89,12 +89,11 @@ class ShareShortcutHelper @Inject constructor(
                     .setCategories(setOf("com.keylesspalace.tusky.Share"))
                     .setShortLabel(account.displayName)
                     .setPerson(person)
-                    .setLongLived(true)
                     .setIcon(icon)
                     .build()
             }
 
-            ShortcutManagerCompat.addDynamicShortcuts(context, shortcuts)
+            ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)
         }
     }
 


### PR DESCRIPTION
I made a mistake in https://github.com/tuskyapp/Tusky/pull/4389 🙄 

With `addDynamicShortcuts` the limit can still be exceeded, `setDynamicShortcuts` is what we want.

Also, `setLongLived` says:

> Sets if a shortcut would be valid even if it has been unpublished/invisible by the app (as a dynamic or pinned shortcut). If it is long lived, it can be cached by various system services even after it has been unpublished as a dynamic shortcut.

I don't think we want that so I removed it.