### PR TITLE
Minimizes keyboard on search screen

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
@@ -106,7 +106,7 @@ class SearchActivity : BottomSheetActivity(), MenuProvider, SearchView.OnQueryTe
             searchView.clearFocus()
         }
     }
-    private fun setupClearFocusOnClickListeners(){
+    private fun setupClearFocusOnClickListeners() {
         binding.overlayPagesClickView.setOnTouchListener { view, event ->
             if (event.action == MotionEvent.ACTION_DOWN) {
                 searchView.clearFocus()

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
@@ -26,6 +26,7 @@ import android.view.MotionEvent
 import androidx.activity.viewModels
 import androidx.appcompat.widget.SearchView
 import androidx.core.view.MenuProvider
+import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import com.keylesspalace.tusky.BottomSheetActivity
 import com.keylesspalace.tusky.R
@@ -117,6 +118,17 @@ class SearchActivity : BottomSheetActivity(), MenuProvider, SearchView.OnQueryTe
         binding.toolbar.setOnClickListener {
             searchView.clearFocus()
         }
+        binding.tabs.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(p0: TabLayout.Tab?) {
+                searchView.clearFocus()
+            }
+
+            override fun onTabUnselected(p0: TabLayout.Tab?) {}
+
+            override fun onTabReselected(p0: TabLayout.Tab?) {
+                searchView.clearFocus()
+            }
+        })
     }
 
     private fun setupSearchView() {

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
@@ -22,6 +22,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
+import android.view.MotionEvent
 import androidx.activity.viewModels
 import androidx.appcompat.widget.SearchView
 import androidx.core.view.MenuProvider
@@ -82,6 +83,7 @@ class SearchActivity : BottomSheetActivity(), MenuProvider, SearchView.OnQueryTe
         searchViewMenuItem.expandActionView()
         searchView = searchViewMenuItem.actionView as SearchView
         setupSearchView()
+        setupClearFocusOnClickListeners()
     }
 
     override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
@@ -101,6 +103,18 @@ class SearchActivity : BottomSheetActivity(), MenuProvider, SearchView.OnQueryTe
         if (Intent.ACTION_SEARCH == intent.action) {
             viewModel.currentQuery = intent.getStringExtra(SearchManager.QUERY).orEmpty()
             viewModel.search(viewModel.currentQuery)
+            searchView.clearFocus()
+        }
+    }
+    private fun setupClearFocusOnClickListeners(){
+        binding.overlayPagesClickView.setOnTouchListener { view, event ->
+            if (event.action == MotionEvent.ACTION_DOWN) {
+                searchView.clearFocus()
+                view.performClick()
+            }
+            false
+        }
+        binding.toolbar.setOnClickListener {
             searchView.clearFocus()
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchActivity.kt
@@ -107,6 +107,7 @@ class SearchActivity : BottomSheetActivity(), MenuProvider, SearchView.OnQueryTe
             searchView.clearFocus()
         }
     }
+
     private fun setupClearFocusOnClickListeners() {
         binding.overlayPagesClickView.setOnTouchListener { view, event ->
             if (event.action == MotionEvent.ACTION_DOWN) {

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -38,6 +38,12 @@
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
+    <View
+        android:id="@+id/overlayPagesClickView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@android:color/transparent" />
+
     <include layout="@layout/item_status_bottom_sheet" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Adds feature if user clicks on toolbar, on the pages box, or on the tabs buttons that the keyboard will minimize and focus will be taken off of search bar.

Further addresses issue #4573 