### PR TITLE
fix caption dialog

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
@@ -130,7 +130,7 @@ class CaptionDialog : DialogFragment() {
         dialog?.apply {
             window?.setLayout(
                 LinearLayout.LayoutParams.MATCH_PARENT,
-                LinearLayout.LayoutParams.MATCH_PARENT
+                LinearLayout.LayoutParams.WRAP_CONTENT
             )
             window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
         }

--- a/app/src/main/res/layout/dialog_image_description.xml
+++ b/app/src/main/res/layout/dialog_image_description.xml
@@ -36,7 +36,6 @@
             android:gravity="start"
             android:importantForAutofill="no"
             android:inputType="textCapSentences|textMultiLine|textAutoCorrect"
-            android:lines="4"
             tools:hint="Description" />
 
     </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/layout/dialog_image_description.xml
+++ b/app/src/main/res/layout/dialog_image_description.xml
@@ -3,14 +3,17 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingBottom="0dp">
+    android:layout_height="wrap_content"
+    android:minHeight="400dp"
+    android:orientation="vertical">
 
     <com.ortiz.touchview.TouchImageView
         android:id="@+id/imageDescriptionView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:layout_marginStart="?dialogPreferredPadding"
+        android:layout_marginTop="?dialogPreferredPadding"
+        android:layout_marginEnd="?dialogPreferredPadding"
         android:layout_weight="1"
         android:contentDescription="@string/post_media_image" />
 
@@ -18,10 +21,10 @@
         style="@style/TuskyTextInput"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
         android:layout_marginStart="?dialogPreferredPadding"
-        android:layout_marginEnd="?dialogPreferredPadding"
         android:layout_marginTop="?dialogPreferredPadding"
+        android:layout_marginEnd="?dialogPreferredPadding"
+        android:layout_weight="1"
         app:counterEnabled="false"
         app:counterTextColor="?android:textColorTertiary"
         app:hintEnabled="false">
@@ -31,9 +34,10 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="start"
-            tools:hint="Description"
             android:importantForAutofill="no"
-            android:inputType="textCapSentences|textMultiLine|textAutoCorrect" />
+            android:inputType="textCapSentences|textMultiLine|textAutoCorrect"
+            android:lines="4"
+            tools:hint="Description" />
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -148,7 +148,6 @@
 
     <style name="TuskyDialogOverlay" parent="@style/ThemeOverlay.Material3.MaterialAlertDialog">
         <item name="alertDialogStyle">@style/TuskyDialog</item>
-        <item name="android:background">@color/colorBackground</item>
         <item name="android:backgroundDimAmount">0.5</item>
     </style>
 


### PR DESCRIPTION
The Material 3 redesign seems to have broken the dialog when very small images where used.
Also removes the weird background behind the context menu (seen in the before screenshot)

Before / after:
<img src="https://github.com/user-attachments/assets/c418125d-ef80-458f-9d94-fde428a2f59f" width="280"/> <img src="https://github.com/user-attachments/assets/b832b16d-0c18-4bf1-a263-de4fe0362854" width="280"/>
