### PR TITLE
guard against invalid position in StatusNotificationViewHolder

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/StatusNotificationViewHolder.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/StatusNotificationViewHolder.kt
@@ -100,12 +100,15 @@ internal class StatusNotificationViewHolder(
                     )
                 }
 
-                binding.notificationContainer.setOnClickListener {
-                    statusActionListener.onViewThread(bindingAdapterPosition)
+                val viewThreadListener = View.OnClickListener {
+                    val position = bindingAdapterPosition
+                    if (position != RecyclerView.NO_POSITION) {
+                        statusActionListener.onViewThread(position)
+                    }
                 }
-                binding.notificationContent.setOnClickListener {
-                    statusActionListener.onViewThread(bindingAdapterPosition)
-                }
+
+                binding.notificationContainer.setOnClickListener(viewThreadListener)
+                binding.notificationContent.setOnClickListener(viewThreadListener)
                 binding.notificationTopText.setOnClickListener {
                     statusActionListener.onViewAccount(viewData.account.id)
                 }


### PR DESCRIPTION
We do this in other ViewHolders as well

Seen in this crash report on Google Play:

```
Exception java.lang.IndexOutOfBoundsException: Index: -1, Size: 0
  at androidx.paging.PageStore.checkIndex (PageStore.kt:56)
  at androidx.paging.PageStore.get (PageStore.kt:66)
  at androidx.paging.PagingDataPresenter.peek (PagingDataPresenter.java:290)
  at androidx.paging.AsyncPagingDataDiffer.peek (AsyncPagingDataDiffer.java:476)
  at androidx.paging.PagingDataAdapter.peek (PagingDataAdapter.kt:312)
  at com.keylesspalace.tusky.components.notifications.NotificationsFragment.onViewThread (NotificationsFragment.kt:409)
  at com.keylesspalace.tusky.components.notifications.StatusNotificationViewHolder.bind$lambda$0 (StatusNotificationViewHolder.java:104)
  at android.view.View.performClick (View.java:7684)
  at android.view.View.performClickInternal (View.java:7661)
  at android.view.View.-$$Nest$mperformClickInternal (Unknown Source)
  at android.view.View$PerformClick.run (View.java:30344)
  at android.os.Handler.handleCallback (Handler.java:1000)
  at android.os.Handler.dispatchMessage (Handler.java:104)
  at android.os.Looper.loopOnce (Looper.java:242)
  at android.os.Looper.loop (Looper.java:362)
  at android.app.ActivityThread.main (ActivityThread.java:8393)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:552)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:992)
```