### PR TITLE
fix updating filter expiration to indefinite

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/StatusListActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/StatusListActivity.kt
@@ -28,6 +28,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.keylesspalace.tusky.appstore.EventHub
 import com.keylesspalace.tusky.appstore.FilterUpdatedEvent
 import com.keylesspalace.tusky.components.filters.EditFilterActivity
+import com.keylesspalace.tusky.components.filters.FilterExpiration
 import com.keylesspalace.tusky.components.filters.FiltersActivity
 import com.keylesspalace.tusky.components.timeline.TimelineFragment
 import com.keylesspalace.tusky.components.timeline.viewmodel.TimelineViewModel.Kind
@@ -251,7 +252,7 @@ class StatusListActivity : BottomSheetActivity() {
                 title = "#$tag",
                 context = listOf(Filter.Kind.HOME.kind),
                 filterAction = Filter.Action.WARN.action,
-                expiresInSeconds = null
+                expiresIn = FilterExpiration.never
             ).fold(
                 { filter ->
                     if (mastodonApi.addFilterKeyword(
@@ -281,7 +282,7 @@ class StatusListActivity : BottomSheetActivity() {
                             listOf(Filter.Kind.HOME.kind),
                             irreversible = false,
                             wholeWord = true,
-                            expiresInSeconds = null
+                            expiresIn = FilterExpiration.never
                         ).fold(
                             { filter ->
                                 mutedFilterV1 = filter
@@ -358,7 +359,7 @@ class StatusListActivity : BottomSheetActivity() {
                             context = filter.context.filter { it != Filter.Kind.HOME.kind },
                             irreversible = null,
                             wholeWord = null,
-                            expiresInSeconds = null
+                            expiresIn = FilterExpiration.never
                         )
                     } else {
                         mastodonApi.deleteFilterV1(filter.id)

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
@@ -137,6 +137,7 @@ class EditFilterActivity : BaseActivity() {
 
         if (originalFilter == null) {
             binding.filterActionWarn.isChecked = true
+            initializeDurationDropDown(false)
         } else {
             loadFilter()
         }
@@ -178,7 +179,11 @@ class EditFilterActivity : BaseActivity() {
     // Populate the UI from the filter's members
     private fun loadFilter() {
         viewModel.load(filter)
-        val durationNames = if (filter.expiresAt != null) {
+        initializeDurationDropDown(withNoChange = filter.expiresAt != null)
+    }
+
+    private fun initializeDurationDropDown(withNoChange: Boolean) {
+        val durationNames = if (withNoChange) {
             arrayOf(getString(R.string.duration_no_change)) + resources.getStringArray(R.array.filter_duration_names)
         } else {
             resources.getStringArray(R.array.filter_duration_names)

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
@@ -1,6 +1,20 @@
+/* Copyright 2024 Tusky contributors
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>. */
+
 package com.keylesspalace.tusky.components.filters
 
-import android.content.Context
 import android.content.DialogInterface.BUTTON_POSITIVE
 import android.os.Bundle
 import android.view.WindowManager
@@ -28,7 +42,6 @@ import com.keylesspalace.tusky.util.isHttpNotFound
 import com.keylesspalace.tusky.util.viewBinding
 import com.keylesspalace.tusky.util.visible
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.Date
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 
@@ -322,19 +335,5 @@ class EditFilterActivity : BaseActivity() {
 
     companion object {
         const val FILTER_TO_EDIT = "FilterToEdit"
-
-        // Mastodon *stores* the absolute date in the filter,
-        // but create/edit take a number of seconds (relative to the time the operation is posted)
-        fun getSecondsForDurationIndex(index: Int, context: Context?, default: Date? = null): Int? {
-            return when (index) {
-                -1 -> if (default == null) {
-                    default
-                } else {
-                    ((default.time - System.currentTimeMillis()) / 1000).toInt()
-                }
-                0 -> null
-                else -> context?.resources?.getIntArray(R.array.filter_duration_values)?.get(index)
-            }
-        }
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterViewModel.kt
@@ -235,14 +235,9 @@ class EditFilterViewModel @Inject constructor(val api: MastodonApi) : ViewModel(
     companion object {
         // Mastodon *stores* the absolute date in the filter,
         // but create/edit take a number of seconds (relative to the time the operation is posted)
-        @VisibleForTesting
-        fun getExpirationForDurationIndex(index: Int, context: Context, default: Date? = null): FilterExpiration? {
+        private fun getExpirationForDurationIndex(index: Int, context: Context): FilterExpiration? {
             return when (index) {
-                -1 -> if (default == null) {
-                    FilterExpiration.unchanged
-                } else {
-                    FilterExpiration.seconds(((default.time - System.currentTimeMillis()) / 1000).toInt())
-                }
+                -1 -> FilterExpiration.unchanged
                 0 -> FilterExpiration.never
                 else -> FilterExpiration.seconds(
                     context.resources.getIntArray(R.array.filter_duration_values)[index]

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterViewModel.kt
@@ -16,7 +16,6 @@
 package com.keylesspalace.tusky.components.filters
 
 import android.content.Context
-import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.connyduck.calladapter.networkresult.fold
@@ -26,7 +25,6 @@ import com.keylesspalace.tusky.entity.FilterKeyword
 import com.keylesspalace.tusky.network.MastodonApi
 import com.keylesspalace.tusky.util.isHttpNotFound
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.util.Date
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterViewModel.kt
@@ -16,6 +16,7 @@
 package com.keylesspalace.tusky.components.filters
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.connyduck.calladapter.networkresult.fold
@@ -234,7 +235,8 @@ class EditFilterViewModel @Inject constructor(val api: MastodonApi) : ViewModel(
     companion object {
         // Mastodon *stores* the absolute date in the filter,
         // but create/edit take a number of seconds (relative to the time the operation is posted)
-        private fun getExpirationForDurationIndex(index: Int, context: Context, default: Date? = null): FilterExpiration? {
+        @VisibleForTesting
+        fun getExpirationForDurationIndex(index: Int, context: Context, default: Date? = null): FilterExpiration? {
             return when (index) {
                 -1 -> if (default == null) {
                     FilterExpiration.unchanged

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/FilterExpiration.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/FilterExpiration.kt
@@ -1,0 +1,39 @@
+/* Copyright 2024 Tusky contributors
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>. */
+
+package com.keylesspalace.tusky.components.filters;
+
+import kotlin.jvm.JvmInline;
+
+/**
+ * Custom class to have typesafety for filter expirations.
+ * Retrofit will call toString when sending this class as part of a form-urlencoded body.
+ */
+@JvmInline
+value class FilterExpiration private constructor(val seconds: Int) {
+
+    override fun toString(): String {
+        return if(seconds < 0) "" else seconds.toString()
+    }
+
+    companion object {
+        val unchanged: FilterExpiration?
+            get() = null
+        val never: FilterExpiration
+            get() = FilterExpiration(-1)
+
+        fun seconds(seconds: Int): FilterExpiration = FilterExpiration(seconds)
+    }
+}

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/FilterExpiration.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/FilterExpiration.kt
@@ -13,9 +13,9 @@
  * You should have received a copy of the GNU General Public License along with Tusky; if not,
  * see <http://www.gnu.org/licenses>. */
 
-package com.keylesspalace.tusky.components.filters;
+package com.keylesspalace.tusky.components.filters
 
-import kotlin.jvm.JvmInline;
+import kotlin.jvm.JvmInline
 
 /**
  * Custom class to have typesafety for filter expirations.
@@ -25,7 +25,7 @@ import kotlin.jvm.JvmInline;
 value class FilterExpiration private constructor(val seconds: Int) {
 
     override fun toString(): String {
-        return if(seconds < 0) "" else seconds.toString()
+        return if (seconds < 0) "" else seconds.toString()
     }
 
     companion object {

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/FilterExpiration.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/FilterExpiration.kt
@@ -29,10 +29,8 @@ value class FilterExpiration private constructor(val seconds: Int) {
     }
 
     companion object {
-        val unchanged: FilterExpiration?
-            get() = null
-        val never: FilterExpiration
-            get() = FilterExpiration(-1)
+        val unchanged: FilterExpiration? = null
+        val never: FilterExpiration = FilterExpiration(-1)
 
         fun seconds(seconds: Int): FilterExpiration = FilterExpiration(seconds)
     }

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -16,6 +16,7 @@
 package com.keylesspalace.tusky.network
 
 import at.connyduck.calladapter.networkresult.NetworkResult
+import com.keylesspalace.tusky.components.filters.FilterExpiration
 import com.keylesspalace.tusky.entity.AccessToken
 import com.keylesspalace.tusky.entity.Account
 import com.keylesspalace.tusky.entity.Announcement
@@ -540,7 +541,7 @@ interface MastodonApi {
         @Field("context[]") context: List<String>,
         @Field("irreversible") irreversible: Boolean?,
         @Field("whole_word") wholeWord: Boolean?,
-        @Field("expires_in") expiresInSeconds: Int?
+        @Field("expires_in") expiresIn: FilterExpiration?
     ): NetworkResult<FilterV1>
 
     @FormUrlEncoded
@@ -551,7 +552,7 @@ interface MastodonApi {
         @Field("context[]") context: List<String>,
         @Field("irreversible") irreversible: Boolean?,
         @Field("whole_word") wholeWord: Boolean?,
-        @Field("expires_in") expiresInSeconds: Int?
+        @Field("expires_in") expiresIn: FilterExpiration?
     ): NetworkResult<FilterV1>
 
     @DELETE("api/v1/filters/{id}")
@@ -563,7 +564,7 @@ interface MastodonApi {
         @Field("title") title: String,
         @Field("context[]") context: List<String>,
         @Field("filter_action") filterAction: String,
-        @Field("expires_in") expiresInSeconds: Int?
+        @Field("expires_in") expiresIn: FilterExpiration?
     ): NetworkResult<Filter>
 
     @FormUrlEncoded
@@ -573,7 +574,7 @@ interface MastodonApi {
         @Field("title") title: String? = null,
         @Field("context[]") context: List<String>? = null,
         @Field("filter_action") filterAction: String? = null,
-        @Field("expires_in") expiresInSeconds: Int? = null
+        @Field("expires_in") expires: FilterExpiration? = null
     ): NetworkResult<Filter>
 
     @DELETE("api/v2/filters/{id}")

--- a/app/src/test/java/com/keylesspalace/tusky/FilterV1Test.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/FilterV1Test.kt
@@ -20,7 +20,6 @@ package com.keylesspalace.tusky
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import at.connyduck.calladapter.networkresult.NetworkResult
-import com.keylesspalace.tusky.components.filters.EditFilterViewModel
 import com.keylesspalace.tusky.components.instanceinfo.InstanceInfoRepository
 import com.keylesspalace.tusky.entity.Attachment
 import com.keylesspalace.tusky.entity.Filter
@@ -47,8 +46,6 @@ import retrofit2.Response
 @Config(sdk = [28])
 @RunWith(AndroidJUnit4::class)
 class FilterV1Test {
-
-    private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
     private lateinit var filterModel: FilterModel
 

--- a/app/src/test/java/com/keylesspalace/tusky/FilterV1Test.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/FilterV1Test.kt
@@ -18,7 +18,6 @@
 package com.keylesspalace.tusky
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import at.connyduck.calladapter.networkresult.NetworkResult
 import com.keylesspalace.tusky.components.instanceinfo.InstanceInfoRepository
 import com.keylesspalace.tusky.entity.Attachment

--- a/app/src/test/java/com/keylesspalace/tusky/FilterV1Test.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/FilterV1Test.kt
@@ -20,7 +20,6 @@ package com.keylesspalace.tusky
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import at.connyduck.calladapter.networkresult.NetworkResult
-import com.keylesspalace.tusky.components.filters.EditFilterActivity
 import com.keylesspalace.tusky.components.filters.EditFilterViewModel
 import com.keylesspalace.tusky.components.instanceinfo.InstanceInfoRepository
 import com.keylesspalace.tusky.entity.Attachment

--- a/app/src/test/java/com/keylesspalace/tusky/FilterV1Test.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/FilterV1Test.kt
@@ -18,8 +18,10 @@
 package com.keylesspalace.tusky
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import at.connyduck.calladapter.networkresult.NetworkResult
 import com.keylesspalace.tusky.components.filters.EditFilterActivity
+import com.keylesspalace.tusky.components.filters.EditFilterViewModel
 import com.keylesspalace.tusky.components.instanceinfo.InstanceInfoRepository
 import com.keylesspalace.tusky.entity.Attachment
 import com.keylesspalace.tusky.entity.Filter
@@ -46,6 +48,8 @@ import retrofit2.Response
 @Config(sdk = [28])
 @RunWith(AndroidJUnit4::class)
 class FilterV1Test {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
 
     private lateinit var filterModel: FilterModel
 
@@ -281,16 +285,16 @@ class FilterV1Test {
     fun unchangedExpiration_shouldBeNegative_whenFilterIsExpired() {
         val expiredBySeconds = 3600
         val expiredDate = Date.from(Instant.now().minusSeconds(expiredBySeconds.toLong()))
-        val updatedDuration = EditFilterActivity.getSecondsForDurationIndex(-1, null, expiredDate)
-        assert(updatedDuration != null && updatedDuration <= -expiredBySeconds)
+        val updatedDuration = EditFilterViewModel.getExpirationForDurationIndex(-1, context, expiredDate)
+        assert(updatedDuration != null && updatedDuration.seconds <= -expiredBySeconds)
     }
 
     @Test
     fun unchangedExpiration_shouldBePositive_whenFilterIsUnexpired() {
         val expiresInSeconds = 3600
         val expiredDate = Date.from(Instant.now().plusSeconds(expiresInSeconds.toLong()))
-        val updatedDuration = EditFilterActivity.getSecondsForDurationIndex(-1, null, expiredDate)
-        assert(updatedDuration != null && updatedDuration > (expiresInSeconds - 60))
+        val updatedDuration = EditFilterViewModel.getExpirationForDurationIndex(-1, context, expiredDate)
+        assert(updatedDuration != null && updatedDuration.seconds > (expiresInSeconds - 60))
     }
 
     companion object {

--- a/app/src/test/java/com/keylesspalace/tusky/FilterV1Test.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/FilterV1Test.kt
@@ -280,22 +280,6 @@ class FilterV1Test {
         )
     }
 
-    @Test
-    fun unchangedExpiration_shouldBeNegative_whenFilterIsExpired() {
-        val expiredBySeconds = 3600
-        val expiredDate = Date.from(Instant.now().minusSeconds(expiredBySeconds.toLong()))
-        val updatedDuration = EditFilterViewModel.getExpirationForDurationIndex(-1, context, expiredDate)
-        assert(updatedDuration != null && updatedDuration.seconds <= -expiredBySeconds)
-    }
-
-    @Test
-    fun unchangedExpiration_shouldBePositive_whenFilterIsUnexpired() {
-        val expiresInSeconds = 3600
-        val expiredDate = Date.from(Instant.now().plusSeconds(expiresInSeconds.toLong()))
-        val updatedDuration = EditFilterViewModel.getExpirationForDurationIndex(-1, context, expiredDate)
-        assert(updatedDuration != null && updatedDuration.seconds > (expiresInSeconds - 60))
-    }
-
     companion object {
         fun mockStatus(
             content: String = "",


### PR DESCRIPTION
Before we would not send `expires_in` when "indefinite" was selected. But that left the expiration at the value it was before. To actually set it to indefinite we need to send `expires_in`, but leave it empty.
With a value class this was actually really nice to fix, the code now self-documents what the special values mean.

Also fixes a regression from the Material 3 redesign where the filter duration drop down would not get populated when creating a filter.

Found while working on https://github.com/tuskyapp/Tusky/pull/4742