### PR TITLE
show actual hashtags in title of hashtag tab

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -886,10 +886,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         tabLayoutMediator = TabLayoutMediator(activeTabLayout, binding.viewPager, true) {
                 tab: TabLayout.Tab, position: Int ->
             tab.icon = AppCompatResources.getDrawable(this@MainActivity, tabs[position].icon)
-            tab.contentDescription = when (tabs[position].id) {
-                LIST -> tabs[position].arguments[1]
-                else -> getString(tabs[position].text)
-            }
+            tab.contentDescription = tabs[position].title(this)
             if (tabs[position].id == DIRECT) {
                 val badge = tab.orCreateBadge
                 badge.isVisible = activeAccount.hasDirectMessageBadge


### PR DESCRIPTION
Instead of just "Hashtags".

Actually, this was a bug. The code to generate the correct title is already here, but it wasn't called. 🤷 

closes https://github.com/tuskyapp/Tusky/issues/4867