### PR TITLE
revert MainActivity launchMode again

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,6 @@
             android:name=".MainActivity"
             android:configChanges="orientation|screenSize|keyboardHidden|screenLayout|smallestScreenSize"
             android:exported="true"
-            android:launchMode="singleTask"
             android:theme="@style/SplashTheme">
 
             <intent-filter>

--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -576,6 +576,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
             }
         }
         startActivity(composeIntent)
+        finish()
     }
 
     private fun setupDrawer(


### PR DESCRIPTION
This fixes
- The problem where Tusky drops your draft when you switch apps while composing
- The problem where MainActivity does not restart when switching theme in preferences

This adds back a bug where one can have multiple instances of MainActivity which can behave weirdly when the active account was switched after they were created. This bug is (unlike the timeline mixup one) transient though, it will go away when restarting the app. As a small mitigation MainActivity is finished when forwarding to ComposeActivity (Tusky 25 behavior).