### PR TITLE
fix hidden url markup when link text contains 🔗

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -132,7 +132,7 @@ fun markupHiddenUrls(view: TextView, content: CharSequence): SpannableStringBuil
         val linkDrawableSpan = EmojiSpan(view)
         linkDrawableSpan.imageDrawable = linkDrawable
 
-        val placeholderIndex = replacementText.indexOf("🔗")
+        val placeholderIndex = originalText.length + 2
 
         spannableContent.setSpan(
             linkDrawableSpan,


### PR DESCRIPTION
Found a post that had a link that contained a 🔗 in the link text, which tripped up our algorithm.
https://toot.mirbsd.org/@fefes_blog/statuses/01J6YVRNW9C3Q6GBCWKT96CYD0

Before / After

<img src="https://github.com/user-attachments/assets/b2ce6f0c-7ae2-4351-86f9-2564252e9a62" width="280"/>
<img src="https://github.com/user-attachments/assets/589ffe6d-e57e-4c2e-bd82-b01ef178d551" width="280"/>