### PR TITLE
correctly scale gifs in FocusDialog

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/FocusDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/FocusDialog.kt
@@ -50,10 +50,10 @@ fun <T> T.makeFocusDialog(
         .downsample(DownsampleStrategy.CENTER_INSIDE)
         .listener(object : RequestListener<Drawable> {
             override fun onLoadFailed(
-                p0: GlideException?,
-                p1: Any?,
-                p2: Target<Drawable?>,
-                p3: Boolean
+                error: GlideException?,
+                model: Any?,
+                target: Target<Drawable?>,
+                isFirstResource: Boolean
             ): Boolean {
                 return false
             }
@@ -68,15 +68,20 @@ fun <T> T.makeFocusDialog(
                 val width = resource.intrinsicWidth
                 val height = resource.intrinsicHeight
 
-                dialogBinding.focusIndicator.setImageSize(width, height)
+                val viewWidth = dialogBinding.imageView.width
+                val viewHeight = dialogBinding.imageView.height
+
+                val scaledHeight = (viewWidth.toFloat() / width.toFloat()) * height
+
+                dialogBinding.focusIndicator.setImageSize(viewWidth, scaledHeight.toInt())
 
                 // We want the dialog to be a little taller than the image, so you can slide your thumb past the image border,
                 // but if it's *too* much taller that looks weird. See if a threshold has been crossed:
                 if (width > height) {
                     val maxHeight = dialogBinding.focusIndicator.maxAttractiveHeight()
 
-                    if (dialogBinding.imageView.height > maxHeight) {
-                        val verticalShrinkLayout = FrameLayout.LayoutParams(width, maxHeight)
+                    if (viewHeight > maxHeight) {
+                        val verticalShrinkLayout = FrameLayout.LayoutParams(viewWidth, maxHeight)
                         dialogBinding.imageView.layoutParams = verticalShrinkLayout
                         dialogBinding.focusIndicator.layoutParams = verticalShrinkLayout
                     }


### PR DESCRIPTION
Found while testing #4528

The problem seems to be that Glide does not scale GIFs as it does static images. This workaround makes sure they still show up correctly.

before / after

<img src="https://github.com/tuskyapp/Tusky/assets/10157047/92c5e423-fa69-4bd5-b353-d5fac46f3074" width="260" />
<img src="https://github.com/tuskyapp/Tusky/assets/10157047/200f801b-0910-44dd-aa8b-39c383f07107" width="260" />
