### PR TITLE
Load shortcut image as Drawable instead of Bitmap

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/ShareShortcutHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ShareShortcutHelper.kt
@@ -56,27 +56,24 @@ class ShareShortcutHelper @Inject constructor(
 
             val shortcuts = accountManager.accounts.take(maxNumberOfShortcuts).mapNotNull { account ->
 
-                val bmp = try {
+                val drawable = try {
                     Glide.with(context)
-                        .asBitmap()
+                        .asDrawable()
                         .load(account.profilePictureUrl)
                         .submitAsync(innerSize, innerSize)
                 } catch (e: GlideException) {
                     // https://github.com/bumptech/glide/issues/4672 :/
                     Log.w(TAG, "failed to load avatar ${account.profilePictureUrl}", e)
-                    AppCompatResources.getDrawable(context, R.drawable.avatar_default)?.toBitmap(innerSize, innerSize) ?: return@mapNotNull null
+                    AppCompatResources.getDrawable(context, R.drawable.avatar_default) ?: return@mapNotNull null
                 }
 
                 // inset the loaded bitmap inside a 108dp transparent canvas so it looks good as adaptive icon
                 val outBmp = Bitmap.createBitmap(outerSize, outerSize, Bitmap.Config.ARGB_8888)
 
                 val canvas = Canvas(outBmp)
-                canvas.drawBitmap(
-                    bmp,
-                    (outerSize - innerSize).toFloat() / 2f,
-                    (outerSize - innerSize).toFloat() / 2f,
-                    null
-                )
+                val borderSize = (outerSize - innerSize) / 2
+                drawable.setBounds(borderSize, borderSize, borderSize + innerSize, borderSize + innerSize)
+                drawable.draw(canvas)
 
                 val icon = IconCompat.createWithAdaptiveBitmap(outBmp)
 

--- a/app/src/main/java/com/keylesspalace/tusky/util/ShareShortcutHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ShareShortcutHelper.kt
@@ -27,7 +27,6 @@ import androidx.core.app.Person
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
-import androidx.core.graphics.drawable.toBitmap
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.GlideException
 import com.keylesspalace.tusky.MainActivity


### PR DESCRIPTION
Loading the image as a `Drawable` allows using the Drawable API to abstract the drawing.
This way, any kind of `Drawable` (including the fallback vector drawable) can be drawn in one pass to the Bitmap, without having to be converted to a `Bitmap` first.

Also, `BitmapDrawable` will automatically use [`Paint.FILTER_BITMAP_FLAG`](https://developer.android.com/reference/android/graphics/Paint#FILTER_BITMAP_FLAG) when drawing, ensuring the resized image is high-quality even when using a Bitmap-backed Canvas.