### PR TITLE
fix crash in AccountListFragment

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/accountlist/AccountListFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/accountlist/AccountListFragment.kt
@@ -57,6 +57,7 @@ import com.keylesspalace.tusky.util.startActivityWithSlideInAnimation
 import com.keylesspalace.tusky.util.viewBinding
 import com.keylesspalace.tusky.view.EndlessOnScrollListener
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import retrofit2.Response
 
@@ -330,6 +331,9 @@ class AccountListFragment :
                 val linkHeader = response.headers()["Link"]
                 onFetchAccountsSuccess(accountList, linkHeader)
             } catch (exception: Exception) {
+                if (exception is CancellationException) {
+                    throw  exception
+                }
                 onFetchAccountsFailure(exception)
             }
         }

--- a/app/src/main/java/com/keylesspalace/tusky/components/accountlist/AccountListFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/accountlist/AccountListFragment.kt
@@ -332,6 +332,9 @@ class AccountListFragment :
                 onFetchAccountsSuccess(accountList, linkHeader)
             } catch (exception: Exception) {
                 if (exception is CancellationException) {
+                    // Scope is cancelled, probably because the fragment is destroyed.
+                    // We must not touch any views anymore, so rethrow the exception.
+                    // (CancellationException in a cancelled scope is normal and will be ignored)
                     throw exception
                 }
                 onFetchAccountsFailure(exception)

--- a/app/src/main/java/com/keylesspalace/tusky/components/accountlist/AccountListFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/accountlist/AccountListFragment.kt
@@ -332,7 +332,7 @@ class AccountListFragment :
                 onFetchAccountsSuccess(accountList, linkHeader)
             } catch (exception: Exception) {
                 if (exception is CancellationException) {
-                    throw  exception
+                    throw exception
                 }
                 onFetchAccountsFailure(exception)
             }


### PR DESCRIPTION
Steps to reproduce: When viewing an account list, very quickly rotate the screen multiple times. I found this easier to do with an emulator, just spam the rotation buttons.
```
java.lang.IllegalStateException: Fragment AccountListFragment{50bbc6c} (8a3e6922-e855-45a7-8a49-c9d16e21e438) did not return a View from onCreateView() or this was called before onCreateView().
	at androidx.fragment.app.Fragment.requireView(Fragment.java:2063)
	at com.keylesspalace.tusky.util.ViewLifecycleLazy.getValue(ViewBindingExtensions.kt:32)
	at com.keylesspalace.tusky.components.accountlist.AccountListFragment.getBinding(AccountListFragment.kt:75)
	at com.keylesspalace.tusky.components.accountlist.AccountListFragment.onFetchAccountsFailure(AccountListFragment.kt:390)
	at com.keylesspalace.tusky.components.accountlist.AccountListFragment.access$onFetchAccountsFailure(AccountListFragment.kt:63)
	at com.keylesspalace.tusky.components.accountlist.AccountListFragment$fetchAccounts$2.invokeSuspend(AccountListFragment.kt:333)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:230)
	at android.os.Handler.handleCallback(Handler.java:942)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.app.ActivityThread.main(ActivityThread.java:7872)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@260dcb1, Dispatchers.Main.immediate]
```