### PR TITLE
fix "delete all notifications by user" query

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/db/dao/NotificationsDao.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/dao/NotificationsDao.kt
@@ -108,10 +108,10 @@ AND
      */
     @Query(
         """DELETE FROM NotificationEntity WHERE tuskyAccountId = :tuskyAccountId AND
-            statusId IN
-            (SELECT serverId FROM TimelineStatusEntity WHERE tuskyAccountId = :tuskyAccountId AND
-            (authorServerId == :userId OR accountId == :userId))
-            AND type != "admin.sign_up" AND type != "admin.report"
+            (accountId = :userId OR
+            statusId IN (SELECT serverId FROM TimelineStatusEntity WHERE tuskyAccountId = :tuskyAccountId AND authorServerId = :userId)
+            )
+            AND type != "SIGN_UP" AND type != "REPORT"
         """
     )
     abstract suspend fun removeAllByUser(tuskyAccountId: Long, userId: String)

--- a/app/src/test/java/com/keylesspalace/tusky/db/dao/NotificationsDaoTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/db/dao/NotificationsDaoTest.kt
@@ -210,10 +210,11 @@ class NotificationsDaoTest {
             fakeNotification(type = Notification.Type.SIGN_UP, id = "4", account = fakeAccount(id = "1"), status = null, report = fakeReport(id = "1", targetAccount = fakeAccount(id = "4"))),
             // will not be removed because it does not reference account 1
             fakeNotification(id = "5", account = fakeAccount(id = "5"), status = fakeStatus(id = "5", authorServerId = "100")),
+            fakeNotification(type = Notification.Type.FOLLOW, id = "6", account = fakeAccount(id = "1"), status = null)
         )
 
         db.insert(notificationsAccount1, tuskyAccountId = 1)
-        db.insert(listOf(fakeNotification(id = "6")), tuskyAccountId = 2)
+        db.insert(listOf(fakeNotification(id = "2000")), tuskyAccountId = 2)
 
         notificationsDao.removeAllByUser(1, "1")
 
@@ -227,7 +228,7 @@ class NotificationsDaoTest {
         }
         cursor.close()
 
-        val expectedNotifications = listOf("3", "4", "5", "6")
+        val expectedNotifications = listOf("2000", "3", "4", "5")
 
         assertEquals(expectedNotifications, loadedNotifications)
     }


### PR DESCRIPTION
The brackets were at the wrong position and notification types are actually serialized differently.

Closes #4817 