### PR TITLE
fix AccountsInListFragment not showing any accounts

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/AccountsInListFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountsInListFragment.kt
@@ -73,11 +73,7 @@ class AccountsInListFragment : DialogFragment() {
         viewModel.load(listId)
     }
 
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        return MaterialAlertDialogBuilder(requireContext())
-            .setView(createView())
-            .create()
-    }
+    override fun getTheme() = R.style.TuskyDialogOverlay
 
     override fun onStart() {
         super.onStart()
@@ -90,7 +86,7 @@ class AccountsInListFragment : DialogFragment() {
         }
     }
 
-    private fun createView(): View {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = FragmentAccountsInListBinding.inflate(layoutInflater)
         val adapter = Adapter()
         val searchAdapter = SearchAdapter()

--- a/app/src/main/java/com/keylesspalace/tusky/AccountsInListFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountsInListFragment.kt
@@ -16,7 +16,6 @@
 
 package com.keylesspalace.tusky
 
-import android.app.Dialog
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -30,7 +29,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.keylesspalace.tusky.databinding.FragmentAccountsInListBinding
 import com.keylesspalace.tusky.databinding.ItemFollowRequestBinding
 import com.keylesspalace.tusky.entity.TimelineAccount
@@ -86,7 +84,7 @@ class AccountsInListFragment : DialogFragment() {
         }
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = FragmentAccountsInListBinding.inflate(layoutInflater)
         val adapter = Adapter()
         val searchAdapter = SearchAdapter()


### PR DESCRIPTION
The problem is that the MaterialAlertDialog uses a layout with "wrap_content" around the custom view. Even though the dialog was stretched to the whole window size, the content was never shown.
The fix reverts to the default dialog and styles it as if it was a MaterialAlertDialog, which works and also looks better on smaller screens.

fixes #4850 