### PR TITLE
Fix some filter bugs

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/StatusListActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/StatusListActivity.kt
@@ -26,7 +26,7 @@ import androidx.lifecycle.lifecycleScope
 import at.connyduck.calladapter.networkresult.fold
 import com.google.android.material.snackbar.Snackbar
 import com.keylesspalace.tusky.appstore.EventHub
-import com.keylesspalace.tusky.appstore.PreferenceChangedEvent
+import com.keylesspalace.tusky.appstore.FilterUpdatedEvent
 import com.keylesspalace.tusky.components.filters.EditFilterActivity
 import com.keylesspalace.tusky.components.filters.FiltersActivity
 import com.keylesspalace.tusky.components.timeline.TimelineFragment
@@ -263,8 +263,7 @@ class StatusListActivity : BottomSheetActivity() {
                         // must be requested again; otherwise does not contain the keyword (but server does)
                         mutedFilter = mastodonApi.getFilter(filter.id).getOrNull()
 
-                        // TODO the preference key here ("home") is not meaningful; should probably be another event if any
-                        eventHub.dispatch(PreferenceChangedEvent(filter.context[0]))
+                        eventHub.dispatch(FilterUpdatedEvent(filter.context))
                         filterCreateSuccess = true
                     } else {
                         Snackbar.make(
@@ -286,7 +285,7 @@ class StatusListActivity : BottomSheetActivity() {
                         ).fold(
                             { filter ->
                                 mutedFilterV1 = filter
-                                eventHub.dispatch(PreferenceChangedEvent(filter.context[0]))
+                                eventHub.dispatch(FilterUpdatedEvent(filter.context))
                                 filterCreateSuccess = true
                             },
                             { throwable2 ->
@@ -372,7 +371,7 @@ class StatusListActivity : BottomSheetActivity() {
             result?.fold(
                 {
                     updateTagMuteState(false)
-                    eventHub.dispatch(PreferenceChangedEvent(Filter.Kind.HOME.kind))
+                    eventHub.dispatch(FilterUpdatedEvent(listOf(Filter.Kind.HOME.kind)))
                     mutedFilterV1 = null
                     mutedFilter = null
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
@@ -276,7 +276,7 @@ class EditFilterActivity : BaseActivity() {
             } else {
                 Snackbar.make(
                     binding.root,
-                    "Error saving filter '${viewModel.title.value}'",
+                    getString(R.string.error_deleting_filter, viewModel.title.value),
                     Snackbar.LENGTH_SHORT
                 ).show()
             }
@@ -299,7 +299,7 @@ class EditFilterActivity : BaseActivity() {
                                 {
                                     Snackbar.make(
                                         binding.root,
-                                        "Error deleting filter '${filter.title}'",
+                                        getString(R.string.error_deleting_filter, filter.title),
                                         Snackbar.LENGTH_SHORT
                                     ).show()
                                 }
@@ -307,7 +307,7 @@ class EditFilterActivity : BaseActivity() {
                         } else {
                             Snackbar.make(
                                 binding.root,
-                                "Error deleting filter '${filter.title}'",
+                                getString(R.string.error_deleting_filter, filter.title),
                                 Snackbar.LENGTH_SHORT
                             ).show()
                         }

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterViewModel.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.connyduck.calladapter.networkresult.fold
-import com.keylesspalace.tusky.appstore.EventHub
 import com.keylesspalace.tusky.entity.Filter
 import com.keylesspalace.tusky.entity.FilterKeyword
 import com.keylesspalace.tusky.network.MastodonApi
@@ -17,7 +16,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 
 @HiltViewModel
-class EditFilterViewModel @Inject constructor(val api: MastodonApi, val eventHub: EventHub) : ViewModel() {
+class EditFilterViewModel @Inject constructor(val api: MastodonApi) : ViewModel() {
     private var originalFilter: Filter? = null
 
     private val _title = MutableStateFlow("")

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersViewModel.kt
@@ -8,7 +8,7 @@ import at.connyduck.calladapter.networkresult.fold
 import com.google.android.material.snackbar.Snackbar
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.appstore.EventHub
-import com.keylesspalace.tusky.appstore.PreferenceChangedEvent
+import com.keylesspalace.tusky.appstore.FilterUpdatedEvent
 import com.keylesspalace.tusky.entity.Filter
 import com.keylesspalace.tusky.network.MastodonApi
 import com.keylesspalace.tusky.util.isHttpNotFound
@@ -95,9 +95,7 @@ class FiltersViewModel @Inject constructor(
                         LoadingState.LOADED
                     )
                 }
-                for (context in filter.context) {
-                    eventHub.dispatch(PreferenceChangedEvent(context))
-                }
+                eventHub.dispatch(FilterUpdatedEvent(filter.context))
             },
             { throwable ->
                 if (throwable.isHttpNotFound()) {

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersViewModel.kt
@@ -1,10 +1,12 @@
 package com.keylesspalace.tusky.components.filters
 
+import android.util.Log
 import android.view.View
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.connyduck.calladapter.networkresult.fold
 import com.google.android.material.snackbar.Snackbar
+import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.appstore.EventHub
 import com.keylesspalace.tusky.appstore.PreferenceChangedEvent
 import com.keylesspalace.tusky.entity.Filter
@@ -49,26 +51,28 @@ class FiltersViewModel @Inject constructor(
 
     private suspend fun observeLoad() {
         loadTrigger.collectLatest {
-            this@FiltersViewModel._state.update { it.copy(loadingState = LoadingState.LOADING) }
+            _state.update { it.copy(loadingState = LoadingState.LOADING) }
 
             api.getFilters().fold(
                 { filters ->
-                    this@FiltersViewModel._state.value = State(filters, LoadingState.LOADED)
+                    _state.value = State(filters, LoadingState.LOADED)
                 },
                 { throwable ->
                     if (throwable.isHttpNotFound()) {
+                        Log.i(TAG, "failed loading filters v2, falling back to v1", throwable)
+
                         api.getFiltersV1().fold(
                             { filters ->
-                                this@FiltersViewModel._state.value = State(filters.map { it.toFilter() }, LoadingState.LOADED)
+                                _state.value = State(filters.map { it.toFilter() }, LoadingState.LOADED)
                             },
-                            { _ ->
-                                // TODO log errors (also below)
-                                this@FiltersViewModel._state.update { it.copy(loadingState = LoadingState.ERROR_OTHER) }
+                            { t ->
+                                Log.w(TAG, "failed loading filters v1", t)
+                                _state.value = State(emptyList(), LoadingState.ERROR_OTHER)
                             }
                         )
-                        this@FiltersViewModel._state.update { it.copy(loadingState = LoadingState.ERROR_OTHER) }
                     } else {
-                        this@FiltersViewModel._state.update { it.copy(loadingState = LoadingState.ERROR_NETWORK) }
+                        Log.w(TAG, "failed loading filters v2", throwable)
+                        _state.update { it.copy(loadingState = LoadingState.ERROR_NETWORK) }
                     }
                 }
             )
@@ -85,7 +89,7 @@ class FiltersViewModel @Inject constructor(
 
         api.deleteFilter(filter.id).fold(
             {
-                this@FiltersViewModel._state.update { currentState ->
+                _state.update { currentState ->
                     State(
                         currentState.filters.filter { it.id != filter.id },
                         LoadingState.LOADED
@@ -99,7 +103,7 @@ class FiltersViewModel @Inject constructor(
                 if (throwable.isHttpNotFound()) {
                     api.deleteFilterV1(filter.id).fold(
                         {
-                            this@FiltersViewModel._state.update { currentState ->
+                            _state.update { currentState ->
                                 State(
                                     currentState.filters.filter { it.id != filter.id },
                                     LoadingState.LOADED
@@ -109,7 +113,7 @@ class FiltersViewModel @Inject constructor(
                         {
                             Snackbar.make(
                                 parent,
-                                "Error deleting filter '${filter.title}'",
+                                parent.context.getString(R.string.error_deleting_filter, filter.title),
                                 Snackbar.LENGTH_SHORT
                             ).show()
                         }
@@ -117,11 +121,15 @@ class FiltersViewModel @Inject constructor(
                 } else {
                     Snackbar.make(
                         parent,
-                        "Error deleting filter '${filter.title}'",
+                        parent.context.getString(R.string.error_deleting_filter, filter.title),
                         Snackbar.LENGTH_SHORT
                     ).show()
                 }
             }
         )
+    }
+
+    companion object {
+        private const val TAG = "FiltersViewModel"
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
@@ -31,6 +31,7 @@ import at.connyduck.calladapter.networkresult.fold
 import at.connyduck.calladapter.networkresult.map
 import at.connyduck.calladapter.networkresult.onFailure
 import com.keylesspalace.tusky.appstore.EventHub
+import com.keylesspalace.tusky.appstore.FilterUpdatedEvent
 import com.keylesspalace.tusky.appstore.PreferenceChangedEvent
 import com.keylesspalace.tusky.components.preference.PreferencesFragment.ReadingOrder
 import com.keylesspalace.tusky.components.timeline.Placeholder
@@ -124,6 +125,9 @@ class NotificationsViewModel @Inject constructor(
             eventHub.events.collect { event ->
                 if (event is PreferenceChangedEvent) {
                     onPreferenceChanged(event.preferenceKey)
+                }
+                if (event is FilterUpdatedEvent && event.filterContext.contains(Filter.Kind.NOTIFICATIONS.kind)) {
+                    refreshTrigger.value += 1
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="error_unblocking_domain">Failed to unmute %1$s: %2$s</string>
     <string name="error_status_source_load">Failed to load the status source from the server.</string>
     <string name="error_deleting_filter">Error deleting filter \'%1$s\'</string>
+    <string name="error_saving_filter">Error saving filter \'%1$s\'</string>
 
     <string name="title_login">Login</string>
     <string name="title_home">Home</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="error_blocking_domain">Failed to mute %1$s: %2$s</string>
     <string name="error_unblocking_domain">Failed to unmute %1$s: %2$s</string>
     <string name="error_status_source_load">Failed to load the status source from the server.</string>
+    <string name="error_deleting_filter">Error deleting filter \'%1$s\'</string>
 
     <string name="title_login">Login</string>
     <string name="title_home">Home</string>


### PR DESCRIPTION
closes #4499 

This restores support for v1 filters. The problem was that the state was uncoditionally set to error instead of checking the v1 response. 
While checking the code I found some other problems:
- Two error messages that were shown to users were not translatable
- When filters were updated sometimes `PreferenceChangedEvent` was sent instead of `FilterUpdatedEvent`
- The notifications fragment was not listening to the `FilterUpdatedEvent`