### PR TITLE
make sure MainActivity doesn't hide other activities when launcher icon is clicked again

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:alwaysRetainTaskState="true"
             android:theme="@style/SplashTheme">
 
             <intent-filter>
@@ -105,6 +106,7 @@
         <activity
             android:name=".components.compose.ComposeActivity"
             android:theme="@style/TuskyDialogActivityTheme"
+            android:alwaysRetainTaskState="true"
             android:windowSoftInputMode="stateVisible|adjustResize" />
         <activity
             android:name=".components.viewthread.ViewThreadActivity"

--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -211,6 +211,12 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         }
         super.onCreate(savedInstanceState)
 
+        // make sure MainActivity doesn't hide other activities when launcher icon is clicked again
+        if ((intent.flags and Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT) != 0) {
+            finish()
+            return
+        }
+
         // will be redirected to LoginActivity by BaseActivity
         activeAccount = accountManager.activeAccount ?: return
 


### PR DESCRIPTION
closes #4789 this time for real, hopefully, maybe

also set `alwaysRetainTaskState` for good measure

> `android:alwaysRetainTaskState`
    Whether the state of the task that the activity is in is always maintained by the system. `"true"` if it is, and `"false"` if the system can reset the task to its initial state in certain situations. The default value is `"false"`. This attribute is meaningful only for the root activity of a task. It's ignored for all other activities.

>    Normally, the system clears a task, removing all activities from the stack above the root activity, in certain situations when the user re-selects that task from the home screen. Typically, this is done if the user hasn't visited the task for a certain amount of time, such as 30 minutes.

>    However, when this attribute is `"true"`, users always return to the task in its last state, regardless of how they get there. This is useful in an application like a web browser where there is a lot of state, such as multiple open tabs, that users don't want to lose. 

https://developer.android.com/guide/topics/manifest/activity-element#always
