### PR TITLE
fix notification filters behaving weirdly

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/account/media/AccountMediaViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/media/AccountMediaViewModel.kt
@@ -43,7 +43,8 @@ class AccountMediaViewModel @Inject constructor(
     val media = Pager(
         config = PagingConfig(
             pageSize = LOAD_AT_ONCE,
-            prefetchDistance = LOAD_AT_ONCE * 2
+            prefetchDistance = LOAD_AT_ONCE * 2,
+            enablePlaceholders = false
         ),
         pagingSourceFactory = {
             AccountMediaPagingSource(

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsViewModel.kt
@@ -42,7 +42,10 @@ class ConversationsViewModel @Inject constructor(
 
     @OptIn(ExperimentalPagingApi::class)
     val conversationFlow = Pager(
-        config = PagingConfig(pageSize = 30),
+        config = PagingConfig(
+            pageSize = 30,
+            enablePlaceholders = false
+        ),
         remoteMediator = ConversationsRemoteMediator(api, database, accountManager),
         pagingSourceFactory = {
             val activeAccount = accountManager.activeAccount

--- a/app/src/main/java/com/keylesspalace/tusky/components/domainblocks/DomainBlocksRepository.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/domainblocks/DomainBlocksRepository.kt
@@ -39,7 +39,11 @@ class DomainBlocksRepository @Inject constructor(
 
     @OptIn(ExperimentalPagingApi::class)
     val domainPager = Pager(
-        config = PagingConfig(pageSize = PAGE_SIZE, initialLoadSize = PAGE_SIZE),
+        config = PagingConfig(
+            pageSize = PAGE_SIZE,
+            initialLoadSize = PAGE_SIZE,
+            enablePlaceholders = false
+        ),
         remoteMediator = DomainBlocksRemoteMediator(api, this),
         pagingSourceFactory = factory
     ).flow

--- a/app/src/main/java/com/keylesspalace/tusky/components/drafts/DraftsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/drafts/DraftsViewModel.kt
@@ -37,7 +37,10 @@ class DraftsViewModel @Inject constructor(
 ) : ViewModel() {
 
     val drafts = Pager(
-        config = PagingConfig(pageSize = 20),
+        config = PagingConfig(
+            pageSize = 20,
+            enablePlaceholders = false
+        ),
         pagingSourceFactory = {
             database.draftDao().draftsPagingSource(
                 accountManager.activeAccount?.id!!

--- a/app/src/main/java/com/keylesspalace/tusky/components/followedtags/FollowedTagsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/followedtags/FollowedTagsViewModel.kt
@@ -25,7 +25,10 @@ class FollowedTagsViewModel @Inject constructor(
 
     @OptIn(ExperimentalPagingApi::class)
     val pager = Pager(
-        config = PagingConfig(pageSize = 100),
+        config = PagingConfig(
+            pageSize = 100,
+            enablePlaceholders = false
+        ),
         remoteMediator = FollowedTagsRemoteMediator(api, this),
         pagingSourceFactory = {
             FollowedTagsPagingSource(

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
@@ -472,7 +472,7 @@ class NotificationsFragment :
         menuBinding.listView.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE)
 
         Notification.Type.visibleTypes.forEachIndexed { index, type ->
-            menuBinding.listView.setItemChecked(index, !viewModel.filters.value.contains(type))
+            menuBinding.listView.setItemChecked(index, !viewModel.excludes.value.contains(type))
         }
 
         window.setContentView(menuBinding.root)

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsPagingAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsPagingAdapter.kt
@@ -89,8 +89,7 @@ class NotificationsPagingAdapter(
                     else -> VIEW_TYPE_UNKNOWN
                 }
             }
-            is NotificationViewData.Placeholder -> VIEW_TYPE_PLACEHOLDER
-            null -> throw IllegalStateException("no item at position $position")
+            else -> VIEW_TYPE_PLACEHOLDER
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
@@ -76,15 +76,15 @@ class NotificationsViewModel @Inject constructor(
 
     private val refreshTrigger = MutableStateFlow(0L)
 
-    private val _filters = MutableStateFlow(
+    private val _excludes = MutableStateFlow(
         accountManager.activeAccount?.let { account -> deserialize(account.notificationsFilter) } ?: emptySet()
     )
-    val filters: StateFlow<Set<Notification.Type>> = _filters.asStateFlow()
+    val excludes: StateFlow<Set<Notification.Type>> = _excludes.asStateFlow()
 
     /** Map from notification id to translation. */
     private val translations = MutableStateFlow(mapOf<String, TranslationViewData>())
 
-    private var remoteMediator = NotificationsRemoteMediator(accountManager, api, db, filters.value)
+    private var remoteMediator = NotificationsRemoteMediator(accountManager, api, db, excludes.value)
 
     private var readingOrder: ReadingOrder =
         ReadingOrder.from(preferences.getString(PrefKeys.READING_ORDER, null))
@@ -92,7 +92,10 @@ class NotificationsViewModel @Inject constructor(
     @OptIn(ExperimentalPagingApi::class, ExperimentalCoroutinesApi::class)
     val notifications = refreshTrigger.flatMapLatest {
         Pager(
-            config = PagingConfig(pageSize = LOAD_AT_ONCE),
+            config = PagingConfig(
+                pageSize = LOAD_AT_ONCE,
+                enablePlaceholders = false
+            ),
             remoteMediator = remoteMediator,
             pagingSourceFactory = {
                 val activeAccount = accountManager.activeAccount
@@ -126,16 +129,16 @@ class NotificationsViewModel @Inject constructor(
     }
 
     fun updateNotificationFilters(newFilters: Set<Notification.Type>) {
-        if (newFilters != _filters.value) {
+        if (newFilters != _excludes.value) {
             val account = accountManager.activeAccount
             if (account != null) {
                 viewModelScope.launch {
                     account.notificationsFilter = serialize(newFilters)
                     accountManager.saveAccount(account)
                     remoteMediator.excludes = newFilters
-                    // clear the cache to trigger a reload
                     db.notificationsDao().cleanupNotifications(account.id, 0)
-                    _filters.value = newFilters
+                    refreshTrigger.value++
+                    _excludes.value = newFilters
                 }
             }
         }
@@ -295,14 +298,16 @@ class NotificationsViewModel @Inject constructor(
                         ReadingOrder.OLDEST_FIRST -> api.notifications(
                             maxId = idAbovePlaceholder,
                             minId = idBelowPlaceholder,
-                            limit = TimelineViewModel.LOAD_AT_ONCE
+                            limit = TimelineViewModel.LOAD_AT_ONCE,
+                            excludes = excludes.value
                         )
                         // Using sinceId, loads up to LOAD_AT_ONCE statuses immediately before
                         // maxId, and no smaller than minId.
                         ReadingOrder.NEWEST_FIRST -> api.notifications(
                             maxId = idAbovePlaceholder,
                             sinceId = idBelowPlaceholder,
-                            limit = TimelineViewModel.LOAD_AT_ONCE
+                            limit = TimelineViewModel.LOAD_AT_ONCE,
+                            excludes = excludes.value
                         )
                     }
                 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/ReportViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/ReportViewModel.kt
@@ -73,7 +73,11 @@ class ReportViewModel @Inject constructor(
     val statusesFlow = accountIdFlow.flatMapLatest { accountId ->
         Pager(
             initialKey = statusId,
-            config = PagingConfig(pageSize = 20, initialLoadSize = 20),
+            config = PagingConfig(
+                pageSize = 20,
+                initialLoadSize = 20,
+                enablePlaceholders = false
+            ),
             pagingSourceFactory = { StatusesPagingSource(accountId, mastodonApi) }
         ).flow
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledStatusViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledStatusViewModel.kt
@@ -36,7 +36,11 @@ class ScheduledStatusViewModel @Inject constructor(
     private val pagingSourceFactory = ScheduledStatusPagingSourceFactory(mastodonApi)
 
     val data = Pager(
-        config = PagingConfig(pageSize = 20, initialLoadSize = 20),
+        config = PagingConfig(
+            pageSize = 20,
+            initialLoadSize = 20,
+            enablePlaceholders = false
+        ),
         pagingSourceFactory = pagingSourceFactory
     ).flow
         .cachedIn(viewModelScope)

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
@@ -86,19 +86,31 @@ class SearchViewModel @Inject constructor(
         }
 
     val statusesFlow = Pager(
-        config = PagingConfig(pageSize = DEFAULT_LOAD_SIZE, initialLoadSize = DEFAULT_LOAD_SIZE),
+        config = PagingConfig(
+            pageSize = DEFAULT_LOAD_SIZE,
+            initialLoadSize = DEFAULT_LOAD_SIZE,
+            enablePlaceholders = false
+        ),
         pagingSourceFactory = statusesPagingSourceFactory
     ).flow
         .cachedIn(viewModelScope)
 
     val accountsFlow = Pager(
-        config = PagingConfig(pageSize = DEFAULT_LOAD_SIZE, initialLoadSize = DEFAULT_LOAD_SIZE),
+        config = PagingConfig(
+            pageSize = DEFAULT_LOAD_SIZE,
+            initialLoadSize = DEFAULT_LOAD_SIZE,
+            enablePlaceholders = false
+        ),
         pagingSourceFactory = accountsPagingSourceFactory
     ).flow
         .cachedIn(viewModelScope)
 
     val hashtagsFlow = Pager(
-        config = PagingConfig(pageSize = DEFAULT_LOAD_SIZE, initialLoadSize = DEFAULT_LOAD_SIZE),
+        config = PagingConfig(
+            pageSize = DEFAULT_LOAD_SIZE,
+            initialLoadSize = DEFAULT_LOAD_SIZE,
+            enablePlaceholders = false
+        ),
         pagingSourceFactory = hashtagsPagingSourceFactory
     ).flow
         .cachedIn(viewModelScope)

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -83,7 +83,10 @@ class CachedTimelineViewModel @Inject constructor(
 
     @OptIn(ExperimentalPagingApi::class)
     override val statuses = Pager(
-        config = PagingConfig(pageSize = LOAD_AT_ONCE),
+        config = PagingConfig(
+            pageSize = LOAD_AT_ONCE,
+            enablePlaceholders = false
+        ),
         remoteMediator = CachedTimelineRemoteMediator(accountManager, api, db),
         pagingSourceFactory = {
             val activeAccount = accountManager.activeAccount

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -85,7 +85,10 @@ class NetworkTimelineViewModel @Inject constructor(
 
     @OptIn(ExperimentalPagingApi::class)
     override val statuses = Pager(
-        config = PagingConfig(pageSize = LOAD_AT_ONCE),
+        config = PagingConfig(
+            pageSize = LOAD_AT_ONCE,
+            enablePlaceholders = false
+        ),
         pagingSourceFactory = {
             NetworkTimelinePagingSource(
                 viewModel = this


### PR DESCRIPTION
This does four things

- set `enablePlaceholders = false` on `PagingConfig`s to avoid Paging Data that contains null placeholders, we don't want them (everywhere, not just in notifications)
- make sure NotificationsPagingAdapter does not crash when it encounters a null placeholder
- makes sure the notifications refresh correctly when the filters change
- the filters are now also respected when loading a gap

closes #4433 