### PR TITLE
fix link preview images

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -1190,7 +1190,8 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                 if (statusDisplayOptions.useBlurhash() && !TextUtils.isEmpty(card.getBlurhash())) {
                     builder = builder.placeholder(decodeBlurHash(card.getBlurhash()));
                 }
-                builder.into(cardImage);
+                builder.centerInside()
+                  .into(cardImage);
             } else if (statusDisplayOptions.useBlurhash() && !TextUtils.isEmpty(card.getBlurhash())) {
                 int radius = cardImage.getContext().getResources()
                     .getDimensionPixelSize(R.dimen.card_radius);


### PR DESCRIPTION
Before (sometimes) vs after:

<img src="https://github.com/user-attachments/assets/baeff1b8-c1ea-4102-bb4d-f8b2063d0972" width="240"/> <img src="https://github.com/user-attachments/assets/748618d3-4eaf-4428-8a7c-c1314d156f66" width="240"/>

I'm not sure what is going on here, Glide is being weird sometimes and this change fixes it.

Regression from https://github.com/tuskyapp/Tusky/pull/4738
