### PR TITLE
remove wrong statuses attribute from Announcement model

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/entity/Announcement.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Announcement.kt
@@ -30,7 +30,6 @@ data class Announcement(
     @Json(name = "updated_at") val updatedAt: Date,
     val read: Boolean = false,
     val mentions: List<Status.Mention>,
-    val statuses: List<Status>,
     val tags: List<HashTag>,
     val emojis: List<Emoji>,
     val reactions: List<Reaction>


### PR DESCRIPTION
https://docs.joinmastodon.org/entities/Announcement/

The statuses in this model are not full statuses but we expect them, so parsing a response that contains one fails.
`com.squareup.moshi.JsonDataException: Required value 'account' missing at $[0].statuses[1]`

Since we don't even use the attribute, we can just remove it to fix the bug.

Closes #4696