### PR TITLE
fix "load more" progressbar sometimes not showing up

### DIFF
--- a/app/src/main/res/layout/item_status_placeholder.xml
+++ b/app/src/main/res/layout/item_status_placeholder.xml
@@ -15,10 +15,11 @@
         android:textSize="?attr/status_text_large"
         android:textStyle="bold" />
 
-    <ProgressBar
+    <com.google.android.material.progressindicator.CircularProgressIndicator
         android:id="@+id/loadMoreProgressBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center" />
+        android:layout_gravity="center"
+        android:indeterminate="true" />
 
 </FrameLayout>


### PR DESCRIPTION
I don't know why exactly, but when the ViewHolder gets recycled and the ProgressBar is set to visible again, it just doesn't show anything. It seems to be a bug in the platform ProgressBar, and it doesn't happen on all devices. Replacing it with a CircularProgressIndicator fixes the bug and looks the same.
Reported here: https://github.com/tuskyapp/Tusky/issues/4493#issuecomment-2182407513
