### PR TITLE
correctly set currentContent in ComposeViewModel.setup

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -525,6 +525,7 @@ class ComposeViewModel @Inject constructor(
         scheduledTootId = composeOptions?.scheduledTootId
         originalStatusId = composeOptions?.statusId
         startingText = composeOptions?.content
+        currentContent = composeOptions?.content
         postLanguage = composeOptions?.language
 
         val tootVisibility = composeOptions?.visibility ?: Status.Visibility.UNKNOWN


### PR DESCRIPTION
Without this, the check that decides if the dialog on close should be shown operates on incorrect data.

closes #4434