### PR TITLE
Disable SplashScreen compat implementation on API 31+

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -204,15 +204,15 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
 
     @SuppressLint("RestrictedApi")
     override fun onCreate(savedInstanceState: Bundle?) {
-        val splashScreen = installSplashScreen()
+        // Newer Android versions don't need to install the compat Splash Screen
+        // and it can cause theming bugs.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            installSplashScreen()
+        }
         super.onCreate(savedInstanceState)
 
-        val activeAccount = accountManager.activeAccount
-        if (activeAccount == null) {
-            splashScreen.setKeepOnScreenCondition { true }
-            // will be redirected to LoginActivity by BaseActivity
-            return
-        }
+        // will be redirected to LoginActivity by BaseActivity
+        val activeAccount = accountManager.activeAccount ?: return
 
         if (explodeAnimationWasRequested()) {
             overrideActivityTransitionCompat(


### PR DESCRIPTION
API 31+ devices don't need to install the compat SplashScreen because they have their own native splash screen implementation. Furthermore, we don't need to customize the splash screen so there is no need to call the library.

On API 31+, the SplashScreen compat library registers some kind of listener which causes display bugs with the Tusky theme on some Android versions. Disabling the library on API 31+ solves this issue.

Fixes #4446.