### PR TITLE
Replace "Hide compose button while scrolling" setting with bottom padding

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.kt
@@ -134,6 +134,10 @@ class TuskyApplication : Application(), Configuration.Provider {
             editor.remove(PrefKeys.TAB_SHOW_HOME_SELF_BOOSTS)
         }
 
+        if (oldVersion < 2024060201) {
+            editor.remove(PrefKeys.Deprecated.FAB_HIDE)
+        }
+
         editor.putInt(PrefKeys.SCHEMA_VERSION, newVersion)
         editor.apply()
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
@@ -129,8 +129,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvide
     private var animateAvatar: Boolean = false
     private var animateEmojis: Boolean = false
 
-    // fields for scroll animation
-    private var hideFab: Boolean = false
+    // for scroll animation
     private var oldOffset: Int = 0
 
     @ColorInt
@@ -170,7 +169,6 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvide
 
         animateAvatar = preferences.getBoolean(PrefKeys.ANIMATE_GIF_AVATARS, false)
         animateEmojis = preferences.getBoolean(PrefKeys.ANIMATE_CUSTOM_EMOJIS, false)
-        hideFab = preferences.getBoolean(PrefKeys.FAB_HIDE, false)
 
         handleWindowInsets()
         setupToolbar()
@@ -362,15 +360,6 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvide
                     supportActionBar?.setDisplayShowTitleEnabled(true)
                 } else {
                     supportActionBar?.setDisplayShowTitleEnabled(false)
-                }
-
-                if (hideFab && !blocking) {
-                    if (verticalOffset > oldOffset) {
-                        binding.accountFloatingActionButton.show()
-                    }
-                    if (verticalOffset < oldOffset) {
-                        binding.accountFloatingActionButton.hide()
-                    }
                 }
 
                 val scaledAvatarSize = (avatarSize + verticalOffset) / avatarSize

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
@@ -86,8 +86,6 @@ class ConversationsFragment :
 
     private var adapter: ConversationAdapter? = null
 
-    private var hideFab = false
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         requireActivity().addMenuProvider(this, viewLifecycleOwner, Lifecycle.State.RESUMED)
 
@@ -168,24 +166,6 @@ class ConversationsFragment :
                         if (getView() != null) {
                             binding.recyclerView.scrollBy(0, Utils.dpToPx(requireContext(), -30))
                         }
-                    }
-                }
-            }
-        })
-
-        hideFab = preferences.getBoolean(PrefKeys.FAB_HIDE, false)
-        binding.recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
-            override fun onScrolled(view: RecyclerView, dx: Int, dy: Int) {
-                val composeButton = (activity as ActionButtonActivity).actionButton
-                if (composeButton != null) {
-                    if (hideFab) {
-                        if (dy > 0 && composeButton.isShown) {
-                            composeButton.hide() // hides the button if we're scrolling down
-                        } else if (dy < 0 && !composeButton.isShown) {
-                            composeButton.show() // shows it if we are scrolling up
-                        }
-                    } else if (!composeButton.isShown) {
-                        composeButton.show()
                     }
                 }
             }
