### PR TITLE
dependency verification: Trust sources packages used by android studio

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -3,6 +3,14 @@
    <configuration>
       <verify-metadata>true</verify-metadata>
       <verify-signatures>false</verify-signatures>
+      <trusted-artifacts>
+          <!-- all these are work-around for https://youtrack.jetbrains.com/issue/IDEA-258328 -->
+          <trust file=".*-javadoc[.]jar" regex="true"/>
+          <trust file=".*-sources[.]jar" regex="true"/>
+          <trust file="gradle-[0-9.]+-src.zip" regex="true"/>
+          <trust file="groovy-[a-z]*-?[0-9.]+.pom" regex="true"/>
+          <!-- end work-around for https://youtrack.jetbrains.com/issue/IDEA-258328 -->
+      </trusted-artifacts>
    </configuration>
    <components>
       <component group="androidx.activity" name="activity" version="1.9.0">


### PR DESCRIPTION
Sync project with gradle files fails for me in android studio without this change

See https://youtrack.jetbrains.com/issue/IDEA-258328/Dependency-verification-failed-Checksums-of-downloaded-sources-not-included-in-verification-metadata.xml