### PR TITLE
improve CaptionDialog for small screens

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
@@ -49,8 +49,13 @@ class CaptionDialog : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val localId = arguments?.getInt(LOCAL_ID_ARG) ?: error("Missing localId")
+        val inset = requireContext().resources.getDimensionPixelSize(R.dimen.caption_dialog_inset)
         return MaterialAlertDialogBuilder(requireContext())
             .setView(createView(savedInstanceState))
+            .setBackgroundInsetTop(inset)
+            .setBackgroundInsetEnd(inset)
+            .setBackgroundInsetBottom(inset)
+            .setBackgroundInsetStart(inset)
             .setPositiveButton(android.R.string.ok) { _, _ ->
                 listener.onUpdateDescription(localId, binding.imageDescriptionText.text.toString())
             }

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -79,4 +79,6 @@
     <dimen name="recyclerview_bottom_padding_actionbutton">88dp</dimen>
     <dimen name="recyclerview_bottom_padding_no_actionbutton">32dp</dimen>
 
+    <dimen name="caption_dialog_inset">24dp</dimen>
+
 </resources>


### PR DESCRIPTION
(or giant soft keyboards)

https://mastodon.social/@bewitchedmind/113703199056088283

Before / After

<img src="https://github.com/user-attachments/assets/04d9f9b8-1041-4b1e-bff4-3665865a6016" width="300"/>
<img src="https://github.com/user-attachments/assets/f88bb67e-ecb0-460a-b22b-58cff5a4b754" width="300"/>


This makes it also look a bit weird on large screens, but I found no easy way to limit the size. Its now basically back to where it was in Tusky 26.

closes https://github.com/tuskyapp/Tusky/issues/4832