### PR TITLE
never filter own posts

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
@@ -153,6 +153,9 @@ class NotificationsViewModel @Inject constructor(
         return when ((notificationViewData as? NotificationViewData.Concrete)?.type) {
             Notification.Type.MENTION, Notification.Type.POLL -> {
                 notificationViewData.statusViewData?.let { statusViewData ->
+                    if (statusViewData.status.account.id == account.accountId) {
+                        return Filter.Action.NONE
+                    }
                     statusViewData.filterAction = filterModel.shouldFilterStatus(statusViewData.actionable)
                     return statusViewData.filterAction
                 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -76,8 +76,6 @@ class CachedTimelineViewModel @Inject constructor(
     filterModel
 ) {
 
-    private val account = accountManager.activeAccount!!
-
     private var currentPagingSource: PagingSource<Int, HomeTimelineData>? = null
 
     /** Map from status id to translation. */

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -304,11 +304,8 @@ class NetworkTimelineViewModel @Inject constructor(
     }
 
     override fun clearWarning(status: StatusViewData.Concrete) {
-        updateStatusByActionableId(status.id) {
-            it.copy(
-                filtered = emptyList(),
-                reblog = status.status.reblog?.copy(filtered = emptyList())
-            )
+        updateStatusByActionableId(status.actionableId) {
+            it.copy(filtered = emptyList())
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -305,7 +305,10 @@ class NetworkTimelineViewModel @Inject constructor(
 
     override fun clearWarning(status: StatusViewData.Concrete) {
         updateStatusByActionableId(status.id) {
-            it.copy(filtered = emptyList())
+            it.copy(
+                filtered = emptyList(),
+                reblog = status.status.reblog?.copy(filtered = emptyList())
+            )
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
@@ -46,6 +46,8 @@ abstract class TimelineViewModel(
     private val filterModel: FilterModel
 ) : ViewModel() {
 
+    protected val account = accountManager.activeAccount!!
+
     abstract val statuses: Flow<PagingData<StatusViewData>>
 
     var kind: Kind = Kind.HOME
@@ -179,6 +181,10 @@ abstract class TimelineViewModel(
 
     protected fun shouldFilterStatus(statusViewData: StatusViewData): Filter.Action {
         val status = statusViewData.asStatusOrNull()?.status ?: return Filter.Action.NONE
+        if (status.actionableStatus.account.id == account.accountId) {
+            // never filter own posts
+            return Filter.Action.NONE
+        }
         return if (
             (status.inReplyToId != null && filterRemoveReplies) ||
             (status.reblog != null && filterRemoveReblogs) ||


### PR DESCRIPTION
This is to match Mastodon web behavior.

Also, make revealing filtered boosts in non-cached timelines work (can only happen on user profiles, other timelines don't have boosts).

found thanks to this: https://tech.lgbt/@darkfox/113378644538792719