### PR TITLE
Tidy translation strings for better Weblate translation

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -256,15 +256,7 @@
 
     <string name="login_connection">Connecting…</string>
 
-    <string name="dialog_whats_an_instance">The address or domain of any instance can be entered
-        here, such as mastodon.social, icosahedron.website, social.tchncs.de, and
-        <a href="https://instances.social">more!</a>
-        \n\nIf you don\'t yet have an account, you can enter the name of the instance you\'d like to
-        join and create an account there.\n\nAn instance is a single place where your account is
-        hosted, but you can easily communicate with and follow folks on other instances as though
-        you were on the same site.
-        \n\nMore info can be found at <a href="https://joinmastodon.org">joinmastodon.org</a>.
-    </string>
+    <string name="dialog_whats_an_instance">The address or domain of any instance can be entered here, such as mastodon.social, icosahedron.website, social.tchncs.de, and <a href="https://instances.social">more!</a>\n\nIf you don\'t yet have an account, you can enter the name of the instance you\'d like to join and create an account there.\n\nAn instance is a single place where your account is hosted, but you can easily communicate with and follow folks on other instances as though you were on the same site.\n\nMore info can be found at <a href="https://joinmastodon.org">joinmastodon.org</a>.</string>
     <string name="dialog_title_finishing_media_upload">Finishing Media Upload</string>
     <string name="dialog_message_uploading_media">Uploading…</string>
     <string name="dialog_download_image">Download</string>
@@ -736,12 +728,11 @@
     <string name="account_note_hint">Your private note about this account</string>
     <string name="account_note_saved">Saved!</string>
 
-    <string name="wellbeing_mode_notice">Some information that might affect your mental wellbeing will be hidden. This includes:\n\n
-        - Favorite/Boost/Follow notifications\n
-        - Favorite/Boost count on posts\n
-        - Follower/Post stats on profiles\n\n
-        Push-notifications will not be affected, but you can review your notification preferences manually.
-    </string>
+    <string name="wellbeing_mode_notice">Some information that might affect your mental wellbeing will be hidden. This includes:
+\n\n- Favorite/Boost/Follow notifications
+\n- Favorite/Boost count on posts
+\n- Follower/Post stats on profiles
+\n\nPush-notifications will not be affected, but you can review your notification preferences manually.</string>
     <string name="review_notifications">Review Notifications</string>
     <string name="limit_notifications">Limit timeline notifications</string>
     <string name="wellbeing_hide_stats_posts">Hide quantitative stats on posts</string>
@@ -835,21 +826,9 @@
     <string name="filter_edit_keyword_title">Edit keyword</string>
     <string name="filter_description_format">%1$s: %2$s</string>
 
-    <string name="help_empty_home">This is your <b>home timeline</b>. It shows the recent posts of the accounts
-        you follow.\n\nTo explore accounts you can either discover them in one of the other timelines.
-        For example the local timeline of your instance [iconics gmd_group]. Or you can search them
-        by name [iconics gmd_search]; for example search for Tusky to find our Mastodon account.</string>
-    <string name="help_empty_conversations">Here are your <b>private messages</b>; sometimes called conversations or direct messages (DM).
-        \n\nPrivate messages are created by setting the visibility [iconics gmd_public] of a post to [iconics gmd_mail] <i>Direct</i> and
-        mentioning one or more users in the text.
-        \n\nFor example you can start on the profile view of an account and tap the create button [iconics gmd_edit] and change the visibility.
-    </string>
-    <string name="help_empty_lists">This is your <b>lists view</b>. You can define a number of private lists and add accounts to that.
-        \n\n
-        NOTE that you can only add accounts you follow to your lists.
-        \n\n
-        These lists can be used as a tab in Account preferences [iconics gmd_account_circle] [iconics gmd_navigate_next] Tabs.
-    </string>
+    <string name="help_empty_home">This is your <b>home timeline</b>. It shows the recent posts of the accounts you follow.\n\nTo explore accounts you can either discover them in one of the other timelines. For example the local timeline of your instance [iconics gmd_group]. Or you can search them by name [iconics gmd_search]; for example search for Tusky to find our Mastodon account.</string>
+    <string name="help_empty_conversations">Here are your <b>private messages</b>; sometimes called conversations or direct messages (DM).\n\nPrivate messages are created by setting the visibility [iconics gmd_public] of a post to [iconics gmd_mail] <i>Direct</i> and mentioning one or more users in the text.\n\nFor example you can start on the profile view of an account and tap the create button [iconics gmd_edit] and change the visibility.</string>
+    <string name="help_empty_lists">This is your <b>lists view</b>. You can define a number of private lists and add accounts to that.\n\nNOTE that you can only add accounts you follow to your lists.\n\nThese lists can be used as a tab in Account preferences [iconics gmd_account_circle] [iconics gmd_navigate_next] Tabs.</string>
 
     <string name="load_newest_notifications">Load newest notifications</string>
     <string name="about_copy">Copy version and device information</string>


