### PR TITLE
fix ANR when loading more on a slow connection

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
@@ -308,27 +308,27 @@ class NotificationsViewModel @Inject constructor(
                     )
                 )
 
-                val response = db.withTransaction {
-                    val idAbovePlaceholder = notificationsDao.getIdAbove(account.id, placeholderId)
-                    val idBelowPlaceholder = notificationsDao.getIdBelow(account.id, placeholderId)
-                    when (readingOrder) {
-                        // Using minId, loads up to LOAD_AT_ONCE statuses with IDs immediately
-                        // after minId and no larger than maxId
-                        ReadingOrder.OLDEST_FIRST -> api.notifications(
-                            maxId = idAbovePlaceholder,
-                            minId = idBelowPlaceholder,
-                            limit = TimelineViewModel.LOAD_AT_ONCE,
-                            excludes = excludes.value
-                        )
-                        // Using sinceId, loads up to LOAD_AT_ONCE statuses immediately before
-                        // maxId, and no smaller than minId.
-                        ReadingOrder.NEWEST_FIRST -> api.notifications(
-                            maxId = idAbovePlaceholder,
-                            sinceId = idBelowPlaceholder,
-                            limit = TimelineViewModel.LOAD_AT_ONCE,
-                            excludes = excludes.value
-                        )
-                    }
+                val (idAbovePlaceholder, idBelowPlaceholder) = db.withTransaction {
+                    notificationsDao.getIdAbove(account.id, placeholderId) to
+                        notificationsDao.getIdBelow(account.id, placeholderId)
+                }
+                val response = when (readingOrder) {
+                    // Using minId, loads up to LOAD_AT_ONCE statuses with IDs immediately
+                    // after minId and no larger than maxId
+                    ReadingOrder.OLDEST_FIRST -> api.notifications(
+                        maxId = idAbovePlaceholder,
+                        minId = idBelowPlaceholder,
+                        limit = TimelineViewModel.LOAD_AT_ONCE,
+                        excludes = excludes.value
+                    )
+                    // Using sinceId, loads up to LOAD_AT_ONCE statuses immediately before
+                    // maxId, and no smaller than minId.
+                    ReadingOrder.NEWEST_FIRST -> api.notifications(
+                        maxId = idAbovePlaceholder,
+                        sinceId = idBelowPlaceholder,
+                        limit = TimelineViewModel.LOAD_AT_ONCE,
+                        excludes = excludes.value
+                    )
                 }
 
                 val notifications = response.body()

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -157,25 +157,25 @@ class CachedTimelineViewModel @Inject constructor(
                     Placeholder(placeholderId, loading = true).toEntity(tuskyAccountId = account.id)
                 )
 
-                val response = db.withTransaction {
-                    val idAbovePlaceholder = timelineDao.getIdAbove(account.id, placeholderId)
-                    val idBelowPlaceholder = timelineDao.getIdBelow(account.id, placeholderId)
-                    when (readingOrder) {
-                        // Using minId, loads up to LOAD_AT_ONCE statuses with IDs immediately
-                        // after minId and no larger than maxId
-                        OLDEST_FIRST -> api.homeTimeline(
-                            maxId = idAbovePlaceholder,
-                            minId = idBelowPlaceholder,
-                            limit = LOAD_AT_ONCE
-                        )
-                        // Using sinceId, loads up to LOAD_AT_ONCE statuses immediately before
-                        // maxId, and no smaller than minId.
-                        NEWEST_FIRST -> api.homeTimeline(
-                            maxId = idAbovePlaceholder,
-                            sinceId = idBelowPlaceholder,
-                            limit = LOAD_AT_ONCE
-                        )
-                    }
+                val (idAbovePlaceholder, idBelowPlaceholder) = db.withTransaction {
+                    timelineDao.getIdAbove(account.id, placeholderId) to
+                        timelineDao.getIdBelow(account.id, placeholderId)
+                }
+                val response = when (readingOrder) {
+                    // Using minId, loads up to LOAD_AT_ONCE statuses with IDs immediately
+                    // after minId and no larger than maxId
+                    OLDEST_FIRST -> api.homeTimeline(
+                        maxId = idAbovePlaceholder,
+                        minId = idBelowPlaceholder,
+                        limit = LOAD_AT_ONCE
+                    )
+                    // Using sinceId, loads up to LOAD_AT_ONCE statuses immediately before
+                    // maxId, and no smaller than minId.
+                    NEWEST_FIRST -> api.homeTimeline(
+                        maxId = idAbovePlaceholder,
+                        sinceId = idBelowPlaceholder,
+                        limit = LOAD_AT_ONCE
+                    )
                 }
 
                 val statuses = response.body()


### PR DESCRIPTION
There were network calls inside a database transaction. That basically locked the database for the duration of the network call, causing the app to freeze if the call took to long.