### PR TITLE
Sort by category in emoji picker

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/EmojiAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/EmojiAdapter.kt
@@ -33,6 +33,7 @@ class EmojiAdapter(
 
     private val emojiList: List<Emoji> = emojiList.filter { emoji -> emoji.visibleInPicker }
         .sortedBy { it.shortcode.lowercase(Locale.ROOT) }
+        .sortedBy { it.category?.lowercase(Locale.ROOT) ?: "" }
 
     override fun getItemCount() = emojiList.size
 

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Emoji.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Emoji.kt
@@ -26,5 +26,6 @@ data class Emoji(
     val shortcode: String,
     val url: String,
     @Json(name = "static_url") val staticUrl: String,
-    @Json(name = "visible_in_picker") val visibleInPicker: Boolean = true
+    @Json(name = "visible_in_picker") val visibleInPicker: Boolean = true,
+    val category: String?
 ) : Parcelable


### PR DESCRIPTION
Emojis are sorted by category within the emoji picker. The original alphabetical sorting is preserved within categories.

This partially addresses #1868 and is only a small part of what is done in #3300, but I think it is still enough to improve quality of life for users.