### PR DESCRIPTION
The way that translations are shown on the Weblate interface is sometimes incorrect compared to how the string resources are processed by Android, I think because of how Weblate reads newlines and spaces. I guess it's Weblate's fault, but since that's what we use, I'm hoping this MR fixes the discrepancy, or at least minimises it.

I've opted to collapse multi-line strings onto one line (i.e. `help_empty_home`), unless there's a list or something (i.e. `wellbeing_mode_notice`) in which case (for XML source readability) minimal newlines are used which hopefully makes the Weblate issue uniform and minor, if it appears at all.

Here's an example of a good string in the strings.xml:
```
    <string name="action_post_failed_detail">Your post failed to upload and has been saved to drafts.\n\nEither the server could not be contacted, or it rejected the post.</string>
```
How it appears in Weblate (note that there no extra spaces anywhere):
![delwedd](https://github.com/user-attachments/assets/aa73d44b-a43b-4135-975e-f9ef5a921c7c)

Here are the problems:
### Example 1
String in strings.xml:
```
    <string name="dialog_whats_an_instance">The address or domain of any instance can be entered
        here, such as mastodon.social, icosahedron.website, social.tchncs.de, and
        <a href="https://instances.social">more!</a>
        \n\nIf you don\'t yet have an account, you can enter the name of the instance you\'d like to
        join and create an account there.\n\nAn instance is a single place where your account is
        hosted, but you can easily communicate with and follow folks on other instances as though
        you were on the same site.
        \n\nMore info can be found at <a href="https://joinmastodon.org">joinmastodon.org</a>.
    </string>
```
How it appears in Weblate (note the spaces between words where there is a newline char in the strings.xml, and the trailing spaces at the very end of the string because the XML tag is on the next line):
![Screenshot_20241226_231804](https://github.com/user-attachments/assets/e98fcef5-1569-406c-806c-0783a145a2e2)

### Example 2
String in strings.xml:
```
    <string name="wellbeing_mode_notice">Some information that might affect your mental wellbeing will be hidden. This includes:\n\n
        - Favorite/Boost/Follow notifications\n
        - Favorite/Boost count on posts\n
        - Follower/Post stats on profiles\n\n
        Push-notifications will not be affected, but you can review your notification preferences manually.
    </string>
```
How it appears in Weblate (note the incorrect space in front of the last line of the source and target languages):
![Screenshot_20241226_225652](https://github.com/user-attachments/assets/23e7c6d6-5268-4737-bfec-a89b5126f164)

### Example 3
String in strings.xml:
```
    <string name="help_empty_lists">This is your <b>lists view</b>. You can define a number of private lists and add accounts to that.
        \n\n
        NOTE that you can only add accounts you follow to your lists.
        \n\n
        These lists can be used as a tab in Account preferences [iconics gmd_account_circle] [iconics gmd_navigate_next] Tabs.
    </string>
```
How it appears in Weblate (for some reason the target language string keeps having more and more spaces added to it, I can't delete them, they keeping being added back again, perhaps it's because of only having \n newline text on a line?):
![Screenshot_20241226_232533](https://github.com/user-attachments/assets/19399b3a-b51b-4a27-a74c-52ea4bf68cbd)

There are other issues as well, and I don't know what causes them. They should be fixed somehow, but that might be (automatic?) formatting or something at your end that I can't help with. You can see some of them fairly recently by browsing https://weblate.tusky.app/changes/browse/tusky/tusky/cy/ - entries where it says "String updated in the repository" and the edit is just whitespace changes. Here's an example where extra whitespace keeps getting added to the target language:

String in strings.xml:
```
    <string name="error_missing_edits">Your server knows that this post was edited, but does not have a copy of the edits, so they can\'t be shown to you.\n\nThis is <a href="https://github.com/mastodon/mastodon/issues/25398">Mastodon issue #25398</a>.</string>
```

How it appears in Weblate (the incorrect spaces keep getting added back in the target language):
![Screenshot_20241226_231507](https://github.com/user-attachments/assets/24540587-728e-4b04-a27d-1421891d8a5b)