### PR TITLE
remove duplicate SHOW_NOTIFICATIONS_FILTER option

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesFragment.kt
@@ -222,13 +222,6 @@ class PreferencesFragment : PreferenceFragmentCompat() {
 
                 switchPreference {
                     setDefaultValue(true)
-                    key = PrefKeys.SHOW_NOTIFICATIONS_FILTER
-                    setTitle(R.string.pref_title_show_notifications_filter)
-                    isSingleLineTitle = false
-                }
-
-                switchPreference {
-                    setDefaultValue(true)
                     key = PrefKeys.CONFIRM_REBLOGS
                     setTitle(R.string.pref_title_confirm_reblogs)
                     isSingleLineTitle = false


### PR DESCRIPTION
The option was removed in https://github.com/tuskyapp/Tusky/pull/3877, then forgotten to be added again in https://github.com/tuskyapp/Tusky/pull/4015. https://github.com/tuskyapp/Tusky/pull/4026 added it again, but took to long to merge, so we made https://github.com/tuskyapp/Tusky/pull/4225 as well and that is how we ended up with the option twice.