### PR TITLE
Fix incorrect theme override outside of MainActivity

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
@@ -34,7 +34,6 @@ import androidx.annotation.StringRes;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.preference.PreferenceManager;
 
 import com.google.android.material.color.MaterialColors;
 import com.google.android.material.snackbar.Snackbar;
@@ -107,7 +106,8 @@ public abstract class BaseActivity extends AppCompatActivity {
         Log.d("activeTheme", theme);
         if (ThemeUtils.isBlack(getResources().getConfiguration(), theme)) {
             setTheme(R.style.TuskyBlackTheme);
-        } else {
+        } else if (this instanceof MainActivity) {
+            // Replace the SplashTheme of MainActivity
             setTheme(R.style.TuskyTheme);
         }
 


### PR DESCRIPTION
The pull request to integrate the SplashScreen library (#4413) required overriding the theme before setting the layout in `MainActivity.onCreate()`, in order to switch from `SplashTheme` to `TuskyTheme`. Since the parent `BaseActivity` already contained code to override the theme in case the user selects the "black" theme, that logic was added at the same spot in `BaseActivity`.

However, since other Activities inherit from `BaseActivity` and sometimes declare a different default theme than `TuskyTheme` in the Manifest, the wrong theme was set for those Activities when not in Black theme mode.

This pull request ensures that the theme will only be overridden to `TuskyTheme` in `MainActivity`, the only Activity that uses a splash screen.