### PR TITLE
set the correct height to the main bottom app bar

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -63,7 +63,7 @@
         <com.google.android.material.bottomappbar.BottomAppBar
             android:id="@+id/bottomNav"
             android:layout_width="match_parent"
-            android:layout_height="58dp"
+            android:layout_height="?attr/actionBarSize"
             android:layout_gravity="bottom"
             android:backgroundTint="?attr/colorSurface"
             app:contentInsetStart="0dp"


### PR DESCRIPTION
Before there was a weird gap when the bar was set to bottom & and the title bar was hidden.
![Screenshot_20241115_140918](https://github.com/user-attachments/assets/23a7b71f-dff8-4f40-ad7f-9cce5c23755f)
