### PR TITLE
build.gradle: Always increase versionCode for Green

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,15 @@ final def CUSTOM_INSTANCE = ""
 // link to your support account. Will be linked on the about page when not empty.
 final def SUPPORT_ACCOUNT_URL = "https://mastodon.social/@Tusky"
 
+/**
+ * Use the number of seconds/10 since Jan 1 2016 as the versionCode.
+ * This lets us upload a new build at most every 10 seconds for the
+ * next 680 years.
+ */
+def greenvcode = (int)(((new Date().getTime()/1000) - 1451606400) / 10)
+
+
+
 android {
     compileSdk 34
     namespace "com.keylesspalace.tusky"
@@ -66,6 +75,8 @@ android {
             resValue "string", "app_name", APP_NAME + " Test"
             applicationIdSuffix ".test"
             versionNameSuffix "-" + gitSha
+            // Always use a bigger versionCode to trigger Android/F-Droid update process
+            versionCode greenvcode
             isDefault true
         }
     }


### PR DESCRIPTION
Due to Android (and the F-Droid) upgrade process, `versionCode` should always increase in order to trigger the update process. 

Use a dedicated `versionCode` for Green releases, time base, which will always increase (beware of time zones ⚠️ )

Another side effect will be: the same code, rebuilt, will be considered as an upgrade, as build time will be newer. 

It is impossible to use the commit number as it is not an `int`.  A better idea would be to count the amounts of commits, with something like  `git rev-list --first-parent --count HEAD` but I didn't manage to do it.