### PR TITLE
fix crash on unknown notification

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/UnknownNotificationViewHolder.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/UnknownNotificationViewHolder.kt
@@ -17,14 +17,14 @@
 
 package com.keylesspalace.tusky.components.notifications
 
-import com.keylesspalace.tusky.adapter.StatusViewHolder
+import androidx.recyclerview.widget.RecyclerView
 import com.keylesspalace.tusky.databinding.ItemUnknownNotificationBinding
 import com.keylesspalace.tusky.util.StatusDisplayOptions
 import com.keylesspalace.tusky.viewdata.NotificationViewData
 
 internal class UnknownNotificationViewHolder(
     binding: ItemUnknownNotificationBinding,
-) : NotificationsViewHolder, StatusViewHolder(binding.root) {
+) : NotificationsViewHolder, RecyclerView.ViewHolder(binding.root) {
 
     override fun bind(
         viewData: NotificationViewData.Concrete,


### PR DESCRIPTION
```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'void android.view.View.setClipToOutline(boolean)' on a null object reference
  at com.keylesspalace.tusky.adapter.StatusBaseViewHolder.<init> (StatusBaseViewHolder.java:150)
  at com.keylesspalace.tusky.adapter.StatusViewHolder.<init> (StatusViewHolder.java:55)
  at com.keylesspalace.tusky.components.notifications.UnknownNotificationViewHolder.<init> (UnknownNotificationViewHolder.java:27)
  at com.keylesspalace.tusky.components.notifications.NotificationsPagingAdapter.onCreateViewHolder (NotificationsPagingAdapter.kt:139)
  at androidx.recyclerview.widget.RecyclerView$Adapter.createViewHolder (RecyclerView.java:7788)
  at androidx.recyclerview.widget.RecyclerView$Recycler.tryGetViewHolderForPositionByDeadline (RecyclerView.java:6873)
  at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition (RecyclerView.java:6757)
  at androidx.recyclerview.widget.RecyclerView$Recycler.getViewForPosition (RecyclerView.java:6753)
  at androidx.recyclerview.widget.LinearLayoutManager$LayoutState.next (LinearLayoutManager.java:2362)
  at androidx.recyclerview.widget.LinearLayoutManager.layoutChunk (LinearLayoutManager.java:1662)
  at androidx.recyclerview.widget.LinearLayoutManager.fill (LinearLayoutManager.java:1622)
  at androidx.recyclerview.widget.LinearLayoutManager.onLayoutChildren (LinearLayoutManager.java:687)
  at androidx.recyclerview.widget.RecyclerView.dispatchLayoutStep2 (RecyclerView.java:4645)
  at androidx.recyclerview.widget.RecyclerView.dispatchLayout (RecyclerView.java:4348)
  at androidx.recyclerview.widget.RecyclerView.onLayout (RecyclerView.java:4919)
  ...
```