### PR TITLE
fix deserializing null focus values

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/view/FocusIndicatorView.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/view/FocusIndicatorView.kt
@@ -107,7 +107,7 @@ class FocusIndicatorView
         val imageSize = this.imageSize
         val focus = this.focus
 
-        if (imageSize != null && focus != null) {
+        if (imageSize != null && focus?.x != null && focus.y != null) {
             val x = axisFromFocus(focus.x, imageSize.x, this.width)
             val y = axisFromFocus(-focus.y, imageSize.y, this.height)
             val circleRadius = getCircleRadius()

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Attachment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Attachment.kt
@@ -71,8 +71,8 @@ data class Attachment(
     @JsonClass(generateAdapter = true)
     @Parcelize
     data class Focus(
-        val x: Float,
-        val y: Float
+        val x: Float?,
+        val y: Float?
     ) : Parcelable {
         fun toMastodonApiString(): String = "$x,$y"
     }

--- a/app/src/main/java/com/keylesspalace/tusky/util/FocalPointUtil.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/FocalPointUtil.kt
@@ -72,9 +72,9 @@ object FocalPointUtil {
         var top = 0f
         var left = 0f
         if (isVerticalCrop(viewWidth, viewHeight, imageWidth, imageHeight)) {
-            top = focalOffset(viewHeight, imageHeight, scale, focalYToCoordinate(focus.y))
+            top = focalOffset(viewHeight, imageHeight, scale, focalYToCoordinate(focus.y ?: 0f))
         } else { // horizontal crop
-            left = focalOffset(viewWidth, imageWidth, scale, focalXToCoordinate(focus.x))
+            left = focalOffset(viewWidth, imageWidth, scale, focalXToCoordinate(focus.x ?: 0f))
         }
 
         mat.postTranslate(left, top)


### PR DESCRIPTION
Found a post with this weird media focus in the wild on chaos.social:

```
"focus": {
    "x": 0.0,
    "y": null
}
```

```
com.squareup.moshi.JsonDataException: Expected a double but was NULL at path $[0].media_attachments[0].meta.focus.y
         at com.squareup.moshi.JsonUtf8Reader.nextDouble(JsonUtf8Reader.java:787)
         at com.squareup.moshi.StandardJsonAdapters$6.fromJson(StandardJsonAdapters.java:167)
         at com.squareup.moshi.StandardJsonAdapters$6.fromJson(StandardJsonAdapters.java:164)
         at com.keylesspalace.tusky.entity.Attachment_FocusJsonAdapter.fromJson(Attachment_FocusJsonAdapter.kt:37)
         at com.keylesspalace.tusky.entity.Attachment_FocusJsonAdapter.fromJson(Attachment_FocusJsonAdapter.kt:20)
         at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
         at com.keylesspalace.tusky.entity.Attachment_MetaDataJsonAdapter.fromJson(Attachment_MetaDataJsonAdapter.kt:54)
         at com.keylesspalace.tusky.entity.Attachment_MetaDataJsonAdapter.fromJson(Attachment_MetaDataJsonAdapter.kt:23)
         at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
         at com.keylesspalace.tusky.entity.AttachmentJsonAdapter.fromJson(AttachmentJsonAdapter.kt:66)
         at com.keylesspalace.tusky.entity.AttachmentJsonAdapter.fromJson(AttachmentJsonAdapter.kt:22)
         at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
         at com.squareup.moshi.CollectionJsonAdapter.fromJson(CollectionJsonAdapter.java:81)
         at com.squareup.moshi.CollectionJsonAdapter$2.fromJson(CollectionJsonAdapter.java:55)
         at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
         at com.keylesspalace.tusky.entity.StatusJsonAdapter.fromJson(StatusJsonAdapter.kt:195)
         at com.keylesspalace.tusky.entity.StatusJsonAdapter.fromJson(StatusJsonAdapter.kt:26)
         at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
         at com.squareup.moshi.CollectionJsonAdapter.fromJson(CollectionJsonAdapter.java:81)
         at com.squareup.moshi.CollectionJsonAdapter$2.fromJson(CollectionJsonAdapter.java:55)
         at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
         at retrofit2.converter.moshi.MoshiResponseBodyConverter.convert(MoshiResponseBodyConverter.java:46)
         at retrofit2.converter.moshi.MoshiResponseBodyConverter.convert(MoshiResponseBodyConverter.java:27)
         at retrofit2.OkHttpCall.parseResponse(OkHttpCall.java:246)
         at retrofit2.OkHttpCall$1.onResponse(OkHttpCall.java:156)
         at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519)
         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
         at java.lang.Thread.run(Thread.java:919)
```