### PR TITLE
fix crash when loading card images with unusual aspect ratio

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -1186,8 +1186,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                 cardImage.setScaleType(ImageView.ScaleType.CENTER_CROP);
 
                 RequestBuilder<Drawable> builder = Glide.with(cardImage.getContext())
-                    .load(card.getImage())
-                    .dontTransform();
+                    .load(card.getImage());
                 if (statusDisplayOptions.useBlurhash() && !TextUtils.isEmpty(card.getBlurhash())) {
                     builder = builder.placeholder(decodeBlurHash(card.getBlurhash()));
                 }
@@ -1213,7 +1212,6 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
                 Glide.with(cardImage.getContext())
                     .load(decodeBlurHash(card.getBlurhash()))
-                    .dontTransform()
                     .into(cardImage);
             } else {
                 cardView.setOrientation(LinearLayout.HORIZONTAL);


### PR DESCRIPTION
closes https://github.com/tuskyapp/Tusky/issues/4725

I checked with examples from https://github.com/tuskyapp/Tusky/pull/2743 and looks like nothing broke. Not sure why the `.dontTransform()` was there. It prevents Glide from correctly sizing the image, leading to a crash.

<details>
<summary>Stacktrace</summary>

```
java.lang.RuntimeException: Canvas: trying to draw too large(401361624bytes) bitmap.
    at android.graphics.RecordingCanvas.throwIfCannotDraw(RecordingCanvas.java:266)
    at android.graphics.BaseRecordingCanvas.drawBitmap(BaseRecordingCanvas.java:94)
    at android.graphics.drawable.BitmapDrawable.draw(BitmapDrawable.java:549)
    at android.widget.ImageView.onDraw(ImageView.java:1446)
    at com.google.android.material.imageview.ShapeableImageView.onDraw(ShapeableImageView.java:188)
    at android.view.View.draw(View.java:23266)
    at android.view.View.updateDisplayListIfDirty(View.java:22133)
    at android.view.View.draw(View.java:22997)
    at android.view.ViewGroup.drawChild(ViewGroup.java:4529)
    at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4290)
    at android.view.View.draw(View.java:23269)
    at android.view.View.updateDisplayListIfDirty(View.java:22133)
    at android.view.View.draw(View.java:22997)
    at android.view.ViewGroup.drawChild(ViewGroup.java:4529)
    at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4290)
    at androidx.constraintlayout.widget.ConstraintLayout.dispatchDraw(ConstraintLayout.java:1994)
    at android.view.View.updateDisplayListIfDirty(View.java:22124)
    at android.view.View.draw(View.java:22997)
    at android.view.ViewGroup.drawChild(ViewGroup.java:4529)
    at androidx.recyclerview.widget.RecyclerView.drawChild(RecyclerView.java:5545)
    at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4290)
    at android.view.View.draw(View.java:23269)
    at androidx.recyclerview.widget.RecyclerView.draw(RecyclerView.java:4944)
    at android.view.View.updateDisplayListIfDirty(View.java:22133)
    at android.view.View.draw(View.java:22997)
    at android.view.ViewGroup.drawChild(ViewGroup.java:4529)
    at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4290)
    at android.view.View.updateDisplayListIfDirty(View.java:22124)
    at android.view.View.draw(View.java:22997)
    at android.view.ViewGroup.drawChild(ViewGroup.java:4529)
    at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4290)
    at android.view.View.draw(View.java:23269)
    at android.view.View.updateDisplayListIfDirty(View.java:22133)
    at android.view.View.draw(View.java:22997)
    at android.view.ViewGroup.drawChild(ViewGroup.java:4529)
    at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4290)
    at android.view.View.updateDisplayListIfDirty(View.java:22124)
    at android.view.View.draw(View.java:22997)
    at android.view.ViewGroup.drawChild(ViewGroup.java:4529)
    at androidx.coordinatorlayout.widget.CoordinatorLayout.drawChild(CoordinatorLayout.java:1277)
    at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4290)
    at android.view.View.updateDisplayListIfDirty(View.java:22124)
    at android.view.View.draw(View.java:22997)
    at android.view.ViewGroup.drawChild(ViewGroup.java:4529)
    at androidx.fragment.app.FragmentContainerView.drawChild(FragmentContainerView.kt:232)
    at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4290)
    at androidx.fragment.app.FragmentContainerView.dispatchDraw(FragmentContainerView.kt:222)
    at android.view.View.updateDisplayListIfDirty(View.java:22124)
    at android.view.View.draw(View.java:22997)
    at android.view.ViewGroup.drawChild(ViewGroup.java:4529)
    at androidx.coordinatorlayout.widget.CoordinatorLayout.drawChild(CoordinatorLayout.java:1277)
    at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4290)
    at android.view.View.updateDisplayListIfDirty(View.java:22124)
    at android.view.View.draw(View.java:22997)
    at android.view.ViewGroup.drawChild(ViewGroup.java:4529)
    at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4290)
    at android.view.View.updateDisplayListIfDirty(View.java:22124)
    at android.view.View.draw(View.java:22997)
    at android.view.ViewGroup.drawChild(ViewGroup.java:4529)
    at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4290)
    at android.view.View.updateDisplayListIfDirty(View.java:22124)
    at android.view.View.draw(View.java:22997)
    at android.view.ViewGroup.drawChild(ViewGroup.java:4529)
    at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4290)
    at android.view.View.updateDisplayListIfDirty(View.java:22124)
    at android.view.View.draw(View.java:22997)
    at android.view.ViewGroup.drawChild(ViewGroup.java:4529)
    at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4290)
    at android.view.View.updateDisplayListIfDirty(View.java:22124)
    at android.view.View.draw(View.java:22997)
    at android.view.ViewGroup.drawChild(ViewGroup.java:4529)
    at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4290)
    at android.view.View.draw(View.java:23269)
    at com.android.internal.policy.DecorView.draw(DecorView.java:821)
    at android.view.View.updateDisplayListIfDirty(View.java:22133)
    at android.view.ThreadedRenderer.updateViewTreeDisplayList(ThreadedRenderer.java:689)
    at android.view.ThreadedRenderer.updateRootDisplayList(ThreadedRenderer.java:695)
    at android.view.ThreadedRenderer.draw(ThreadedRenderer.java:793)
    at android.view.ViewRootImpl.draw(ViewRootImpl.java:4789)
    at android.view.ViewRootImpl.performDraw(ViewRootImpl.java:4500)
    at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:3687)
    at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:2371)
    at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:9297)
    at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1231)
    at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1239)
    at android.view.Choreographer.doCallbacks(Choreographer.java:899)
    at android.view.Choreographer.doFrame(Choreographer.java:832)
    at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1214)
    at android.os.Handler.handleCallback(Handler.java:942)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:201)
    at android.os.Looper.loop(Looper.java:288)
    at android.app.ActivityThread.main(ActivityThread.java:7924)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```
</details>