### PR TITLE
fix timeline jumping

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/account/media/AccountMediaViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/media/AccountMediaViewModel.kt
@@ -45,8 +45,7 @@ class AccountMediaViewModel @Inject constructor(
     val media = Pager(
         config = PagingConfig(
             pageSize = LOAD_AT_ONCE,
-            prefetchDistance = LOAD_AT_ONCE * 2,
-            enablePlaceholders = false
+            prefetchDistance = LOAD_AT_ONCE * 2
         ),
         pagingSourceFactory = {
             AccountMediaPagingSource(

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
@@ -171,7 +171,8 @@ class ConversationsFragment :
 
         adapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
             override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
-                if (positionStart == 0 && adapter.itemCount != itemCount) {
+                val firstPos = (binding.recyclerView.layoutManager as LinearLayoutManager).findFirstCompletelyVisibleItemPosition()
+                if (firstPos == 0 && positionStart == 0 && adapter.itemCount != itemCount) {
                     binding.recyclerView.post {
                         if (getView() != null) {
                             binding.recyclerView.scrollBy(0, Utils.dpToPx(requireContext(), -30))

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsViewModel.kt
@@ -45,8 +45,7 @@ class ConversationsViewModel @Inject constructor(
     @OptIn(ExperimentalPagingApi::class)
     val conversationFlow = Pager(
         config = PagingConfig(
-            pageSize = 30,
-            enablePlaceholders = false
+            pageSize = 30
         ),
         remoteMediator = ConversationsRemoteMediator(api, database, accountManager),
         pagingSourceFactory = {

--- a/app/src/main/java/com/keylesspalace/tusky/components/domainblocks/DomainBlocksRepository.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/domainblocks/DomainBlocksRepository.kt
@@ -41,8 +41,7 @@ class DomainBlocksRepository @Inject constructor(
     val domainPager = Pager(
         config = PagingConfig(
             pageSize = PAGE_SIZE,
-            initialLoadSize = PAGE_SIZE,
-            enablePlaceholders = false
+            initialLoadSize = PAGE_SIZE
         ),
         remoteMediator = DomainBlocksRemoteMediator(api, this),
         pagingSourceFactory = factory

--- a/app/src/main/java/com/keylesspalace/tusky/components/drafts/DraftsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/drafts/DraftsViewModel.kt
@@ -40,8 +40,7 @@ class DraftsViewModel @Inject constructor(
 
     val drafts = Pager(
         config = PagingConfig(
-            pageSize = 20,
-            enablePlaceholders = false
+            pageSize = 20
         ),
         pagingSourceFactory = {
             database.draftDao().draftsPagingSource(

--- a/app/src/main/java/com/keylesspalace/tusky/components/followedtags/FollowedTagsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/followedtags/FollowedTagsViewModel.kt
@@ -27,8 +27,7 @@ class FollowedTagsViewModel @Inject constructor(
     @OptIn(ExperimentalPagingApi::class)
     val pager = Pager(
         config = PagingConfig(
-            pageSize = 100,
-            enablePlaceholders = false
+            pageSize = 100
         ),
         remoteMediator = FollowedTagsRemoteMediator(api, this),
         pagingSourceFactory = {

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
@@ -236,7 +236,8 @@ class NotificationsFragment :
 
         adapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
             override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
-                if (positionStart == 0 && adapter.itemCount != itemCount) {
+                val firstPos = (binding.recyclerView.layoutManager as LinearLayoutManager).findFirstCompletelyVisibleItemPosition()
+                if (firstPos == 0 && positionStart == 0 && adapter.itemCount != itemCount) {
                     binding.recyclerView.post {
                         if (getView() != null) {
                             binding.recyclerView.scrollBy(

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
@@ -95,8 +95,7 @@ class NotificationsViewModel @Inject constructor(
     val notifications = refreshTrigger.flatMapLatest {
         Pager(
             config = PagingConfig(
-                pageSize = LOAD_AT_ONCE,
-                enablePlaceholders = false
+                pageSize = LOAD_AT_ONCE
             ),
             remoteMediator = remoteMediator,
             pagingSourceFactory = {

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/ReportViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/ReportViewModel.kt
@@ -79,8 +79,7 @@ class ReportViewModel @Inject constructor(
             initialKey = statusId,
             config = PagingConfig(
                 pageSize = 20,
-                initialLoadSize = 20,
-                enablePlaceholders = false
+                initialLoadSize = 20
             ),
             pagingSourceFactory = { StatusesPagingSource(accountId, mastodonApi) }
         ).flow

--- a/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledStatusViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/scheduled/ScheduledStatusViewModel.kt
@@ -40,8 +40,7 @@ class ScheduledStatusViewModel @Inject constructor(
     val data = Pager(
         config = PagingConfig(
             pageSize = 20,
-            initialLoadSize = 20,
-            enablePlaceholders = false
+            initialLoadSize = 20
         ),
         pagingSourceFactory = pagingSourceFactory
     ).flow

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
@@ -90,8 +90,7 @@ class SearchViewModel @Inject constructor(
     val statusesFlow = Pager(
         config = PagingConfig(
             pageSize = DEFAULT_LOAD_SIZE,
-            initialLoadSize = DEFAULT_LOAD_SIZE,
-            enablePlaceholders = false
+            initialLoadSize = DEFAULT_LOAD_SIZE
         ),
         pagingSourceFactory = statusesPagingSourceFactory
     ).flow
@@ -100,8 +99,7 @@ class SearchViewModel @Inject constructor(
     val accountsFlow = Pager(
         config = PagingConfig(
             pageSize = DEFAULT_LOAD_SIZE,
-            initialLoadSize = DEFAULT_LOAD_SIZE,
-            enablePlaceholders = false
+            initialLoadSize = DEFAULT_LOAD_SIZE
         ),
         pagingSourceFactory = accountsPagingSourceFactory
     ).flow
@@ -110,8 +108,7 @@ class SearchViewModel @Inject constructor(
     val hashtagsFlow = Pager(
         config = PagingConfig(
             pageSize = DEFAULT_LOAD_SIZE,
-            initialLoadSize = DEFAULT_LOAD_SIZE,
-            enablePlaceholders = false
+            initialLoadSize = DEFAULT_LOAD_SIZE
         ),
         pagingSourceFactory = hashtagsPagingSourceFactory
     ).flow

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
@@ -257,7 +257,8 @@ class TimelineFragment :
 
         adapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
             override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
-                if (positionStart == 0 && adapter.itemCount != itemCount) {
+                val firstPos = (binding.recyclerView.layoutManager as LinearLayoutManager).findFirstCompletelyVisibleItemPosition()
+                if (firstPos == 0 && positionStart == 0 && adapter.itemCount != itemCount) {
                     binding.recyclerView.post {
                         if (getView() != null) {
                             if (isSwipeToRefreshEnabled) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -194,7 +194,7 @@ class CachedTimelineViewModel @Inject constructor(
                     loadMoreFailed(placeholderId, HttpException(response))
                     return@launch
                 }
-                
+
                 db.withTransaction {
                     timelineDao.deleteHomeTimelineItem(activeAccount.id, placeholderId)
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -86,8 +86,7 @@ class CachedTimelineViewModel @Inject constructor(
     @OptIn(ExperimentalPagingApi::class)
     override val statuses = Pager(
         config = PagingConfig(
-            pageSize = LOAD_AT_ONCE,
-            enablePlaceholders = false
+            pageSize = LOAD_AT_ONCE
         ),
         remoteMediator = CachedTimelineRemoteMediator(accountManager, api, db),
         pagingSourceFactory = {
@@ -195,7 +194,7 @@ class CachedTimelineViewModel @Inject constructor(
                     loadMoreFailed(placeholderId, HttpException(response))
                     return@launch
                 }
-
+                
                 db.withTransaction {
                     timelineDao.deleteHomeTimelineItem(activeAccount.id, placeholderId)
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -88,8 +88,7 @@ class NetworkTimelineViewModel @Inject constructor(
     @OptIn(ExperimentalPagingApi::class)
     override val statuses = Pager(
         config = PagingConfig(
-            pageSize = LOAD_AT_ONCE,
-            enablePlaceholders = false
+            pageSize = LOAD_AT_ONCE
         ),
         pagingSourceFactory = {
             NetworkTimelinePagingSource(

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingTagsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/TrendingTagsFragment.kt
@@ -26,6 +26,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.GridLayoutManager.SpanSizeLookup
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
@@ -72,7 +73,8 @@ class TrendingTagsFragment :
 
         adapter.registerAdapterDataObserver(object : RecyclerView.AdapterDataObserver() {
             override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
-                if (positionStart == 0 && adapter.itemCount != itemCount) {
+                val firstPos = (binding.recyclerView.layoutManager as LinearLayoutManager).findFirstCompletelyVisibleItemPosition()
+                if (firstPos == 0 && positionStart == 0 && adapter.itemCount != itemCount) {
                     binding.recyclerView.post {
                         if (getView() != null) {
                             binding.recyclerView.scrollBy(


### PR DESCRIPTION
Two things changed here:

The check for `positionStart`only in `onItemRangeInserted` is not always correct - we only want to jump up when something is inserted at the top, if we already are at the top.

`enablePlaceholders = false` has unintended side effects -  the recyclerview adapter sometimes receives an "onItemRangeRemoved" followed by an "onItemRangeInserted", instead of just "onItemRangeChanged".

Together they should make sure the timelines stay were they are.