### PR TITLE
increase width of tab indicator

### DIFF
--- a/app/src/main/res/drawable/tab_indicator_bottom.xml
+++ b/app/src/main/res/drawable/tab_indicator_bottom.xml
@@ -8,11 +8,11 @@
       <!-- Color is assigned programmatically with the value of "tabIndicatorColor". -->
       <solid android:color="@android:color/white"/>
       <corners
-          android:bottomLeftRadius="4dp"
-          android:bottomRightRadius="4dp"
+          android:bottomLeftRadius="3dp"
+          android:bottomRightRadius="3dp"
           android:topLeftRadius="0dp"
           android:topRightRadius="0dp"/>
-      <size android:height="4dp"/>
+      <size android:height="3dp"/>
     </shape>
   </item>
 </layer-list>

--- a/app/src/main/res/drawable/tab_indicator_top.xml
+++ b/app/src/main/res/drawable/tab_indicator_top.xml
@@ -10,9 +10,9 @@
       <corners
           android:bottomLeftRadius="0dp"
           android:bottomRightRadius="0dp"
-          android:topLeftRadius="4dp"
-          android:topRightRadius="4dp"/>
-      <size android:height="4dp"/>
+          android:topLeftRadius="3dp"
+          android:topRightRadius="3dp"/>
+      <size android:height="3dp"/>
     </shape>
   </item>
 </layer-list>

--- a/app/src/main/res/drawable/tab_indicator_top.xml
+++ b/app/src/main/res/drawable/tab_indicator_top.xml
@@ -8,10 +8,10 @@
       <!-- Color is assigned programmatically with the value of "tabIndicatorColor". -->
       <solid android:color="@android:color/white"/>
       <corners
-          android:bottomLeftRadius="4dp"
-          android:bottomRightRadius="4dp"
-          android:topLeftRadius="0dp"
-          android:topRightRadius="0dp"/>
+          android:bottomLeftRadius="0dp"
+          android:bottomRightRadius="0dp"
+          android:topLeftRadius="4dp"
+          android:topRightRadius="4dp"/>
       <size android:height="4dp"/>
     </shape>
   </item>

--- a/app/src/main/res/layout/activity_account.xml
+++ b/app/src/main/res/layout/activity_account.xml
@@ -444,6 +444,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:tabGravity="center"
+                app:tabIndicatorHeight="4dp"
+                app:tabIndicator="@drawable/tab_indicator_top"
+                app:tabIndicatorFullWidth="true"
                 app:tabMode="scrollable" />
 
         </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -45,6 +45,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:tabGravity="fill"
+                    app:tabIndicator="@drawable/tab_indicator_top"
+                    app:tabIndicatorFullWidth="true"
                     app:tabMaxWidth="0dp"
                     app:tabMode="scrollable" />
 
@@ -80,8 +82,9 @@
                 android:layout_height="?attr/actionBarSize"
                 android:background="?attr/colorSurface"
                 app:tabGravity="fill"
-                app:tabIndicatorGravity="top"
                 app:tabIndicator="@drawable/tab_indicator_bottom"
+                app:tabIndicatorFullWidth="true"
+                app:tabIndicatorGravity="top"
                 app:tabMode="scrollable"
                 app:tabPaddingTop="0dp" />
 

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -26,6 +26,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:tabGravity="fill"
+            app:tabIndicator="@drawable/tab_indicator_top"
+            app:tabIndicatorFullWidth="true"
             app:tabMaxWidth="0dp"
             app:tabMode="fixed" />
 


### PR DESCRIPTION
There have been multiple complaints by users that the new Material 3 tab indicator is too small. 

Setting `app:tabIndicatorFullWidth="true"` alone looks weird imho, so I additionally added some padding.

cc @mcclure 

Before / After

![before](https://github.com/user-attachments/assets/2234aed0-c558-4318-8cd5-fdb39af436a2) ![after](https://github.com/user-attachments/assets/1d806ad1-139c-41ed-9939-bc45f66d95c0)