### PR TITLE
continue uploading media after sending post

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
@@ -97,9 +97,11 @@ class MediaUploader @Inject constructor(
     private val mediaUploadApi: MediaUploadApi
 ) {
 
-    private val uploads = mutableMapOf<Int, UploadData>()
-
-    private var mostRecentId: Int = 0
+    private companion object {
+        private const val TAG = "MediaUploader"
+        private val uploads = mutableMapOf<Int, UploadData>()
+        private var mostRecentId: Int = 0
+    }
 
     fun getNewLocalMediaId(): Int {
         return mostRecentId++
@@ -325,9 +327,5 @@ class MediaUploader @Inject constructor(
     private fun shouldResizeMedia(media: QueuedMedia, instanceInfo: InstanceInfo): Boolean {
         return media.type == QueuedMedia.Type.IMAGE &&
             (media.mediaSize > instanceInfo.imageSizeLimit || getImageSquarePixels(context.contentResolver, media.uri) > instanceInfo.imageMatrixLimit)
-    }
-
-    private companion object {
-        private const val TAG = "MediaUploader"
     }
 }


### PR DESCRIPTION
regression from https://github.com/tuskyapp/Tusky/pull/4599

https://pug.ninja/@motoridersd/113102603349423738

The problem is, `MediaUploader` is no longer a singleton, so the state is not correctly shared between `ComposeActivity` and `SendStatusService.` But it can't be a singleton, since `MediaUploadApi` (injected into `MediaUploader`) needs to be recreated on account change.
Let's share the state in the companion object instead.