### PR TITLE
fix another crash in ShareShortcutHelper

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/ShareShortcutHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ShareShortcutHelper.kt
@@ -59,8 +59,6 @@ class ShareShortcutHelper @Inject constructor(
                     Glide.with(context)
                         .asBitmap()
                         .load(account.profilePictureUrl)
-                        .placeholder(R.drawable.avatar_default)
-                        .error(R.drawable.avatar_default)
                         .submitAsync(innerSize, innerSize)
                 } catch (e: GlideException) {
                     // https://github.com/bumptech/glide/issues/4672 :/


### PR DESCRIPTION
Glide sometimes calls the callback more than once (for the placeholder, then for the actual image), but a coroutine can only resume once.

```
Exception java.lang.IllegalStateException:
  at kotlinx.coroutines.CancellableContinuationImpl.alreadyResumedError (CancellableContinuationImpl.kt:555)
  at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl (CancellableContinuationImpl.kt:520)
  at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl$default (CancellableContinuationImpl.kt:493)
  at kotlinx.coroutines.CancellableContinuationImpl.resumeWith (CancellableContinuationImpl.kt:364)
  at com.keylesspalace.tusky.util.GlideExtensionsKt$submitAsync$2$target$1.onResourceReady (GlideExtensions.kt:39)
  at com.bumptech.glide.request.SingleRequest.onResourceReady (SingleRequest.java:650)
  at com.bumptech.glide.request.SingleRequest.onResourceReady (SingleRequest.java:596)
  at com.bumptech.glide.request.SingleRequest.begin (SingleRequest.java:243)
  at com.bumptech.glide.manager.RequestTracker.resumeRequests (RequestTracker.java:115)
  at com.bumptech.glide.RequestManager.resumeRequests (RequestManager.java:339)
  at com.bumptech.glide.RequestManager.onStart (RequestManager.java:364)
  at com.bumptech.glide.manager.ApplicationLifecycle.addListener (ApplicationLifecycle.java:15)
  at com.bumptech.glide.RequestManager$1.run (RequestManager.java:84)
  at android.os.Handler.handleCallback (Handler.java:958)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:230)
  at android.os.Looper.loop (Looper.java:319)
  at android.app.ActivityThread.main (ActivityThread.java:8893)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:608)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
```

While removing the placeholder fixes the problem here, we should probably put some safeguards into `submitAsync` so that this can't happen again elsewhere. Any ideas how to do that, @cbeyls?