### PR TITLE
set singleLineTitle=false for all preferences via theme

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/AccountPreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/AccountPreferencesFragment.kt
@@ -173,7 +173,6 @@ class AccountPreferencesFragment : PreferenceFragmentCompat() {
                     setEntries(R.array.post_privacy_names)
                     setEntryValues(R.array.post_privacy_values)
                     key = PrefKeys.DEFAULT_POST_PRIVACY
-                    isSingleLineTitle = false
                     setSummaryProvider { entry }
                     val visibility = accountManager.activeAccount?.defaultPostPrivacy ?: Status.Visibility.PUBLIC
                     value = visibility.stringValue
@@ -196,7 +195,6 @@ class AccountPreferencesFragment : PreferenceFragmentCompat() {
                         setEntries(R.array.reply_privacy_names)
                         setEntryValues(R.array.reply_privacy_values)
                         key = PrefKeys.DEFAULT_REPLY_PRIVACY
-                        isSingleLineTitle = false
                         setSummaryProvider { entry }
                         val visibility = activeAccount.defaultReplyPrivacy
                         value = visibility.stringValue
@@ -232,7 +230,6 @@ class AccountPreferencesFragment : PreferenceFragmentCompat() {
                         ).toTypedArray()
                     entryValues = (listOf("") + locales.map { it.language }).toTypedArray()
                     key = PrefKeys.DEFAULT_POST_LANGUAGE
-                    isSingleLineTitle = false
                     icon = icon(GoogleMaterial.Icon.gmd_translate)
                     value = accountManager.activeAccount?.defaultPostLanguage.orEmpty()
                     isPersistent = false // This will be entirely server-driven
@@ -248,7 +245,6 @@ class AccountPreferencesFragment : PreferenceFragmentCompat() {
                     setTitle(R.string.pref_default_media_sensitivity)
                     icon = icon(R.drawable.ic_eye_24dp)
                     key = PrefKeys.DEFAULT_MEDIA_SENSITIVITY
-                    isSingleLineTitle = false
                     val sensitivity = accountManager.activeAccount?.defaultMediaSensitivity == true
                     setDefaultValue(sensitivity)
                     icon = getIconForSensitivity(sensitivity)
@@ -267,21 +263,18 @@ class AccountPreferencesFragment : PreferenceFragmentCompat() {
                 switchPreference {
                     key = PrefKeys.MEDIA_PREVIEW_ENABLED
                     setTitle(R.string.pref_title_show_media_preview)
-                    isSingleLineTitle = false
                     preferenceDataStore = accountPreferenceDataStore
                 }
 
                 switchPreference {
                     key = PrefKeys.ALWAYS_SHOW_SENSITIVE_MEDIA
                     setTitle(R.string.pref_title_alway_show_sensitive_media)
-                    isSingleLineTitle = false
                     preferenceDataStore = accountPreferenceDataStore
                 }
 
                 switchPreference {
                     key = PrefKeys.ALWAYS_OPEN_SPOILER
                     setTitle(R.string.pref_title_alway_open_spoiler)
-                    isSingleLineTitle = false
                     preferenceDataStore = accountPreferenceDataStore
                 }
             }

--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesFragment.kt
@@ -146,7 +146,6 @@ class PreferencesFragment : PreferenceFragmentCompat() {
                     key = PrefKeys.SHOW_SELF_USERNAME
                     setSummaryProvider { entry }
                     setTitle(R.string.pref_title_show_self_username)
-                    isSingleLineTitle = false
                 }
 
                 switchPreference {
@@ -159,21 +158,18 @@ class PreferencesFragment : PreferenceFragmentCompat() {
                     setDefaultValue(true)
                     key = PrefKeys.SHOW_NOTIFICATIONS_FILTER
                     setTitle(R.string.pref_title_show_notifications_filter)
-                    isSingleLineTitle = false
                 }
 
                 switchPreference {
                     setDefaultValue(false)
                     key = PrefKeys.ABSOLUTE_TIME_VIEW
                     setTitle(R.string.pref_title_absolute_time)
-                    isSingleLineTitle = false
                 }
 
                 switchPreference {
                     setDefaultValue(true)
                     key = PrefKeys.SHOW_BOT_OVERLAY
                     setTitle(R.string.pref_title_bot_overlay)
-                    isSingleLineTitle = false
                     icon = icon(R.drawable.ic_bot_24dp)
                 }
 
@@ -181,63 +177,54 @@ class PreferencesFragment : PreferenceFragmentCompat() {
                     setDefaultValue(false)
                     key = PrefKeys.ANIMATE_GIF_AVATARS
                     setTitle(R.string.pref_title_animate_gif_avatars)
-                    isSingleLineTitle = false
                 }
 
                 switchPreference {
                     setDefaultValue(false)
                     key = PrefKeys.ANIMATE_CUSTOM_EMOJIS
                     setTitle(R.string.pref_title_animate_custom_emojis)
-                    isSingleLineTitle = false
                 }
 
                 switchPreference {
                     setDefaultValue(true)
                     key = PrefKeys.USE_BLURHASH
                     setTitle(R.string.pref_title_gradient_for_media)
-                    isSingleLineTitle = false
                 }
 
                 switchPreference {
                     setDefaultValue(false)
                     key = PrefKeys.SHOW_CARDS_IN_TIMELINES
                     setTitle(R.string.pref_title_show_cards_in_timelines)
-                    isSingleLineTitle = false
                 }
 
                 switchPreference {
                     setDefaultValue(true)
                     key = PrefKeys.CONFIRM_REBLOGS
                     setTitle(R.string.pref_title_confirm_reblogs)
-                    isSingleLineTitle = false
                 }
 
                 switchPreference {
                     setDefaultValue(false)
                     key = PrefKeys.CONFIRM_FAVOURITES
                     setTitle(R.string.pref_title_confirm_favourites)
-                    isSingleLineTitle = false
                 }
 
                 switchPreference {
                     setDefaultValue(false)
                     key = PrefKeys.CONFIRM_FOLLOWS
                     setTitle(R.string.pref_title_confirm_follows)
-                    isSingleLineTitle = false
                 }
 
                 switchPreference {
                     setDefaultValue(true)
                     key = PrefKeys.ENABLE_SWIPE_FOR_TABS
                     setTitle(R.string.pref_title_enable_swipe_for_tabs)
-                    isSingleLineTitle = false
                 }
 
                 switchPreference {
                     setDefaultValue(false)
                     key = PrefKeys.SHOW_STATS_INLINE
                     setTitle(R.string.pref_title_show_stat_inline)
-                    isSingleLineTitle = false
                 }
             }
 
@@ -246,7 +233,6 @@ class PreferencesFragment : PreferenceFragmentCompat() {
                     setDefaultValue(false)
                     key = PrefKeys.CUSTOM_TABS
                     setTitle(R.string.pref_title_custom_tabs)
-                    isSingleLineTitle = false
                 }
             }
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -178,10 +178,16 @@
 
     <style name="TuskyPreferenceTheme" parent="@style/PreferenceThemeOverlay">
         <item name="switchPreferenceCompatStyle">@style/TuskySwitchPreference</item>
+        <item name="dialogPreferenceStyle">@style/TuskyDialogPreference</item>
+    </style>
+
+    <style name="TuskyDialogPreference" parent="@style/Preference.DialogPreference.Material">
+        <item name="singleLineTitle">false</item>
     </style>
 
     <style name="TuskySwitchPreference" parent="@style/Preference.SwitchPreferenceCompat.Material">
         <item name="widgetLayout">@layout/preference_material_switch</item>
+        <item name="singleLineTitle">false</item>
     </style>
 
     <style name="TuskyImageButton" parent="@style/Widget.MaterialComponents.Button.UnelevatedButton">


### PR DESCRIPTION
We want multi line titles so they are readable on small screens or with large font sizes, and setting the attribute on every single preference individually is annoying (and we forgot one).


https://pawb.fun/@keeri/113772067202381363