### PR TITLE
fix background of bottom tab bar

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -33,9 +33,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="48dp"
                 android:orientation="horizontal"
-                app:contentInsetStart="0dp"
                 android:paddingLeft="0dp"
                 android:paddingRight="0dp"
+                app:contentInsetStart="0dp"
                 app:contentInsetStartWithNavigation="0dp"
                 app:navigationContentDescription="@string/action_open_drawer">
 
@@ -78,6 +78,7 @@
                 style="@style/TuskyTabAppearance"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
+                android:background="?attr/colorSurface"
                 app:tabGravity="fill"
                 app:tabIndicatorGravity="top"
                 app:tabMode="scrollable"


### PR DESCRIPTION
`TabLayout` with Material 3 styling has a thin line at the bottom. That makes sense when it is above the scrollable content, but not when it is below.

Before:
![before](https://github.com/user-attachments/assets/619f125b-c817-4615-b6b6-29c885c90723)

After:
![after](https://github.com/user-attachments/assets/3b22d183-c844-4859-9bf8-d530f63cf97e)
