### PR TITLE
fix wrong content description of back button in ViewThreadActivity

### DIFF
--- a/app/src/main/res/layout/activity_view_thread.xml
+++ b/app/src/main/res/layout/activity_view_thread.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="com.keylesspalace.tusky.components.viewthread.ViewThreadActivity">
@@ -19,8 +19,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:contentInsetStartWithNavigation="0dp"
-            app:layout_scrollFlags="scroll|enterAlways"
-            app:navigationContentDescription="@string/action_open_drawer" />
+            app:layout_scrollFlags="scroll|enterAlways" />
+
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.fragment.app.FragmentContainerView
@@ -29,6 +29,6 @@
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-    <include layout="@layout/item_status_bottom_sheet"/>
+    <include layout="@layout/item_status_bottom_sheet" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
"Open Drawer" makes no sense here. Removing the attribute makes the description fall back to the default "Navigate up" which is better.