### PR TITLE
fix default post privacy setting sometimes showing the value of the wrong account

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/AccountPreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/AccountPreferencesFragment.kt
@@ -185,6 +185,7 @@ class AccountPreferencesFragment : PreferenceFragmentCompat() {
                     val visibility = accountManager.activeAccount?.defaultPostPrivacy ?: Status.Visibility.PUBLIC
                     value = visibility.serverString
                     setIcon(getIconForVisibility(visibility))
+                    isPersistent = false // its saved to the account and shouldn't be in shared preferences
                     setOnPreferenceChangeListener { _, newValue ->
                         setIcon(
                             getIconForVisibility(Status.Visibility.byString(newValue as String))
@@ -206,6 +207,7 @@ class AccountPreferencesFragment : PreferenceFragmentCompat() {
                         val visibility = activeAccount.defaultReplyPrivacy
                         value = visibility.serverString
                         setIcon(getIconForVisibility(visibility))
+                        isPersistent = false // its saved to the account and shouldn't be in shared preferences
                         setOnPreferenceChangeListener { _, newValue ->
                             val newVisibility = Status.Visibility.byString(newValue as String)
                             setIcon(getIconForVisibility(newVisibility))


### PR DESCRIPTION
Without the `isPersistent = false` flag the preference is saved to SharedPreferences in addition to the account and overrides the shown value. So it would always show the value of the last account it was set to. It was working fine though, only the shown value was wrong.

https://social.sitedethib.com/@Claire/112769984398891581