### PR TITLE
hide content warning button when there is no content

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -235,9 +235,14 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             );
             contentWarningDescription.setText(emojiSpoiler);
             contentWarningDescription.setVisibility(View.VISIBLE);
-            contentWarningButton.setVisibility(View.VISIBLE);
-            setContentWarningButtonText(expanded);
-            contentWarningButton.setOnClickListener(view -> toggleExpandedState(true, !expanded, status, statusDisplayOptions, listener));
+            boolean hasContent = !TextUtils.isEmpty(status.getContent());
+            if (hasContent) {
+                contentWarningButton.setVisibility(View.VISIBLE);
+                setContentWarningButtonText(expanded);
+                contentWarningButton.setOnClickListener(view -> toggleExpandedState(true, !expanded, status, statusDisplayOptions, listener));
+            } else {
+                contentWarningButton.setVisibility(View.GONE);
+            }
             this.setTextVisible(true, expanded, status, statusDisplayOptions, listener);
         } else {
             contentWarningDescription.setVisibility(View.GONE);


### PR DESCRIPTION
I encountered [this weird post](https://akko.wtf/notice/Aiz78vrg9jBNHJrvIO) today that had a content warning button but no content.

<img src="https://github.com/tuskyapp/Tusky/assets/10157047/975090e1-7552-4750-97b4-1917b06aeb60" width="320"/>

This change will match Mastodon behavior and hide the button when there is no content to reveal.

We probably did not encounter this bug earlier because Mastodon moves the CW to the content when the content is empty, but apparently not for federated posts.