### PR TITLE
fix MainActivity behavior

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:alwaysRetainTaskState="true"
+            android:maxRecents="1"
             android:theme="@style/SplashTheme">
 
             <intent-filter>

--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -212,9 +212,10 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         super.onCreate(savedInstanceState)
 
         // make sure MainActivity doesn't hide other activities when launcher icon is clicked again
-        if (!isTaskRoot
-            && intent.hasCategory(Intent.CATEGORY_LAUNCHER)
-            && intent.action == Intent.ACTION_MAIN) {
+        if (!isTaskRoot &&
+            intent.hasCategory(Intent.CATEGORY_LAUNCHER) &&
+            intent.action == Intent.ACTION_MAIN
+        ) {
             finish()
             return
         }

--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -212,7 +212,9 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         super.onCreate(savedInstanceState)
 
         // make sure MainActivity doesn't hide other activities when launcher icon is clicked again
-        if ((intent.flags and Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT) != 0) {
+        if (!isTaskRoot
+            && intent.hasCategory(Intent.CATEGORY_LAUNCHER)
+            && intent.action == Intent.ACTION_MAIN) {
             finish()
             return
         }
@@ -582,7 +584,6 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
             }
         }
         startActivity(composeIntent)
-        finish()
     }
 
     private fun setupDrawer(
@@ -1006,6 +1007,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
             intent.action = forward.action
             intent.putExtras(forward)
         }
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         finish()
         startActivity(intent)
     }


### PR DESCRIPTION
This fixes two issues, but I tested them together to make sure this time everything works as expected.

1) The fix in #4813 went into the right direction, but the condition was a bit too broad. When sharing something to Tusky so that Tusky switches accounts, sometimes nothing would happen.

2) fixes #4766. There are two possibilities here (I think it depends mostly on API level):
    2a) Sharing starts a new task. `android:maxRecents="1"` makes sure old tasks disappear and are not left in the weird in-between state.
    3a) Sharing starts a new `MainActivity` in an existing task. `Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK` makes sure old `MainActivity` instances are removed. On newer Android versions this has the sideeffect of changing the switch animation, but whatever.

Basically this gives us the behavior I wanted to achieve with the `android:launchMode="singleTask"` without the unintended side effects.