### PR TITLE
only run one test deployment at once

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - develop
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   check-and-build:
     uses: ./.github/workflows/check-and-build.yml
@@ -23,7 +27,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Set versionsCode
+      - name: Set versionCode
         run: |
           export VERSION_CODE=$(( ${BUILD_NUMBER} + 11000 ))
           sed -i'.original' -e "s/^\([[:space:]]*versionCode[[:space:]]*\)[0-9]*/\\1$VERSION_CODE/" app/build.gradle


### PR DESCRIPTION
When merging a bunch of PRs at once, it is enough if the newest one gets deployed.