### PR TITLE
fix thread view background on tablets

### DIFF
--- a/app/src/main/res/layout-sw640dp/fragment_view_thread.xml
+++ b/app/src/main/res/layout-sw640dp/fragment_view_thread.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="?attr/windowBackgroundColor">
 
     <com.keylesspalace.tusky.view.TuskySwipeRefreshLayout
         android:id="@+id/swipeRefreshLayout"


### PR DESCRIPTION
So it matches the rest of the app

Before / after


<img src="https://github.com/user-attachments/assets/63b8a663-8b03-4e5f-850a-a9d1a4229f99" width="280"/> <img src="https://github.com/user-attachments/assets/86d70e1e-7f73-4274-8b09-6b90a9598a7a" width="280"/>