### PR TITLE
3771: Only use timeline entries tied to the currently viewing account

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/db/dao/TimelineDao.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/dao/TimelineDao.kt
@@ -53,7 +53,7 @@ FROM HomeTimelineEntity h
 LEFT JOIN TimelineStatusEntity s ON (h.statusId = s.serverId AND s.tuskyAccountId = :tuskyAccountId)
 LEFT JOIN TimelineAccountEntity a ON (s.authorServerId = a.serverId AND a.tuskyAccountId = :tuskyAccountId)
 LEFT JOIN TimelineAccountEntity rb ON (h.reblogAccountId = rb.serverId AND rb.tuskyAccountId = :tuskyAccountId)
-LEFT JOIN TimelineAccountEntity replied ON (s.inReplyToAccountId = replied.serverId)
+LEFT JOIN TimelineAccountEntity replied ON (s.inReplyToAccountId = replied.serverId AND replied.tuskyAccountId = :tuskyAccountId)
 WHERE h.tuskyAccountId = :tuskyAccountId
 ORDER BY LENGTH(h.id) DESC, h.id DESC"""
     )


### PR DESCRIPTION
Fixes (should) doubled reply posts in timelines (https://corteximplant.com/@Sirs0ri/113783407002282357)

Hard to test as you need two accounts logged in to Tusky with operlapping locally cached account data.