### PR TITLE
don't load custom emojis in their full size

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/FollowRequestViewHolder.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/FollowRequestViewHolder.kt
@@ -16,7 +16,7 @@
 package com.keylesspalace.tusky.adapter
 
 import android.graphics.Typeface
-import android.text.SpannableStringBuilder
+import android.text.SpannableString
 import android.text.Spanned
 import android.text.style.StyleSpan
 import androidx.recyclerview.widget.RecyclerView
@@ -67,7 +67,7 @@ class FollowRequestViewHolder(
         val wrappedName = account.name.unicodeWrap()
         val emojifiedName: CharSequence = wrappedName.emojify(
             account.emojis,
-            itemView,
+            binding.displayNameTextView,
             animateEmojis
         )
         binding.displayNameTextView.text = emojifiedName
@@ -76,9 +76,9 @@ class FollowRequestViewHolder(
                 R.string.notification_follow_request_format,
                 wrappedName
             )
-            binding.notificationTextView.text = SpannableStringBuilder(wholeMessage).apply {
+            binding.notificationTextView.text = SpannableString(wholeMessage).apply {
                 setSpan(StyleSpan(Typeface.BOLD), 0, wrappedName.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-            }.emojify(account.emojis, itemView, animateEmojis)
+            }.emojify(account.emojis, binding.notificationTextView, animateEmojis)
         }
         binding.notificationTextView.visible(showHeader)
         val formattedUsername = itemView.context.getString(

--- a/app/src/main/java/com/keylesspalace/tusky/components/announcements/AnnouncementAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/announcements/AnnouncementAdapter.kt
@@ -37,7 +37,6 @@ import com.keylesspalace.tusky.util.emojify
 import com.keylesspalace.tusky.util.parseAsMastodonHtml
 import com.keylesspalace.tusky.util.setClickableText
 import com.keylesspalace.tusky.util.visible
-import java.lang.ref.WeakReference
 
 interface AnnouncementActionListener : LinkListener {
     fun openReactionPicker(announcementId: String, target: View)
@@ -111,7 +110,7 @@ class AnnouncementAdapter(
                         // we set the EmojiSpan on a space, because otherwise the Chip won't have the right size
                         // https://github.com/tuskyapp/Tusky/issues/2308
                         val spanBuilder = SpannableStringBuilder("  ${reaction.count}")
-                        val span = EmojiSpan(WeakReference(this))
+                        val span = EmojiSpan(this)
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                             span.contentDescription = reaction.name
                         }

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/ReportNotificationViewHolder.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/ReportNotificationViewHolder.kt
@@ -41,8 +41,8 @@ class ReportNotificationViewHolder(
         val report = viewData.report!!
         val reporter = viewData.account
 
-        val reporterName = reporter.name.unicodeWrap().emojify(reporter.emojis, itemView, statusDisplayOptions.animateEmojis)
-        val reporteeName = report.targetAccount.name.unicodeWrap().emojify(report.targetAccount.emojis, itemView, statusDisplayOptions.animateEmojis)
+        val reporterName = reporter.name.unicodeWrap().emojify(reporter.emojis, binding.notificationTopText, statusDisplayOptions.animateEmojis)
+        val reporteeName = report.targetAccount.name.unicodeWrap().emojify(report.targetAccount.emojis, binding.notificationTopText, statusDisplayOptions.animateEmojis)
 
         binding.notificationTopText.text = itemView.context.getString(R.string.notification_header_report_format, reporterName, reporteeName)
         binding.notificationSummary.text = itemView.context.getString(R.string.notification_summary_report_format, getRelativeTimeSpanString(itemView.context, report.createdAt.time, System.currentTimeMillis()), report.statusIds?.size ?: 0)

--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -48,7 +48,6 @@ import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.entity.HashTag
 import com.keylesspalace.tusky.entity.Status.Mention
 import com.keylesspalace.tusky.interfaces.LinkListener
-import java.lang.ref.WeakReference
 import java.net.URI
 import java.net.URISyntaxException
 
@@ -128,7 +127,7 @@ fun markupHiddenUrls(view: TextView, content: CharSequence): SpannableStringBuil
 
         val linkDrawable = AppCompatResources.getDrawable(view.context, R.drawable.ic_link)!!
         // ImageSpan does not always align the icon correctly in the line, let's use our custom emoji span for this
-        val linkDrawableSpan = EmojiSpan(WeakReference(view))
+        val linkDrawableSpan = EmojiSpan(view)
         linkDrawableSpan.imageDrawable = linkDrawable
 
         val placeholderIndex = replacementText.indexOf("🔗")

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -75,4 +75,6 @@
 
     <dimen name="account_swiperefresh_distance">64dp</dimen>
 
+    <dimen name="fallback_emoji_size">16sp</dimen>
+
 </resources>


### PR DESCRIPTION
This should save quite some memory, but most importantly it gets rid of this crash:

```
java.lang.RuntimeException: Canvas: trying to draw too large(121969936bytes) bitmap.
           at android.graphics.RecordingCanvas.throwIfCannotDraw(RecordingCanvas.java:266)
           at android.graphics.BaseRecordingCanvas.drawBitmap(BaseRecordingCanvas.java:94)
           at android.graphics.drawable.BitmapDrawable.draw(BitmapDrawable.java:549)
           at com.keylesspalace.tusky.util.EmojiSpan.draw(CustomEmojiHelper.kt:131)
           ...
```