### PR TITLE
remove "default" from posting defaults preference names

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -338,9 +338,9 @@
     <string name="pref_summary_http_proxy_missing">&lt;not set></string>
     <string name="pref_summary_http_proxy_invalid">&lt;invalid></string>
 
-    <string name="pref_default_post_privacy">Default post privacy (synced with server)</string>
-    <string name="pref_default_post_language">Default posting language (synced with server)</string>
-    <string name="pref_default_reply_privacy">Default reply privacy (not synced with server)</string>
+    <string name="pref_default_post_privacy">Post privacy (synced with server)</string>
+    <string name="pref_default_post_language">Posting language (synced with server)</string>
+    <string name="pref_default_reply_privacy">Reply privacy (not synced with server)</string>
     <string name="pref_default_reply_privacy_explanation">The pre-selected privacy will depend on the post you are replying to.</string>
     <string name="pref_default_media_sensitivity">Always mark media as sensitive (synced with server)</string>
     <string name="pref_match_default_post_privacy">Match default post privacy</string>


### PR DESCRIPTION
This makes the interface less cluttered and matches Mastodon. The "default" is already in the preference group title, I think this is clear enough.

Before:
![Screenshot_20240807_172653](https://github.com/user-attachments/assets/c72dde12-91b9-4c0e-b2a4-6802dfcf1925)

After:
![Screenshot_20240807_172240](https://github.com/user-attachments/assets/538c89ec-648d-4ef1-8f78-5c2cf951a039)

Mastodon:
<img width="844" alt="Screenshot 2024-08-07 at 17 21 11" src="https://github.com/user-attachments/assets/601b231e-1f94-4898-b8f3-7eaf7ebe640c">
