### PR TITLE
keep ordering when picking multiple media files at once

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -198,7 +198,7 @@ class ComposeActivity :
         } else {
             viewModel.pickMedia(
                 uris.map { uri ->
-                    ComposeViewModel.PickedMedia(uri)
+                    ComposeViewModel.MediaData(uri)
                 }
             )
         }
@@ -355,7 +355,7 @@ class ComposeActivity :
                         Intent.ACTION_SEND_MULTIPLE -> {
                             intent.getParcelableArrayListExtraCompat<Uri>(Intent.EXTRA_STREAM)
                                 ?.map { uri ->
-                                    ComposeViewModel.PickedMedia(uri)
+                                    ComposeViewModel.MediaData(uri)
                                 }?.let(viewModel::pickMedia)
                         }
                     }
@@ -1116,7 +1116,7 @@ class ComposeActivity :
 
                 viewModel.pickMedia(
                     content.clip.map { clipItem ->
-                        ComposeViewModel.PickedMedia(
+                        ComposeViewModel.MediaData(
                             uri = clipItem.uri,
                             description = description
                         )

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeActivity.kt
@@ -164,11 +164,7 @@ class ComposeActivity :
     private val takePictureLauncher =
         registerForActivityResult(ActivityResultContracts.TakePicture()) { success ->
             if (success) {
-                viewModel.pickMedia(
-                    listOf(
-                        ComposeViewModel.PickedMedia(photoUploadUri!!)
-                    )
-                )
+                viewModel.pickMedia(photoUploadUri!!)
             }
         }
     private val pickMediaFilePermissionLauncher =
@@ -353,7 +349,7 @@ class ComposeActivity :
                     when (intent.action) {
                         Intent.ACTION_SEND -> {
                             intent.getParcelableExtraCompat<Uri>(Intent.EXTRA_STREAM)?.let { uri ->
-                                viewModel.pickMedia(listOf(ComposeViewModel.PickedMedia(uri)))
+                                viewModel.pickMedia(uri)
                             }
                         }
                         Intent.ACTION_SEND_MULTIPLE -> {

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -22,7 +22,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import at.connyduck.calladapter.networkresult.fold
 import com.keylesspalace.tusky.components.compose.ComposeActivity.ComposeKind
-import com.keylesspalace.tusky.components.compose.ComposeActivity.QueuedMedia
 import com.keylesspalace.tusky.components.compose.ComposeAutoCompleteAdapter.AutocompleteResult
 import com.keylesspalace.tusky.components.drafts.DraftHelper
 import com.keylesspalace.tusky.components.instanceinfo.InstanceInfo
@@ -41,6 +40,7 @@ import com.keylesspalace.tusky.util.randomAlphanumericString
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -55,7 +55,6 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 
 @HiltViewModel
 class ComposeViewModel @Inject constructor(
@@ -92,7 +91,7 @@ class ComposeViewModel @Inject constructor(
         .shareIn(viewModelScope, SharingStarted.Eagerly, replay = 1)
 
     private val _markMediaAsSensitive =
-        MutableStateFlow(accountManager.activeAccount?.defaultMediaSensitivity ?: false)
+        MutableStateFlow(accountManager.activeAccount?.defaultMediaSensitivity == true)
     val markMediaAsSensitive: StateFlow<Boolean> = _markMediaAsSensitive.asStateFlow()
 
     private val _statusVisibility = MutableStateFlow(Status.Visibility.UNKNOWN)
@@ -127,31 +126,29 @@ class ComposeViewModel @Inject constructor(
 
     private var setupComplete = false
 
-    suspend fun pickMedia(
-        mediaUri: Uri,
-        description: String? = null,
-        focus: Attachment.Focus? = null
-    ): Result<QueuedMedia> = withContext(
-        Dispatchers.IO
-    ) {
-        try {
-            val (type, uri, size) = mediaUploader.prepareMedia(mediaUri, instanceInfo.first())
-            val mediaItems = _media.value
-            if (type != QueuedMedia.Type.IMAGE &&
-                mediaItems.isNotEmpty() &&
-                mediaItems[0].type == QueuedMedia.Type.IMAGE
-            ) {
-                Result.failure(VideoOrImageException())
-            } else {
-                val queuedMedia = addMediaToQueue(type, uri, size, description, focus)
-                Result.success(queuedMedia)
+    fun pickMedia(mediaList: List<PickedMedia>) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val instanceInfo = instanceInfo.first()
+            mediaList.map { m ->
+                async(Dispatchers.IO) { mediaUploader.prepareMedia(m.uri, instanceInfo) }
+            }.forEachIndexed { index, preparedMedia ->
+                preparedMedia.await().fold({ (type, uri, size) ->
+                    if (type != QueuedMedia.Type.IMAGE &&
+                        _media.value.firstOrNull()?.type == QueuedMedia.Type.IMAGE
+                    ) {
+                        _uploadError.emit(VideoOrImageException())
+                    } else {
+                        val pickedMedia = mediaList[index]
+                        addMediaToQueue(type, uri, size, pickedMedia.description, pickedMedia.focus)
+                    }
+                }, { error ->
+                    _uploadError.emit(error)
+                })
             }
-        } catch (e: Exception) {
-            Result.failure(e)
         }
     }
 
-    suspend fun addMediaToQueue(
+    fun addMediaToQueue(
         type: QueuedMedia.Type,
         uri: Uri,
         mediaSize: Long,
@@ -159,20 +156,17 @@ class ComposeViewModel @Inject constructor(
         focus: Attachment.Focus? = null,
         replaceItem: QueuedMedia? = null
     ): QueuedMedia {
-        var stashMediaItem: QueuedMedia? = null
+        val mediaItem = QueuedMedia(
+            localId = mediaUploader.getNewLocalMediaId(),
+            uri = uri,
+            type = type,
+            mediaSize = mediaSize,
+            description = description,
+            focus = focus,
+            state = QueuedMedia.State.UPLOADING
+        )
 
         _media.update { mediaList ->
-            val mediaItem = QueuedMedia(
-                localId = mediaUploader.getNewLocalMediaId(),
-                uri = uri,
-                type = type,
-                mediaSize = mediaSize,
-                description = description,
-                focus = focus,
-                state = QueuedMedia.State.UPLOADING
-            )
-            stashMediaItem = mediaItem
-
             if (replaceItem != null) {
                 mediaUploader.cancelUploadScope(replaceItem.localId)
                 mediaList.map {
@@ -182,8 +176,6 @@ class ComposeViewModel @Inject constructor(
                 mediaList + mediaItem
             }
         }
-        val mediaItem =
-            stashMediaItem!! // stashMediaItem is always non-null and uncaptured at this point, but Kotlin doesn't know that
 
         viewModelScope.launch {
             mediaUploader
@@ -505,11 +497,9 @@ class ComposeViewModel @Inject constructor(
         val draftAttachments = composeOptions?.draftAttachments
         if (draftAttachments != null) {
             // when coming from DraftActivity
-            viewModelScope.launch {
-                draftAttachments.forEach { attachment ->
-                    pickMedia(attachment.uri, attachment.description, attachment.focus)
-                }
-            }
+            draftAttachments.map { attachment ->
+                PickedMedia(attachment.uri, attachment.description, attachment.focus)
+            }.let { pickMedia(it) }
         } else {
             composeOptions?.mediaAttachments?.forEach { a ->
                 // when coming from redraft or ScheduledTootActivity
@@ -588,6 +578,36 @@ class ComposeViewModel @Inject constructor(
         CONTINUE_EDITING_OR_DISCARD_CHANGES, // editing post
         CONTINUE_EDITING_OR_DISCARD_DRAFT // edit draft
     }
+
+    data class QueuedMedia(
+        val localId: Int,
+        val uri: Uri,
+        val type: Type,
+        val mediaSize: Long,
+        val uploadPercent: Int = 0,
+        val id: String? = null,
+        val description: String? = null,
+        val focus: Attachment.Focus? = null,
+        val state: State
+    ) {
+        enum class Type {
+            IMAGE,
+            VIDEO,
+            AUDIO
+        }
+        enum class State {
+            UPLOADING,
+            UNPROCESSED,
+            PROCESSED,
+            PUBLISHED
+        }
+    }
+
+    data class PickedMedia(
+        val uri: Uri,
+        val description: String? = null,
+        val focus: Attachment.Focus? = null
+    )
 }
 
 /**

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/ComposeViewModel.kt
@@ -127,13 +127,13 @@ class ComposeViewModel @Inject constructor(
     private var setupComplete = false
 
     fun pickMedia(uri: Uri) {
-        pickMedia(listOf(PickedMedia(uri)))
+        pickMedia(listOf(MediaData(uri)))
     }
 
-    fun pickMedia(mediaList: List<PickedMedia>) = viewModelScope.launch(Dispatchers.IO) {
+    fun pickMedia(mediaList: List<MediaData>) = viewModelScope.launch(Dispatchers.IO) {
         val instanceInfo = instanceInfo.first()
         mediaList.map { m ->
-            async(Dispatchers.IO) { mediaUploader.prepareMedia(m.uri, instanceInfo) }
+            async { mediaUploader.prepareMedia(m.uri, instanceInfo) }
         }.forEachIndexed { index, preparedMedia ->
             preparedMedia.await().fold({ (type, uri, size) ->
                 if (type != QueuedMedia.Type.IMAGE &&
@@ -500,7 +500,7 @@ class ComposeViewModel @Inject constructor(
         if (draftAttachments != null) {
             // when coming from DraftActivity
             draftAttachments.map { attachment ->
-                PickedMedia(attachment.uri, attachment.description, attachment.focus)
+                MediaData(attachment.uri, attachment.description, attachment.focus)
             }.let(::pickMedia)
         } else {
             composeOptions?.mediaAttachments?.forEach { a ->
@@ -605,7 +605,7 @@ class ComposeViewModel @Inject constructor(
         }
     }
 
-    data class PickedMedia(
+    data class MediaData(
         val uri: Uri,
         val description: String? = null,
         val focus: Attachment.Focus? = null

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaPreviewAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaPreviewAdapter.kt
@@ -31,25 +31,25 @@ import com.keylesspalace.tusky.components.compose.view.ProgressImageView
 
 class MediaPreviewAdapter(
     context: Context,
-    private val onAddCaption: (ComposeActivity.QueuedMedia) -> Unit,
-    private val onAddFocus: (ComposeActivity.QueuedMedia) -> Unit,
-    private val onEditImage: (ComposeActivity.QueuedMedia) -> Unit,
-    private val onRemove: (ComposeActivity.QueuedMedia) -> Unit
-) : ListAdapter<ComposeActivity.QueuedMedia, MediaPreviewAdapter.PreviewViewHolder>(
-    object : DiffUtil.ItemCallback<ComposeActivity.QueuedMedia>() {
+    private val onAddCaption: (ComposeViewModel.QueuedMedia) -> Unit,
+    private val onAddFocus: (ComposeViewModel.QueuedMedia) -> Unit,
+    private val onEditImage: (ComposeViewModel.QueuedMedia) -> Unit,
+    private val onRemove: (ComposeViewModel.QueuedMedia) -> Unit
+) : ListAdapter<ComposeViewModel.QueuedMedia, MediaPreviewAdapter.PreviewViewHolder>(
+    object : DiffUtil.ItemCallback<ComposeViewModel.QueuedMedia>() {
         override fun areItemsTheSame(
-            oldItem: ComposeActivity.QueuedMedia,
-            newItem: ComposeActivity.QueuedMedia
+            oldItem: ComposeViewModel.QueuedMedia,
+            newItem: ComposeViewModel.QueuedMedia
         ) = oldItem.localId == newItem.localId
 
         override fun areContentsTheSame(
-            oldItem: ComposeActivity.QueuedMedia,
-            newItem: ComposeActivity.QueuedMedia
+            oldItem: ComposeViewModel.QueuedMedia,
+            newItem: ComposeViewModel.QueuedMedia
         ) = oldItem == newItem
     }
 ) {
 
-    private fun onMediaClick(item: ComposeActivity.QueuedMedia, view: View) {
+    private fun onMediaClick(item: ComposeViewModel.QueuedMedia, view: View) {
         val popup = PopupMenu(view.context, view)
         val addCaptionId = 1
         val addFocusId = 2
@@ -57,9 +57,9 @@ class MediaPreviewAdapter(
         val removeId = 4
 
         popup.menu.add(0, addCaptionId, 0, R.string.action_set_caption)
-        if (item.type == ComposeActivity.QueuedMedia.Type.IMAGE) {
+        if (item.type == ComposeViewModel.QueuedMedia.Type.IMAGE) {
             popup.menu.add(0, addFocusId, 0, R.string.action_set_focus)
-            if (item.state != ComposeActivity.QueuedMedia.State.PUBLISHED) {
+            if (item.state != ComposeViewModel.QueuedMedia.State.PUBLISHED) {
                 // Already-published items can't be edited
                 popup.menu.add(0, editImageId, 0, R.string.action_edit_image)
             }
@@ -88,7 +88,7 @@ class MediaPreviewAdapter(
         val item = getItem(position)
         holder.progressImageView.setChecked(!item.description.isNullOrEmpty())
         holder.progressImageView.setProgress(item.uploadPercent)
-        if (item.type == ComposeActivity.QueuedMedia.Type.AUDIO) {
+        if (item.type == ComposeViewModel.QueuedMedia.Type.AUDIO) {
             // TODO: Fancy waveform display?
             holder.progressImageView.setImageResource(R.drawable.ic_music_box_preview_24dp)
         } else {

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/MediaUploader.kt
@@ -156,6 +156,8 @@ class MediaUploader @Inject constructor(
         var uri = inUri
         val mimeType: String?
 
+        println("preparing media on thread ${Thread.currentThread().name}")
+
         try {
             when (inUri.scheme) {
                 ContentResolver.SCHEME_CONTENT -> {

--- a/app/src/main/java/com/keylesspalace/tusky/util/PickMediaFiles.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/PickMediaFiles.kt
@@ -16,6 +16,7 @@
 package com.keylesspalace.tusky.util
 
 import android.app.Activity
+import android.content.ClipData
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -40,13 +41,17 @@ class PickMediaFiles : ActivityResultContract<Boolean, List<Uri>>() {
                 // Single media, upload it and done.
                 return listOf(intentData)
             } else if (clipData != null) {
-                val result: MutableList<Uri> = mutableListOf()
-                for (i in 0 until clipData.itemCount) {
-                    result.add(clipData.getItemAt(i).uri)
-                }
-                return result
+                return clipData.map { clipItem -> clipItem.uri }
             }
         }
         return emptyList()
     }
+}
+
+fun <T> ClipData.map(transform: (ClipData.Item) -> T): List<T> {
+    val destination = ArrayList<T>(this.itemCount)
+    for (i in 0 until this.itemCount) {
+        destination.add(transform(getItemAt(i)))
+    }
+    return destination
 }


### PR DESCRIPTION
This restructures the code so that all picked media will be added to the upload queue in the correct order and also does some other code cleanup.

closes #4754 