### PR TITLE
improve filters v1 loading

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
@@ -93,7 +93,7 @@ abstract class TimelineViewModel(
                         is FilterUpdatedEvent -> {
                             if (filterContextMatchesKind(this@TimelineViewModel.kind, event.filterContext)) {
                                 filterModel.init(kind.toFilterKind())
-                                fullReload()
+                                invalidate()
                             }
                         }
                     }


### PR DESCRIPTION
A user still on Mastodon 3 complained that since my change in https://github.com/tuskyapp/Tusky/pull/4539 the timeline reloads on starting Tusky. Well, we need to do some reloading of the timeline after loading the v1 filters or they won't work. Changing the `fullReload` to `invalidate` improves the situation by not loading everything from the network again (just the database) but there is still some noticeable loading.
(I'm not willing to invest any more time to support these old instances)