@@ -407,10 +387,6 @@ class ConversationsFragment :
 
     private fun onPreferenceChanged(adapter: ConversationAdapter, key: String) {
         when (key) {
-            PrefKeys.FAB_HIDE -> {
-                hideFab = preferences.getBoolean(PrefKeys.FAB_HIDE, false)
-            }
-
             PrefKeys.MEDIA_PREVIEW_ENABLED -> {
                 val enabled = accountManager.activeAccount!!.mediaPreviewEnabled
                 val oldMediaPreviewEnabled = adapter.mediaPreviewEnabled

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
@@ -44,7 +44,6 @@ import com.keylesspalace.tusky.appstore.PreferenceChangedEvent
 import com.keylesspalace.tusky.components.account.AccountActivity
 import com.keylesspalace.tusky.databinding.FragmentTimelineBinding
 import com.keylesspalace.tusky.fragment.SFragment
-import com.keylesspalace.tusky.interfaces.ActionButtonActivity
 import com.keylesspalace.tusky.interfaces.ReselectableFragment
 import com.keylesspalace.tusky.interfaces.StatusActionListener
 import com.keylesspalace.tusky.settings.PrefKeys

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.DividerItemDecoration
 import com.keylesspalace.tusky.BaseActivity
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.databinding.ActivityFiltersBinding
@@ -50,6 +51,10 @@ class FiltersActivity : BaseActivity(), FiltersListener {
         binding.swipeRefreshLayout.setColorSchemeResources(R.color.tusky_blue)
 
         setTitle(R.string.pref_title_timeline_filters)
+
+        binding.filtersList.addItemDecoration(
+            DividerItemDecoration(this, DividerItemDecoration.VERTICAL)
+        )
 
         observeViewModel()
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/followedtags/FollowedTagsActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/followedtags/FollowedTagsActivity.kt
@@ -85,19 +85,6 @@ class FollowedTagsActivity :
             DividerItemDecoration(this, DividerItemDecoration.VERTICAL)
         )
         (binding.followedTagsView.itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
-
-        val hideFab = sharedPreferences.getBoolean(PrefKeys.FAB_HIDE, false)
-        if (hideFab) {
-            binding.followedTagsView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
-                override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
-                    if (dy > 0 && binding.fab.isShown) {
-                        binding.fab.hide()
-                    } else if (dy < 0 && !binding.fab.isShown) {
-                        binding.fab.show()
-                    }
-                }
-            })
-        }
     }
 
     private fun setupAdapter(): FollowedTagsAdapter {

--- a/app/src/main/java/com/keylesspalace/tusky/components/followedtags/FollowedTagsActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/followedtags/FollowedTagsActivity.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.paging.LoadState
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import at.connyduck.calladapter.networkresult.fold
 import com.google.android.material.snackbar.Snackbar
@@ -24,7 +23,6 @@ import com.keylesspalace.tusky.components.compose.ComposeAutoCompleteAdapter
 import com.keylesspalace.tusky.databinding.ActivityFollowedTagsBinding
 import com.keylesspalace.tusky.interfaces.HashtagActionListener
 import com.keylesspalace.tusky.network.MastodonApi
-import com.keylesspalace.tusky.settings.PrefKeys
 import com.keylesspalace.tusky.util.copyToClipboard
 import com.keylesspalace.tusky.util.hide
 import com.keylesspalace.tusky.util.show

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
@@ -100,7 +100,6 @@ class NotificationsFragment :
 
     private var adapter: NotificationsPagingAdapter? = null
 
-    private var hideFab: Boolean = false
     private var showNotificationsFilterBar: Boolean = true
     private var readingOrder: ReadingOrder = ReadingOrder.NEWEST_FIRST
 
@@ -180,25 +179,7 @@ class NotificationsFragment :
             DividerItemDecoration(context, DividerItemDecoration.VERTICAL)
         )
 
-        hideFab = preferences.getBoolean(PrefKeys.FAB_HIDE, false)
         readingOrder = ReadingOrder.from(preferences.getString(PrefKeys.READING_ORDER, null))
