### PR TITLE
include filtered notifications in the notification tab

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsRemoteMediator.kt
@@ -73,7 +73,8 @@ class NotificationsRemoteMediator(
                         // so already existing placeholders don't get accidentally overwritten
                         sinceId = topPlaceholderId,
                         limit = state.config.pageSize,
-                        excludes = excludes
+                        excludes = excludes,
+                        includeFiltered = true
                     )
 
                     val notifications = notificationResponse.body()
@@ -89,14 +90,24 @@ class NotificationsRemoteMediator(
 
             val notificationResponse = when (loadType) {
                 LoadType.REFRESH -> {
-                    api.notifications(sinceId = topPlaceholderId, limit = state.config.pageSize, excludes = excludes)
+                    api.notifications(
+                        sinceId = topPlaceholderId,
+                        limit = state.config.pageSize,
+                        excludes = excludes,
+                        includeFiltered = true
+                    )
                 }
                 LoadType.PREPEND -> {
                     return MediatorResult.Success(endOfPaginationReached = true)
                 }
                 LoadType.APPEND -> {
                     val maxId = state.pages.findLast { it.data.isNotEmpty() }?.data?.lastOrNull()?.id
-                    api.notifications(maxId = maxId, limit = state.config.pageSize, excludes = excludes)
+                    api.notifications(
+                        maxId = maxId,
+                        limit = state.config.pageSize,
+                        excludes = excludes,
+                        includeFiltered = true
+                    )
                 }
             }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
@@ -303,7 +303,8 @@ class NotificationsViewModel @Inject constructor(
                             maxId = idAbovePlaceholder,
                             minId = idBelowPlaceholder,
                             limit = TimelineViewModel.LOAD_AT_ONCE,
-                            excludes = excludes.value
+                            excludes = excludes.value,
+                            includeFiltered = true
                         )
                         // Using sinceId, loads up to LOAD_AT_ONCE statuses immediately before
                         // maxId, and no smaller than minId.
@@ -311,7 +312,8 @@ class NotificationsViewModel @Inject constructor(
                             maxId = idAbovePlaceholder,
                             sinceId = idBelowPlaceholder,
                             limit = TimelineViewModel.LOAD_AT_ONCE,
-                            excludes = excludes.value
+                            excludes = excludes.value,
+                            includeFiltered = true
                         )
                     }
                 }

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -149,7 +149,7 @@ interface MastodonApi {
         @Query("limit") limit: Int? = null,
         /** Types to excludes from the results */
         @Query("exclude_types[]") excludes: Set<Notification.Type>? = null,
-        @Query("include_filtered") includeFiltered: Boolean
+        @Query("include_filtered") includeFiltered: Boolean = true
     ): Response<List<Notification>>
 
     /** Fetch a single notification */

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -148,7 +148,8 @@ interface MastodonApi {
         /** Maximum number of results to return. Defaults to 15, max is 30 */
         @Query("limit") limit: Int? = null,
         /** Types to excludes from the results */
-        @Query("exclude_types[]") excludes: Set<Notification.Type>? = null
+        @Query("exclude_types[]") excludes: Set<Notification.Type>? = null,
+        @Query("include_filtered") includeFiltered: Boolean
     ): Response<List<Notification>>
 
     /** Fetch a single notification */

--- a/app/src/test/java/com/keylesspalace/tusky/components/notifications/NotificationsRemoteMediatorTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/notifications/NotificationsRemoteMediatorTest.kt
@@ -80,7 +80,7 @@ class NotificationsRemoteMediatorTest {
         val remoteMediator = NotificationsRemoteMediator(
             accountManager = accountManager,
             api = mock {
-                onBlocking { notifications(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doReturn Response.error(500, "".toResponseBody())
+                onBlocking { notifications(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doReturn Response.error(500, "".toResponseBody())
             },
             db = db,
             excludes = emptySet()
@@ -99,7 +99,7 @@ class NotificationsRemoteMediatorTest {
         val remoteMediator = NotificationsRemoteMediator(
             accountManager = accountManager,
             api = mock {
-                onBlocking { notifications(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doThrow IOException()
+                onBlocking { notifications(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()) } doThrow IOException()
             },
             db = db,
             excludes = emptySet()


### PR DESCRIPTION
This is a quick workaround to have Tusky behave the same on Mastodon 4.2 and 4.3 instances: All notifications are shown. This should prevent confusion for users that are using mostly Tusky.

Note, I'm also working on full support for filtered notifications, but that will still take a while.