### PR TITLE
Simplify hashtag line checker to avoid infinite loop in android matcher

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -119,9 +119,8 @@ fun setClickableText(
     }
 }
 
-private val trailingHashtagExpression by unsafeLazy {
-    Pattern.compile("""$WORD_BREAK_EXPRESSION(#$HASHTAG_EXPRESSION$WORD_BREAK_FROM_SPACE_EXPRESSION+)*""", Pattern.CASE_INSENSITIVE)
-}
+private val hashtagWithHashPattern = Pattern.compile("^#$HASHTAG_EXPRESSION$")
+private val whitespacePattern = Pattern.compile("""\s+""")
 
 /**
  * Find the "trailing" hashtags in spanned content
@@ -131,7 +130,7 @@ private val trailingHashtagExpression by unsafeLazy {
 internal fun getTrailingHashtags(content: Spanned): Pair<Int, List<HashTag>> {
     // split() instead of lines() because we need to be able to account for the length of the removed delimiter
     val trailingContentLength = content.split('\r', '\n').asReversed().takeWhile { line ->
-        line.isBlank() || trailingHashtagExpression.matcher(line).matches()
+        line.split(whitespacePattern).all { it.isBlank() || hashtagWithHashPattern.matcher(it).matches() }
     }.sumOf { it.length + 1 } // length + 1 to include the stripped line ending character
 
     return when (trailingContentLength) {

--- a/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/LinkHelper.kt
@@ -120,7 +120,7 @@ fun setClickableText(
 }
 
 private val hashtagWithHashPattern = Pattern.compile("^#$HASHTAG_EXPRESSION$")
-private val whitespacePattern = Pattern.compile("""\s+""")
+private val whitespacePattern = Regex("""\s+""")
 
 /**
  * Find the "trailing" hashtags in spanned content
@@ -130,7 +130,7 @@ private val whitespacePattern = Pattern.compile("""\s+""")
 internal fun getTrailingHashtags(content: Spanned): Pair<Int, List<HashTag>> {
     // split() instead of lines() because we need to be able to account for the length of the removed delimiter
     val trailingContentLength = content.split('\r', '\n').asReversed().takeWhile { line ->
-        line.split(whitespacePattern).all { it.isBlank() || hashtagWithHashPattern.matcher(it).matches() }
+        line.splitToSequence(whitespacePattern).all { it.isBlank() || hashtagWithHashPattern.matcher(it).matches() }
     }.sumOf { it.length + 1 } // length + 1 to include the stripped line ending character
 
     return when (trailingContentLength) {

--- a/app/src/main/java/com/keylesspalace/tusky/util/StringUtils.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/StringUtils.kt
@@ -8,8 +8,6 @@ import kotlin.random.Random
 
 private const val POSSIBLE_CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-const val WORD_BREAK_EXPRESSION = """(^|$|[^\p{L}\p{N}_])"""
-const val WORD_BREAK_FROM_SPACE_EXPRESSION = """(^|$|\s)"""
 const val HASHTAG_EXPRESSION = "([\\w_]*[\\p{Alpha}_][\\w_]*)"
 val hashtagPattern = Pattern.compile(HASHTAG_EXPRESSION, Pattern.CASE_INSENSITIVE or Pattern.MULTILINE)
 


### PR DESCRIPTION
https://masto.nyc/@GetMisch/113557332197065306 causes an infinite loop in the native matcher with the original pattern, trying a different approach