-
-        binding.recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
-            override fun onScrolled(view: RecyclerView, dx: Int, dy: Int) {
-                val composeButton = (activity as ActionButtonActivity).actionButton
-                if (composeButton != null) {
-                    if (hideFab) {
-                        if (dy > 0 && composeButton.isShown) {
-                            composeButton.hide() // hides the button if we're scrolling down
-                        } else if (dy < 0 && !composeButton.isShown) {
-                            composeButton.show() // shows it if we are scrolling up
-                        }
-                    } else if (!composeButton.isShown) {
-                        composeButton.show()
-                    }
-                }
-            }
-        })
 
         adapter.addLoadStateListener { loadState ->
             if (loadState.refresh != LoadState.Loading && loadState.source.refresh != LoadState.Loading) {
@@ -481,10 +462,6 @@ class NotificationsFragment :
 
     private fun onPreferenceChanged(adapter: NotificationsPagingAdapter, key: String) {
         when (key) {
-            PrefKeys.FAB_HIDE -> {
-                hideFab = preferences.getBoolean(PrefKeys.FAB_HIDE, false)
-            }
-
             PrefKeys.MEDIA_PREVIEW_ENABLED -> {
                 val enabled = accountManager.activeAccount!!.mediaPreviewEnabled
                 val oldMediaPreviewEnabled = adapter.mediaPreviewEnabled

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
@@ -55,7 +55,6 @@ import com.keylesspalace.tusky.databinding.NotificationsFilterBinding
 import com.keylesspalace.tusky.entity.Notification
 import com.keylesspalace.tusky.fragment.SFragment
 import com.keylesspalace.tusky.interfaces.AccountActionListener
-import com.keylesspalace.tusky.interfaces.ActionButtonActivity
 import com.keylesspalace.tusky.interfaces.ReselectableFragment
 import com.keylesspalace.tusky.interfaces.StatusActionListener
 import com.keylesspalace.tusky.settings.PrefKeys

--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesFragment.kt
@@ -172,13 +172,6 @@ class PreferencesFragment : PreferenceFragmentCompat() {
 
                 switchPreference {
                     setDefaultValue(false)
-                    key = PrefKeys.FAB_HIDE
-                    setTitle(R.string.pref_title_hide_follow_button)
-                    isSingleLineTitle = false
-                }
-
-                switchPreference {
-                    setDefaultValue(false)
                     key = PrefKeys.ABSOLUTE_TIME_VIEW
                     setTitle(R.string.pref_title_absolute_time)
                     isSingleLineTitle = false

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
@@ -109,7 +109,6 @@ class TimelineFragment :
     private var adapter: TimelinePagingAdapter? = null
 
     private var isSwipeToRefreshEnabled = true
-    private var hideFab = false
 
     /**
      * Adapter position of the placeholder that was most recently clicked to "Load more". If null
@@ -277,26 +276,6 @@ class TimelineFragment :
             viewModel.statuses.collectLatest { pagingData ->
                 adapter.submitData(pagingData)
             }
-        }
-
-        if (actionButtonPresent()) {
-            hideFab = preferences.getBoolean(PrefKeys.FAB_HIDE, false)
-            binding.recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
-                override fun onScrolled(view: RecyclerView, dx: Int, dy: Int) {
-                    val composeButton = (activity as ActionButtonActivity).actionButton
-                    if (composeButton != null) {
-                        if (hideFab) {
-                            if (dy > 0 && composeButton.isShown) {
-                                composeButton.hide() // hides the button if we're scrolling down
-                            } else if (dy < 0 && !composeButton.isShown) {
-                                composeButton.show() // shows it if we are scrolling up
-                            }
-                        } else if (!composeButton.isShown) {
-                            composeButton.show()
-                        }
-                    }
-                }
-            })
         }
 
         viewLifecycleOwner.lifecycleScope.launch {
@@ -573,10 +552,6 @@ class TimelineFragment :
 
     private fun onPreferenceChanged(adapter: TimelinePagingAdapter, key: String) {
         when (key) {
-            PrefKeys.FAB_HIDE -> {
-                hideFab = preferences.getBoolean(PrefKeys.FAB_HIDE, false)
-            }
-
             PrefKeys.MEDIA_PREVIEW_ENABLED -> {
                 val enabled = accountManager.activeAccount!!.mediaPreviewEnabled
                 val oldMediaPreviewEnabled = adapter.mediaPreviewEnabled

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
@@ -25,6 +25,7 @@ import android.view.View
 import android.view.accessibility.AccessibilityManager
 import androidx.core.content.getSystemService
 import androidx.core.view.MenuProvider
+import androidx.core.view.updatePadding
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -389,6 +390,14 @@ class TimelineFragment :
         binding.recyclerView.layoutManager = LinearLayoutManager(context)
         val divider = DividerItemDecoration(context, RecyclerView.VERTICAL)
         binding.recyclerView.addItemDecoration(divider)
+
+        val recyclerViewBottomPadding = if ((activity as? ActionButtonActivity?)?.actionButton != null) {
+            resources.getDimensionPixelSize(R.dimen.recyclerview_bottom_padding_actionbutton)
+        } else {
+            resources.getDimensionPixelSize(R.dimen.recyclerview_bottom_padding_no_actionbutton)
+        }
+
+        binding.recyclerView.updatePadding(bottom = recyclerViewBottomPadding)
 
         // CWs are expanded without animation, buttons animate itself, we don't need it basically
         (binding.recyclerView.itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false

--- a/app/src/main/java/com/keylesspalace/tusky/settings/SettingsConstants.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/settings/SettingsConstants.kt
@@ -56,7 +56,6 @@ object PrefKeys {
 
     const val SCHEMA_VERSION: String = "schema_version"
     const val APP_THEME = "appTheme"
-    const val FAB_HIDE = "fabHide"
     const val LANGUAGE = "language"
     const val STATUS_TEXT_SIZE = "statusTextSize"
     const val READING_ORDER = "readingOrder"
@@ -112,4 +111,8 @@ object PrefKeys {
 
     /** UI text scaling factor, stored as float, 100 = 100% = no scaling */
     const val UI_TEXT_SCALE_RATIO = "uiTextScaleRatio"
+
+    object Deprecated {
+        const val FAB_HIDE = "fabHide"
+    }
 }

--- a/app/src/main/res/layout-sw640dp/fragment_timeline.xml
+++ b/app/src/main/res/layout-sw640dp/fragment_timeline.xml
@@ -32,6 +32,7 @@
 
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/recyclerView"
+                    android:clipToPadding="false"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent" />
 

--- a/app/src/main/res/layout-sw640dp/fragment_timeline_notifications.xml
+++ b/app/src/main/res/layout-sw640dp/fragment_timeline_notifications.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2023 Tusky Contributors
   ~
   ~ This file is a part of Tusky.
@@ -85,7 +84,9 @@
                     android:id="@+id/recyclerView"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:background="?android:attr/colorBackground" />
+                    android:background="?android:attr/colorBackground"
+                    android:clipToPadding="false"
+                    android:paddingBottom="@dimen/recyclerview_bottom_padding_actionbutton" />
 
                 <com.keylesspalace.tusky.view.BackgroundMessageView
                     android:id="@+id/statusView"

--- a/app/src/main/res/layout-sw640dp/fragment_view_thread.xml
+++ b/app/src/main/res/layout-sw640dp/fragment_view_thread.xml
@@ -23,15 +23,18 @@
                 android:layout_height="0dp"
                 android:layout_weight="1"
                 android:background="?android:attr/colorBackground"
+                android:clipToPadding="false"
+                android:paddingBottom="@dimen/recyclerview_bottom_padding_no_actionbutton"
+                android:scrollbarStyle="outsideInset"
                 android:scrollbars="vertical" />
 
             <com.google.android.material.progressindicator.LinearProgressIndicator
                 android:id="@+id/threadProgressBar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:visibility="gone"
+                android:contentDescription="@string/a11y_label_loading_thread"
                 android:indeterminate="true"
-                android:contentDescription="@string/a11y_label_loading_thread" />
+                android:visibility="gone" />
 
             <com.keylesspalace.tusky.view.BackgroundMessageView
                 android:id="@+id/statusView"
@@ -47,9 +50,9 @@
         android:id="@+id/initialProgressBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:visibility="gone"
-        android:indeterminate="true"
         android:layout_gravity="center"
-        android:contentDescription="@string/a11y_label_loading_thread" />
+        android:contentDescription="@string/a11y_label_loading_thread"
+        android:indeterminate="true"
+        android:visibility="gone" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_announcements.xml
+++ b/app/src/main/res/layout/activity_announcements.xml
@@ -28,7 +28,9 @@
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/announcementsList"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:paddingBottom="@dimen/recyclerview_bottom_padding_no_actionbutton" />
 
             <com.keylesspalace.tusky.view.BackgroundMessageView
                 android:id="@+id/errorMessageView"

--- a/app/src/main/res/layout/activity_drafts.xml
+++ b/app/src/main/res/layout/activity_drafts.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".components.drafts.DraftsActivity">
@@ -14,16 +14,20 @@
         android:id="@+id/draftsRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+        android:clipToPadding="false"
+        android:paddingBottom="@dimen/recyclerview_bottom_padding_no_actionbutton"
+        android:scrollbarStyle="outsideInset"
+        android:scrollbars="vertical"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <com.keylesspalace.tusky.view.BackgroundMessageView
         android:id="@+id/draftsErrorMessageView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
+        android:layout_gravity="center"
         android:src="@android:color/transparent"
         android:visibility="gone"
-        android:layout_gravity="center"
         tools:src="@drawable/errorphant_error"
         tools:visibility="visible" />
 

--- a/app/src/main/res/layout/activity_filters.xml
+++ b/app/src/main/res/layout/activity_filters.xml
@@ -12,9 +12,9 @@
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipeRefreshLayout"
-        android:layout_marginTop="?attr/actionBarSize"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:layout_marginTop="?attr/actionBarSize">
 
         <FrameLayout
             android:layout_width="match_parent"
@@ -24,6 +24,8 @@
                 android:id="@+id/filtersList"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:scrollbarStyle="outsideInset"
+                android:scrollbars="vertical"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
             <com.keylesspalace.tusky.view.BackgroundMessageView

--- a/app/src/main/res/layout/activity_followed_tags.xml
+++ b/app/src/main/res/layout/activity_followed_tags.xml
@@ -14,10 +14,11 @@
         android:id="@+id/followedTagsView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:itemCount="5"
-        tools:listitem="@layout/item_followed_hashtag"
+        android:clipToPadding="false"
+        android:paddingBottom="@dimen/recyclerview_bottom_padding_actionbutton"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        />
+        tools:itemCount="5"
+        tools:listitem="@layout/item_followed_hashtag" />
 
     <com.keylesspalace.tusky.view.BackgroundMessageView
         android:id="@+id/followedTagsMessageView"
@@ -25,8 +26,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        tools:visibility="gone"
-        />
+        tools:visibility="gone" />
 
     <ProgressBar
         android:id="@+id/followedTagsProgressBar"
@@ -34,8 +34,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        tools:visibility="gone"
-        />
+        tools:visibility="gone" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab"

--- a/app/src/main/res/layout/activity_lists.xml
+++ b/app/src/main/res/layout/activity_lists.xml
@@ -29,7 +29,9 @@
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/listsRecycler"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent" />
+                    android:layout_height="match_parent"
+                    android:clipToPadding="false"
+                    android:paddingBottom="@dimen/recyclerview_bottom_padding_actionbutton" />
 
                 <com.keylesspalace.tusky.view.BackgroundMessageView
                     android:id="@+id/messageView"

--- a/app/src/main/res/layout/fragment_account_list.xml
+++ b/app/src/main/res/layout/fragment_account_list.xml
@@ -16,7 +16,9 @@
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/recyclerView"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:paddingBottom="@dimen/recyclerview_bottom_padding_no_actionbutton" />
 
             <com.keylesspalace.tusky.view.BackgroundMessageView
                 android:id="@+id/messageView"

--- a/app/src/main/res/layout/fragment_domain_blocks.xml
+++ b/app/src/main/res/layout/fragment_domain_blocks.xml
@@ -13,7 +13,9 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:paddingBottom="@dimen/recyclerview_bottom_padding_no_actionbutton" />
 
     <com.keylesspalace.tusky.view.BackgroundMessageView
         android:id="@+id/messageView"

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -15,6 +15,8 @@
             android:layout_height="match_parent"
             android:layout_gravity="center"
             android:background="?android:attr/windowBackground"
+            android:clipToPadding="false"
+            android:paddingBottom="@dimen/recyclerview_bottom_padding_no_actionbutton"
             tools:listitem="@layout/item_account" />
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/fragment_timeline.xml
+++ b/app/src/main/res/layout/fragment_timeline.xml
@@ -16,6 +16,7 @@
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/recyclerView"
+                android:clipToPadding="false"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />
 

--- a/app/src/main/res/layout/fragment_timeline_notifications.xml
+++ b/app/src/main/res/layout/fragment_timeline_notifications.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2023 Tusky Contributors
   ~
   ~ This file is a part of Tusky.
@@ -77,7 +76,9 @@
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/recyclerView"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:paddingBottom="@dimen/recyclerview_bottom_padding_actionbutton" />
 
             <com.keylesspalace.tusky.view.BackgroundMessageView
                 android:id="@+id/statusView"

--- a/app/src/main/res/layout/fragment_trending_tags.xml
+++ b/app/src/main/res/layout/fragment_trending_tags.xml
@@ -18,7 +18,9 @@
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/recyclerView"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:paddingBottom="@dimen/recyclerview_bottom_padding_no_actionbutton" />
 
             <com.keylesspalace.tusky.view.BackgroundMessageView
                 android:id="@+id/messageView"

--- a/app/src/main/res/layout/fragment_view_edits.xml
+++ b/app/src/main/res/layout/fragment_view_edits.xml
@@ -53,8 +53,8 @@
                 app:layout_constrainedWidth="true"
                 app:layout_constraintStart_toEndOf="@id/status_avatar"
                 app:layout_constraintTop_toTopOf="@+id/status_avatar"
-                tools:text="Ente r the void you foooooo"
-                tools:ignore="SelectableText"/>
+                tools:ignore="SelectableText"
+                tools:text="Ente r the void you foooooo" />
 
             <TextView
                 android:id="@+id/status_username"
@@ -67,8 +67,8 @@
                 android:textSize="?attr/status_text_medium"
                 app:layout_constraintStart_toStartOf="@+id/status_display_name"
                 app:layout_constraintTop_toBottomOf="@id/status_display_name"
-                tools:text="\@Entenhausen@birbsarecooooooooooool.site"
-                tools:ignore="SelectableText" />
+                tools:ignore="SelectableText"
+                tools:text="\@Entenhausen@birbsarecooooooooooool.site" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
@@ -87,6 +87,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="?android:attr/colorBackground"
+                android:clipToPadding="false"
+                android:paddingBottom="@dimen/recyclerview_bottom_padding_no_actionbutton"
+                android:scrollbarStyle="outsideInset"
                 android:scrollbars="vertical" />
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
     </LinearLayout>
@@ -95,17 +98,17 @@
         android:id="@+id/initialProgressBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:visibility="gone"
-        android:indeterminate="true"
         android:layout_gravity="center"
-        android:contentDescription="@string/a11y_label_loading_thread" />
+        android:contentDescription="@string/a11y_label_loading_thread"
+        android:indeterminate="true"
+        android:visibility="gone" />
 
     <com.keylesspalace.tusky.view.BackgroundMessageView
         android:id="@+id/statusView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:visibility="gone" >
+        android:visibility="gone">
 
     </com.keylesspalace.tusky.view.BackgroundMessageView>
 

--- a/app/src/main/res/layout/fragment_view_thread.xml
+++ b/app/src/main/res/layout/fragment_view_thread.xml
@@ -13,9 +13,9 @@
             android:id="@+id/threadProgressBar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="gone"
+            android:contentDescription="@string/a11y_label_loading_thread"
             android:indeterminate="true"
-            android:contentDescription="@string/a11y_label_loading_thread" />
+            android:visibility="gone" />
 
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/swipeRefreshLayout"
@@ -33,6 +33,9 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:background="?android:attr/colorBackground"
+                    android:clipToPadding="false"
+                    android:paddingBottom="@dimen/recyclerview_bottom_padding_no_actionbutton"
+                    android:scrollbarStyle="outsideInset"
                     android:scrollbars="vertical" />
 
                 <com.keylesspalace.tusky.view.BackgroundMessageView
@@ -49,9 +52,9 @@
         android:id="@+id/initialProgressBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:visibility="gone"
-        android:indeterminate="true"
         android:layout_gravity="center"
-        android:contentDescription="@string/a11y_label_loading_thread" />
+        android:contentDescription="@string/a11y_label_loading_thread"
+        android:indeterminate="true"
+        android:visibility="gone" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -77,4 +77,8 @@
 
     <dimen name="fallback_emoji_size">16sp</dimen>
 
+    <!-- 56dp + 16dp padding on top and bottom -->
+    <dimen name="recyclerview_bottom_padding_actionbutton">88dp</dimen>
+    <dimen name="recyclerview_bottom_padding_no_actionbutton">32dp</dimen>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -314,7 +314,6 @@
 
     <string name="pref_title_browser_settings">Browser</string>
     <string name="pref_title_custom_tabs">Use Chrome Custom Tabs</string>
-    <string name="pref_title_hide_follow_button">Hide compose button while scrolling</string>
     <string name="pref_title_language">Language</string>
     <string name="pref_title_bot_overlay">Show indicator for bots</string>
     <string name="pref_title_animate_gif_avatars">Animate GIF avatars</string>


### PR DESCRIPTION
As discussed in our contributors meeting.

Advantages:
- last element of list never obscured by action button
- less code that runs on every scroll
- less settings to worry about

Additionally: 
- Added a (smaller) padding to the bottom of lists without action button, I think it looks nice if there is a bit of white space and the nav bar divider and the last list divider don't touch.
- The list of filters had no dividers, I added them.
- Recyclerviews with fixed height (Drafts, Filters, edits) now have scrollbars
- code formatted all touched xml files

closes https://github.com/tuskyapp/Tusky/issues/1563

<img src="https://github.com/tuskyapp/Tusky/assets/10157047/cd50199f-e84f-4402-93e4-a5a1beba2a08" width="280"/>

