### PR TITLE
rotate tab indicator when tab bar is at the bottom

### DIFF
--- a/app/src/main/res/drawable/tab_indicator_bottom.xml
+++ b/app/src/main/res/drawable/tab_indicator_bottom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+  <item
+      android:left="2dp"
+      android:right="2dp">
+    <shape
+        android:shape="rectangle">
+      <!-- Color is assigned programmatically with the value of "tabIndicatorColor". -->
+      <solid android:color="@android:color/white"/>
+      <corners
+          android:bottomLeftRadius="3dp"
+          android:bottomRightRadius="3dp"
+          android:topLeftRadius="0dp"
+          android:topRightRadius="0dp"/>
+      <size android:height="3dp"/>
+    </shape>
+  </item>
+</layer-list>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -80,6 +80,7 @@
                 android:layout_height="?attr/actionBarSize"
                 app:tabGravity="fill"
                 app:tabIndicatorGravity="top"
+                app:tabIndicator="@drawable/tab_indicator_bottom"
                 app:tabMode="scrollable"
                 app:tabPaddingTop="0dp" />
 


### PR DESCRIPTION
Looks way better imho

Before
![before](https://github.com/user-attachments/assets/5888e2ee-c342-4b06-a834-50f9d07951b4)


After
![after](https://github.com/user-attachments/assets/024e0c98-1e0a-4a4d-82f7-a7ede657ad25)
