### PR TITLE
fix voting in boosted polls on user profiles

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -111,10 +111,6 @@ class CachedTimelineViewModel @Inject constructor(
         }
         .flowOn(Dispatchers.Default)
 
-    override fun updatePoll(newPoll: Poll, status: StatusViewData.Concrete) {
-        // handled by CacheUpdater
-    }
-
     override fun changeExpanded(expanded: Boolean, status: StatusViewData.Concrete) {
         viewModelScope.launch {
             db.timelineStatusDao()

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -41,7 +41,6 @@ import com.keylesspalace.tusky.db.AppDatabase
 import com.keylesspalace.tusky.db.entity.HomeTimelineData
 import com.keylesspalace.tusky.db.entity.HomeTimelineEntity
 import com.keylesspalace.tusky.entity.Filter
-import com.keylesspalace.tusky.entity.Poll
 import com.keylesspalace.tusky.network.FilterModel
 import com.keylesspalace.tusky.network.MastodonApi
 import com.keylesspalace.tusky.usecase.TimelineCases

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -31,6 +31,7 @@ import com.keylesspalace.tusky.appstore.DomainMuteEvent
 import com.keylesspalace.tusky.appstore.Event
 import com.keylesspalace.tusky.appstore.EventHub
 import com.keylesspalace.tusky.appstore.MuteEvent
+import com.keylesspalace.tusky.appstore.PollVoteEvent
 import com.keylesspalace.tusky.appstore.StatusChangedEvent
 import com.keylesspalace.tusky.appstore.StatusDeletedEvent
 import com.keylesspalace.tusky.appstore.UnfollowEvent
@@ -116,6 +117,7 @@ class NetworkTimelineViewModel @Inject constructor(
     private fun handleEvent(event: Event) {
         when (event) {
             is StatusChangedEvent -> handleStatusChangedEvent(event.status)
+            is PollVoteEvent -> handlePollVote(event.statusId, event.poll)
             is UnfollowEvent -> {
                 if (kind == Kind.HOME) {
                     val id = event.accountId
@@ -146,12 +148,6 @@ class NetworkTimelineViewModel @Inject constructor(
                 }
             }
         }
-    }
-
-    override fun updatePoll(newPoll: Poll, status: StatusViewData.Concrete) {
-        status.copy(
-            status = status.status.copy(poll = newPoll)
-        ).update()
     }
 
     override fun changeExpanded(expanded: Boolean, status: StatusViewData.Concrete) {
@@ -295,6 +291,12 @@ class NetworkTimelineViewModel @Inject constructor(
 
     private fun handleStatusChangedEvent(status: Status) {
         updateStatusByActionableId(status.id) { status }
+    }
+
+    private fun handlePollVote(statusId: String, poll: Poll) {
+        updateStatusByActionableId(statusId) { status ->
+            status.copy(poll = poll)
+        }
     }
 
     override fun fullReload() {

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
@@ -145,9 +145,6 @@ abstract class TimelineViewModel(
                 return@launch
             }
 
-            val votedPoll = poll.votedCopy(choices)
-            updatePoll(votedPoll, status)
-
             try {
                 timelineCases.voteInPoll(status.actionableId, poll.id, choices).getOrThrow()
             } catch (t: Exception) {
@@ -156,8 +153,6 @@ abstract class TimelineViewModel(
                 }
             }
         }
-
-    abstract fun updatePoll(newPoll: Poll, status: StatusViewData.Concrete)
 
     abstract fun changeExpanded(expanded: Boolean, status: StatusViewData.Concrete)
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
@@ -29,7 +29,6 @@ import com.keylesspalace.tusky.components.preference.PreferencesFragment.Reading
 import com.keylesspalace.tusky.components.timeline.util.ifExpected
 import com.keylesspalace.tusky.db.AccountManager
 import com.keylesspalace.tusky.entity.Filter
-import com.keylesspalace.tusky.entity.Poll
 import com.keylesspalace.tusky.network.FilterModel
 import com.keylesspalace.tusky.settings.PrefKeys
 import com.keylesspalace.tusky.usecase.TimelineCases


### PR DESCRIPTION
Without this fix, the vote goes through but the poll in the app doesn't update.
Fixed by using `updateStatusByActionableId`, which automatically handles boosted & regular posts. Also handle poll votes the same way as in the home timeline, by listening to the `PollVoteEvent`.