### PR TITLE
Do not cancel the caption dialog on touches on navbar

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
@@ -84,7 +84,7 @@ class CaptionDialog : DialogFragment() {
         }
 
         isCancelable = true
-        getDialog()?.setCanceledOnTouchOutside(false) // Dialog is full screen anyway. But without this, taps in navbar while keyboard is up can dismiss the dialog.
+        dialog?.setCanceledOnTouchOutside(false) // Dialog is full screen anyway. But without this, taps in navbar while keyboard is up can dismiss the dialog.
 
         val previewUri = arguments?.getParcelableCompat<Uri>(PREVIEW_URI_ARG) ?: error("Preview Uri is null")
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
@@ -84,6 +84,7 @@ class CaptionDialog : DialogFragment() {
         }
 
         isCancelable = true
+        getDialog()?.setCanceledOnTouchOutside(false) // Dialog is full screen anyway. But without this, taps in navbar while keyboard is up can dismiss the dialog.
 
         val previewUri = arguments?.getParcelableCompat<Uri>(PREVIEW_URI_ARG) ?: error("Preview Uri is null")
 


### PR DESCRIPTION
This one is odd.
I find that if I
- Add an image to a post
- Set a caption on the image
- Tap the caption dialog to bring up the keyboard
- Tap the navbar (very easy to do by accident while typing, just tap under the spacebar)

The caption dialog disappears and you lose your caption.
(This doesn't happen in ANY other dialog in the app, and in the caption dialog it ONLY happens when the keyboard is up.)
I got a tablet and on the tablet this happens ALL THE TIME.

I was considering adding a "really cancel?" dialog to the caption dialog. But then I discovered (thank you @memorion@mastodon.social) by setting getCanceledOnTouchOutside(false), I could make the bad behavior go ahead completely. In my tests now I can only make the dialog go away by tapping the actual back button.

I believe the potential negative impact of this is low because the caption dialog is full screen, so it was already impossible to trigger the touch outside behavior on *purpose*.

I might attempt a "really cancel caption?" dialog later because it sucks to lose a long caption you have typed, but I think this fixes my personal problem by itself.