### PR TITLE
fix timeline jumping around when new posts are inserted at the top

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsFragment.kt
@@ -218,6 +218,7 @@ class NotificationsFragment :
                             )
                         }
                     }
+                    loadMorePosition = null
                 }
                 if (readingOrder == ReadingOrder.OLDEST_FIRST) {
                     updateReadingPositionForOldestFirst(adapter)

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineFragment.kt
@@ -266,6 +266,8 @@ class TimelineFragment :
                             }
                         }
                     }
+                    // we loaded new posts at the top - no need to handle "load more" anymore
+                    loadMorePosition = null
                 }
                 if (readingOrder == ReadingOrder.OLDEST_FIRST) {
                     updateReadingPositionForOldestFirst(adapter)


### PR DESCRIPTION
This fixes a bug where the timeline would jump to the position of a previously clicked "load more" when new post are inserted at the top after swiping to refresh.

This only happens when "Reading order" is set to "Oldest first".

The problem is that updateReadingPositionForOldestFirst (which consumes the marker to which it should jump) is called from onItemRangeInserted. But onItemRangeInserted is not called everytime a "load more" is clicked, leaving the marker active, causing a jump the next time onItemRangeInserted is called.

I am not sure this fixes all cases of the various jumping bugs that have been reported recently as this was the only one I could reliably reproduce.

Related to https://github.com/tuskyapp/Tusky/issues/4493