### PR TITLE
fix translations not working on instances where domain does not match instance name

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/instanceinfo/InstanceInfoRepository.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/instanceinfo/InstanceInfoRepository.kt
@@ -17,6 +17,7 @@ package com.keylesspalace.tusky.components.instanceinfo
 
 import android.util.Log
 import at.connyduck.calladapter.networkresult.NetworkResult
+import at.connyduck.calladapter.networkresult.fold
 import at.connyduck.calladapter.networkresult.getOrElse
 import at.connyduck.calladapter.networkresult.getOrThrow
 import at.connyduck.calladapter.networkresult.map
@@ -65,9 +66,11 @@ class InstanceInfoRepository @Inject constructor(
         //  - caching default value (we want to rather re-fetch if it fails)
         if (instanceInfoCache[instanceName] == null) {
             externalScope.launch {
-                fetchAndPersistInstanceInfo().onSuccess { fetched ->
-                    instanceInfoCache[fetched.instance] = fetched.toInfoOrDefault()
-                }
+                fetchAndPersistInstanceInfo().fold({ fetched ->
+                    instanceInfoCache[instanceName] = fetched.toInfoOrDefault()
+                }, { e ->
+                    Log.w(TAG, "failed to precache instance info", e)
+                })
             }
         }
     }


### PR DESCRIPTION
https://social.froonix.org/@cs/112767747835228296

We were caching the instance info with the instance name as the key and then look it up with the actual domain and those do not always match so the check if translation is supported fails.  fnx.li vs social.froonix.org in this case.