### PR TITLE
remove plurals.xml

### DIFF
--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -610,12 +610,14 @@
     <string name="pref_reading_order_newest_first">Спачатку навейшыя</string>
     <string name="dialog_follow_hashtag_title">Падпісацца на хэштэг</string>
     <string name="action_post_failed">Не атрымалася запампаваць</string>
-    <string name="action_post_failed_detail">Не атрымалася запампаваць ваш допіс і ён быў захаваны ў чарнавік.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Не атрымалася запампаваць ваш допіс і ён быў захаваны ў чарнавік.
 \n
-\nАльбо не атрымалася злучыцца з серверам ці ён адхіліў допіс.</string>
-    <string name="action_post_failed_detail_plural">Не атрымалася запампаваць вашы допісы і яны былі захаваны ў чарнавікі.
+\nАльбо не атрымалася злучыцца з серверам ці ён адхіліў допіс.</item>
+        <item quantity="other">Не атрымалася запампаваць вашы допісы і яны былі захаваны ў чарнавікі.
 \n
-\nАльбо не атрымалася злучыцца з серверам ці ён адхіліў допісы.</string>
+\nАльбо не атрымалася злучыцца з серверам ці ён адхіліў допісы.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Паказаць чарнавікі</string>
     <string name="action_post_failed_do_nothing">Адмяніць</string>
     <string name="description_login">Працуе амаль заўсёды. Даныя не ўцякаюць у іншыя праграмы.</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -517,12 +517,14 @@
     <string name="post_edited">S\'ha editat %1$s</string>
     <string name="notification_update_name">Edicions de publicacions</string>
     <string name="action_post_failed">La càrrega ha fallat</string>
-    <string name="action_post_failed_detail">La teva publicació no s\'ha pogut penjar i s\'ha desat als esborranys.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">La teva publicació no s\'ha pogut penjar i s\'ha desat als esborranys.
 \n
-\nNo s\'ha pogut contactar amb el servidor o bé ha rebutjat la publicació.</string>
-    <string name="action_post_failed_detail_plural">Les teves publicacions no s\'han pogut penjar i s\'han desat als esborranys.
+\nNo s\'ha pogut contactar amb el servidor o bé ha rebutjat la publicació.</item>
+        <item quantity="other">Les teves publicacions no s\'han pogut penjar i s\'han desat als esborranys.
 \n
-\nNo s\'ha pogut contactar amb el servidor o ha rebutjat les publicacions.</string>
+\nNo s\'ha pogut contactar amb el servidor o ha rebutjat les publicacions.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Mostra esborranys</string>
     <string name="action_post_failed_do_nothing">Descartar</string>
     <string name="send_account_link_to">Comparteix l\'URL del compte a…</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -679,9 +679,14 @@
     <string name="title_public_trending_hashtags">Populární hashtagy</string>
     <string name="error_media_upload_sending_fmt">Nahrávání selhalo: %1$s</string>
     <string name="title_followed_hashtags">Sledované hashtagy</string>
-    <string name="action_post_failed_detail_plural">Nahrávání tvých postuů selhalo a posty byly uloženy mezi koncepty.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Nahrávání tvého postu selhalo a post byl uložen mezi koncepty.
 \n
-\nServer buď nemohl být kontaktován, nebo posty odmítl.</string>
+\nServer buď nemohl být kontaktován, nebo post odmítl.</item>
+        <item quantity="other">Nahrávání tvých postuů selhalo a posty byly uloženy mezi koncepty.
+\n
+\nServer buď nemohl být kontaktován, nebo posty odmítl.</item>
+    </plurals>
     <string name="post_privacy_direct">Přímo</string>
     <string name="notification_listenable_worker_description">Upozornění když Tusky běží na pozadí</string>
     <string name="about_device_info_title">Tvé zařízení</string>
@@ -708,9 +713,6 @@
     <string name="notification_header_report_format">%1$s nahlášeno %2$s</string>
     <string name="notification_summary_report_format">%1$s · %2$d postů připojeno</string>
     <string name="action_post_failed">Nahrávání selhalo</string>
-    <string name="action_post_failed_detail">Nahrávání tvého postu selhalo a post byl uložen mezi koncepty.
-\n
-\nServer buď nemohl být kontaktován, nebo post odmítl.</string>
     <string name="ui_error_accept_follow_request">Povolení žádosti o sledování selhalo: %1$s</string>
     <string name="help_empty_lists">Toto je tvůj seznam <b>seznamů</b>. Můžeš si definovat různý počet soukromých seznamů a přidat do nich uživatelské účty.
 \n

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -639,15 +639,18 @@
     <string name="action_browser_login">Mewngofnodi â phorwr</string>
     <string name="description_login">Yn gweithio yn y rhan mwyaf o achosion. Nid oes unrhyw ddata yn cael ei ollwng i apiau eraill.</string>
     <string name="description_browser_login">Efallai y bydd dulliau dilysu ychwanegol ar gael, ond mae eu hangen porwr arall.</string>
-    <string name="action_post_failed_detail">Methodd eich neges â llwytho i fyny a chafodd ei chadw i\'ch drafftiau.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Methodd eich neges â llwytho i fyny a chafodd ei chadw i\'ch drafftiau.
 \n
-\nNaill ai nid oedd modd cysylltu â\'r gweinydd, neu fe wrthododd y neges.</string>
+\nNaill ai nid oedd modd cysylltu â\'r gweinydd, neu fe wrthododd y neges.</item>
+        <item quantity="other">Methodd eich negeseuon â llwytho i fyny a chafodd ei chadw i\'ch drafftiau.
+\n
+\nNaill ai nid oedd modd cysylltu â\'r gweinydd, neu fe wrthododd y negeseuon.</item>
+    </plurals>
     <string name="action_post_failed">Wedi methu llwytho i fyny</string>
     <string name="action_post_failed_show_drafts">Dangos drafftiau</string>
     <string name="action_post_failed_do_nothing">Diystyru</string>
-    <string name="action_post_failed_detail_plural">Methodd eich negeseuon â llwytho i fyny a chafodd ei chadw i\'ch drafftiau.
-\n
-\nNaill ai nid oedd modd cysylltu â\'r gweinydd, neu fe wrthododd y negeseuon.</string>
+
     <string name="title_public_trending_hashtags">Hashnodau poblogaidd</string>
     <string name="accessibility_talking_about_tag">Mae %1$d o bobl yn siarad am hashnod %2$s</string>
     <string name="total_usage">Defnydd cyfan</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -578,12 +578,14 @@
     <string name="pref_title_http_proxy_port_message">Port sollte zwischen %1$d und %2$d liegen</string>
     <string name="error_muting_hashtag_format">Fehler beim Stummschalten von #%1$s</string>
     <string name="action_post_failed">Hochladen fehlgeschlagen</string>
-    <string name="action_post_failed_detail">Dein Beitrag konnte nicht gepostet werden und wurde als Entwurf gespeichert.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Dein Beitrag konnte nicht gepostet werden und wurde als Entwurf gespeichert.
 \n
-\nEntweder ist die Verbindung zum Server fehlgeschlagen oder der Server hat den Beitrag abgelehnt.</string>
-    <string name="action_post_failed_detail_plural">Deine Beiträge konnte nicht gepostet werden und wurde als Entwürfe gespeichert.
+\nEntweder ist die Verbindung zum Server fehlgeschlagen oder der Server hat den Beitrag abgelehnt.</item>
+        <item quantity="other">Deine Beiträge konnte nicht gepostet werden und wurde als Entwürfe gespeichert.
 \n
-\nEntweder ist die Verbindung zum Server fehlgeschlagen oder der Server hat die Beiträge abgelehnt.</string>
+\nEntweder ist die Verbindung zum Server fehlgeschlagen oder der Server hat die Beiträge abgelehnt.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Entwürfe anzeigen</string>
     <string name="action_post_failed_do_nothing">Abbrechen</string>
     <string name="post_edited">Bearbeitet %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -603,12 +603,14 @@
     <string name="pref_summary_http_proxy_disabled">Desactivado</string>
     <string name="pref_summary_http_proxy_missing">&lt;sin establecer&gt;</string>
     <string name="pref_summary_http_proxy_invalid">&lt;inválido&gt;</string>
-    <string name="action_post_failed_detail">No se ha podido subir tu publicación y se ha guardado en Borradores.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">No se ha podido subir tu publicación y se ha guardado en Borradores.
 \n
-\nO no se ha podido contactar con el servidor, o ha rechazado tu publicación.</string>
-    <string name="action_post_failed_detail_plural">Tus publicaciones no se han podido subir y se han guardado en Borradores.
+\nO no se ha podido contactar con el servidor, o ha rechazado tu publicación.</item>
+        <item quantity="other">Tus publicaciones no se han podido subir y se han guardado en Borradores.
 \n
-\nO no se ha podido contactar con el servidor, o ha rechazado tus publicaciones.</string>
+\nO no se ha podido contactar con el servidor, o ha rechazado tus publicaciones.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Mostrar borradores</string>
     <string name="send_account_username_to">Compartir nombre de usuario de la cuenta con…</string>
     <string name="account_username_copied">Nombre de usuario copiado</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -520,12 +520,14 @@
     <string name="title_followed_hashtags">Jarraitutako traolak</string>
     <string name="notification_update_format">%1$s-(e)k bere tuta editatu du</string>
     <string name="action_post_failed">Igoerak huts egin du</string>
-    <string name="action_post_failed_detail">Akatsa zure tuta bidaltzean, beraz, zirriborroetara bidali da.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Akatsa zure tuta bidaltzean, beraz, zirriborroetara bidali da.
 \n
-\nZerbitzariarekin ezin izan da komunikatu edo tuta baztertu egin da.</string>
-    <string name="action_post_failed_detail_plural">Akatsa zure tutak bidaltzean, beraz, zirriborroetara bidali dira.
+\nZerbitzariarekin ezin izan da komunikatu edo tuta baztertu egin da.</item>
+        <item quantity="other">Akatsa zure tutak bidaltzean, beraz, zirriborroetara bidali dira.
 \n
-\nZerbitzariarekin ezin izan da komunikatu edo zure tutak baztertuak izan dira.</string>
+\nZerbitzariarekin ezin izan da komunikatu edo zure tutak baztertuak izan dira.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Zirriborroak erakutsi</string>
     <string name="action_post_failed_do_nothing">Baztertu</string>
     <string name="post_media_alt">ALT</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -585,12 +585,14 @@
     <string name="action_post_failed">بارگذاری شکست خورد</string>
     <string name="action_post_failed_show_drafts">نمایش پیش‌نویس‌ها</string>
     <string name="action_post_failed_do_nothing">رد کردن</string>
-    <string name="action_post_failed_detail">بارگذاری فرسته‌تان شکست خورد و در پیش‌نویس‌ها ذخیره شد.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">بارگذاری فرسته‌تان شکست خورد و در پیش‌نویس‌ها ذخیره شد.
 \n
-\nارتباط با کارساز برقرار نشد یا فرسته را رد کرد.</string>
-    <string name="action_post_failed_detail_plural">بارگذاری فرسته‌هایتان شکست خورد و در پیش‌نویس‌ها ذخیره شد.
+\nارتباط با کارساز برقرار نشد یا فرسته را رد کرد.</item>
+        <item quantity="other">بارگذاری فرسته‌هایتان شکست خورد و در پیش‌نویس‌ها ذخیره شد.
 \n
-\nارتباط با کارساز برقرار نشد یا فرسته‌ها را رد کرد.</string>
+\nارتباط با کارساز برقرار نشد یا فرسته‌ها را رد کرد.</item>
+    </plurals>
     <string name="description_login">در بیش‌تر حالت‌ها کار می‌کند. هیچ داده‌ای به دیگر کاره‌ها نشت نمی‌کند.</string>
     <string name="pref_reading_order_oldest_first">نخست قدیمی‌ترین</string>
     <string name="description_browser_login">ممکن است از روش‌های تأیید خویت اضافی پشتیبانی کند؛ ولی نیازمند مرورگری پشتیبانی شده است.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -414,9 +414,14 @@
     <string name="error_media_upload_sending_fmt">Tiedoston lataaminen epäonnistui: %1$s</string>
     <string name="account_username_copied">Käyttäjätunnus kopioitu</string>
     <string name="error_multimedia_size_limit">Video- tai äänitiedoston koko ei voi ylittää %1$s Mt.</string>
-    <string name="action_post_failed_detail">Julkaisusi lähettäminen epäonnistui ja se tallennettiin luonnoksiin.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Julkaisusi lähettäminen epäonnistui ja se tallennettiin luonnoksiin.
 \n
-\nPalvelimeen ei saatu yhteyttä tai se hylkäsi julkaisun.</string>
+\nPalvelimeen ei saatu yhteyttä tai se hylkäsi julkaisun.</item>
+        <item quantity="other">Julkaisusi lähettäminen epäonnistui ja ne tallennettiin luonnoksiin.
+\n
+\nPalvelimeen ei saatu yhteyttä tai se hylkäsi julkaisun.</item>
+    </plurals>
     <string name="dialog_whats_an_instance">Tähän voit syöttää minkä vaan instanssin osoitteen tai domainin, kuten esimerkiksi mastodon.social, icosahedron.website, social.tchncs.de, ja <a href="https://instances.social">muut!</a>
 \n
 \nJos sinulla ei vielä ole tiliä, voit syöttää sen instanssin nimen johon haluat liittyä, ja sitten luoda tilin.
@@ -444,9 +449,6 @@
     <string name="notification_report_format">Uusi ilmianto tilille %1$s</string>
     <string name="notification_summary_report_format">%1$s · %2$d julkaisua liitetty</string>
     <string name="action_browser_login">Kirjaudu selaimella</string>
-    <string name="action_post_failed_detail_plural">Julkaisusi lähettäminen epäonnistui ja ne tallennettiin luonnoksiin.
-\n
-\nPalvelimeen ei saatu yhteyttä tai se hylkäsi julkaisun.</string>
     <string name="action_post_failed_do_nothing">Peru</string>
     <string name="action_share_account_link">Jaa linkki tiliin</string>
     <string name="action_share_account_username">Jaa tilin käyttäjätunnus</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -612,12 +612,14 @@
     <string name="report_category_spam">Spam</string>
     <string name="report_category_other">Autre</string>
     <string name="total_accounts">comptes</string>
-    <string name="action_post_failed_detail">Le statut n\'a pas pu être publié, il a été sauvegardé dans les brouillons.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Le statut n\'a pas pu être publié, il a été sauvegardé dans les brouillons.
 \n
-\nLe serveur n\'est pas joignable, ou celui-ci a refusé la publication.</string>
-    <string name="action_post_failed_detail_plural">Les status n\'ont pas pu être publiés, ils ont été sauvegardés dans les brouillons.
+\nLe serveur n\'est pas joignable, ou celui-ci a refusé la publication.</item>
+        <item quantity="other">Les status n\'ont pas pu être publiés, ils ont été sauvegardés dans les brouillons.
 \n
-\nLe serveur n\'est pas joignable, ou celui-ci a refusé la publication.</string>
+\nLe serveur n\'est pas joignable, ou celui-ci a refusé la publication.</item>
+    </plurals>
     <string name="action_refresh">Actualiser</string>
     <string name="failed_to_unpin">Échec du détachement</string>
     <string name="pref_title_show_self_username">Montrer le nom d\'utilisateur dans la barre d\'outils</string>

--- a/app/src/main/res/values-gd/strings.xml
+++ b/app/src/main/res/values-gd/strings.xml
@@ -590,9 +590,14 @@
     <string name="notification_report_description">Brathan mu ghearanan na maorsainneachd</string>
     <string name="post_media_alt">ALT</string>
     <string name="action_post_failed">Dh’fhàillig leis an luchdadh suas</string>
-    <string name="action_post_failed_detail_plural">Dh’fhàillig luchdadh suas nam postaichean agad is chaidh an sàbhaladh ’nan dreachdan.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Dh’fhàillig luchdadh suas a’ phuist agad is chaidh a shàbhaladh ’na dhreachd.
 \n
-\nCha d’ fhuair sinn grèim air an fhrithealaiche no dhiùlt e na postaichean.</string>
+\nCha d’ fhuair sinn grèim air an fhrithealaiche no dhiùlt e am post.</item>
+        <item quantity="other">Dh’fhàillig luchdadh suas nam postaichean agad is chaidh an sàbhaladh ’nan dreachdan.
+\n
+\nCha d’ fhuair sinn grèim air an fhrithealaiche no dhiùlt e na postaichean.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Seall na dreachdan</string>
     <string name="action_post_failed_do_nothing">Leig seachad</string>
     <string name="confirmation_hashtag_unfollowed">Chan eil #%1$s a’ leantainn tuilleadh</string>
@@ -613,9 +618,6 @@
     <string name="account_username_copied">Chaidh lethbhreac a dhèanamh dhen ainm-chleachdaiche</string>
     <string name="compose_unsaved_changes">Tha atharraichean gun sàbhaladh agad.</string>
     <string name="error_status_source_load">Dh’fhàillig luchdadh bun-tùs a’ phuist on fhrithealaiche.</string>
-    <string name="action_post_failed_detail">Dh’fhàillig luchdadh suas a’ phuist agad is chaidh a shàbhaladh ’na dhreachd.
-\n
-\nCha d’ fhuair sinn grèim air an fhrithealaiche no dhiùlt e am post.</string>
     <string name="action_share_account_username">Co-roinn ainm-cleachdaiche a’ chunntais</string>
     <string name="send_account_link_to">Co-roinn URL a’ chunntais le…</string>
     <string name="send_account_username_to">Co-roinn ainm-cleachdaiche a’ chunntais le…</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -586,12 +586,14 @@
     <string name="pref_summary_http_proxy_disabled">Desactivado</string>
     <string name="pref_summary_http_proxy_invalid">&lt;non válido&gt;</string>
     <string name="action_post_failed">Produciuse un fallo no envío</string>
-    <string name="action_post_failed_detail">Produciuse un fallo no envío da publicación e gardouse nos borradores.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Produciuse un fallo no envío da publicación e gardouse nos borradores.
 \n
-\nPode que o servidor non estivese accesible ou que rexeitase a publicación.</string>
-    <string name="action_post_failed_detail_plural">Produciuse un fallo no envío das túas publicacións e gardáronse nos borradores.
+\nPode que o servidor non estivese accesible ou que rexeitase a publicación.</item>
+        <item quantity="other">Produciuse un fallo no envío das túas publicacións e gardáronse nos borradores.
 \n
-\nPode que o servidor non estivese accesible ou que rexeitase as publicacións.</string>
+\nPode que o servidor non estivese accesible ou que rexeitase as publicacións.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Mostrar borradores</string>
     <string name="action_post_failed_do_nothing">Desbotar</string>
     <string name="action_browser_login">Acceder co Navegador</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -593,12 +593,14 @@
     <string name="send_account_username_to">Fiók felhasználói nevének megosztása vele…</string>
     <string name="account_username_copied">Felhasználónév másolva</string>
     <string name="action_post_failed">Feltöltés meghiúsult</string>
-    <string name="action_post_failed_detail">A bejegyzésed feltöltése meghiúsult, és a vázlatokba mentettük el.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">A bejegyzésed feltöltése meghiúsult, és a vázlatokba mentettük el.
 \n
-\nVagy a kiszolgálót nem lehetett elérni, vagy visszautasította a bejegyzést.</string>
-    <string name="action_post_failed_detail_plural">A bejegyzésed feltöltése meghiúsult, és a vázlatokba mentettük el.
+\nVagy a kiszolgálót nem lehetett elérni, vagy visszautasította a bejegyzést.</item>
+        <item quantity="other">A bejegyzésed feltöltése meghiúsult, és a vázlatokba mentettük el.
 \n
-\nVagy a kiszolgálót nem lehetett elérni, vagy visszautasította a bejegyzést.</string>
+\nVagy a kiszolgálót nem lehetett elérni, vagy visszautasította a bejegyzést.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Vázlatok megjelenítése</string>
     <string name="action_post_failed_do_nothing">Elvetés</string>
     <string name="action_browser_login">Bejelentkezés Böngészővel</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -590,12 +590,14 @@
     <string name="action_post_failed">Innsending mistókst</string>
     <string name="action_post_failed_show_drafts">Birta drög</string>
     <string name="action_post_failed_do_nothing">Afgreiða</string>
-    <string name="action_post_failed_detail">Ekki tókst að senda inn færsluna þína og hefur hún verið vistuð í Drög.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Ekki tókst að senda inn færsluna þína og hefur hún verið vistuð í Drög.
 \n
-\nAnnað hvort náðist ekki í netþjóninn, eða hann hafnaði færslunni.</string>
-    <string name="action_post_failed_detail_plural">Ekki tókst að senda inn færslurnar þína og hafa þær verið vistaðar í Drög.
+\nAnnað hvort náðist ekki í netþjóninn, eða hann hafnaði færslunni.</item>
+        <item quantity="other">Ekki tókst að senda inn færslurnar þína og hafa þær verið vistaðar í Drög.
 \n
-\nAnnað hvort náðist ekki í netþjóninn, eða hann hafnaði færslunum.</string>
+\nAnnað hvort náðist ekki í netþjóninn, eða hann hafnaði færslunum.</item>
+    </plurals>
     <string name="action_browser_login">Skrá inn í vafra</string>
     <string name="description_login">Virkar í flestum tilvikum. Engum gögnum er lekið til annarra forrita.</string>
     <string name="description_browser_login">Gæti stutt fleiri aðferðir til auðkenningar, en krefst studds vafra.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -602,12 +602,14 @@
     <string name="pref_summary_http_proxy_missing">&lt;non impostato&gt;</string>
     <string name="pref_summary_http_proxy_invalid">&lt;non valido&gt;</string>
     <string name="pref_reading_order_newest_first">Più nuovi prima</string>
-    <string name="action_post_failed_detail">Non è stato possibile caricare il tuo post ed è stato salvato nelle bozze.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Non è stato possibile caricare il tuo post ed è stato salvato nelle bozze.
 \n
-\nNon è stato possibile contattare il server oppure il server ha rifiutato il post.</string>
-    <string name="action_post_failed_detail_plural">Non è stato possibile caricare i tuoi post e sono stati salvati nelle bozze.
+\nNon è stato possibile contattare il server oppure il server ha rifiutato il post.</item>
+        <item quantity="other">Non è stato possibile caricare i tuoi post e sono stati salvati nelle bozze.
 \n
-\nNon è stato possibile contattare il server oppure il server ha rifiutato i post.</string>
+\nNon è stato possibile contattare il server oppure il server ha rifiutato i post.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Mostra bozze</string>
     <string name="action_post_failed_do_nothing">Chiudi</string>
     <string name="send_account_username_to">Condividi nome utente dell\'account a…</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -584,17 +584,16 @@
     <string name="notification_update_description">やり取りした投稿が編集されたときの通知</string>
     <string name="pref_title_http_proxy_port_message">ポートは %1$d から %2$d の間でなければなりません</string>
     <string name="action_post_failed">アップロードに失敗しました</string>
-    <string name="action_post_failed_detail">アップロードに失敗した投稿は下書きに保存されました。
+    <plurals name="action_post_failed_detail">
+        <item quantity="other">アップロードに失敗した投稿は下書きに保存されました。
 \n
-\nサーバーと接続できなかったか、投稿が拒否されました。</string>
+\nサーバーと接続できなかったか、投稿が拒否されました。</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">下書きを表示</string>
     <string name="action_post_failed_do_nothing">閉じる</string>
     <string name="action_browser_login">ブラウザでログイン</string>
     <string name="description_login">ほとんどの場合に動作します。他のアプリにはデータが漏洩しません。</string>
     <string name="description_browser_login">追加の認証方法がサポートされる可能性がありますが、対応ブラウザが必要です。</string>
-    <string name="action_post_failed_detail_plural">アップロードに失敗した投稿は下書きに保存されました。
-\n
-\nサーバーと接続できなかったか、投稿が拒否されました。</string>
     <string name="dialog_follow_hashtag_title">ハッシュタグをフォロー</string>
     <string name="post_media_image">画像</string>
     <string name="notification_unknown_name">不明</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -545,12 +545,14 @@
     <string name="abbreviated_in_years">pēc %1$dg</string>
     <string name="abbreviated_in_seconds">pēc %1$ds</string>
     <string name="pref_title_alway_open_spoiler">Vienmēr izvērst ziņas, kas atzīmētas ar satura brīdinājumu</string>
-    <string name="action_post_failed_detail">Neizdevās augšupielādēt tavu ierakstu un tas tika saglabāts melnrakstos.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Neizdevās augšupielādēt tavu ierakstu un tas tika saglabāts melnrakstos.
 \n
-\nVai nu neizdevās sazināties ar serveri, vai arī tas noraidīja ierakstu.</string>
-    <string name="action_post_failed_detail_plural">Neizdevās augšupielādēt tavus ierakstus un tie tika saglabāti melnrakstos.
+\nVai nu neizdevās sazināties ar serveri, vai arī tas noraidīja ierakstu.</item>
+        <item quantity="other">Neizdevās augšupielādēt tavus ierakstus un tie tika saglabāti melnrakstos.
 \n
-\nVai nu neizdevās sazināties ar serveri, vai arī tas noraidīja ierakstus.</string>
+\nVai nu neizdevās sazināties ar serveri, vai arī tas noraidīja ierakstus.</item>
+    </plurals>
     <string name="notification_favourite_description">Paziņojumi par tavu ierakstu pievienošanu izlasei</string>
     <string name="wellbeing_mode_notice">Daļa informācijas, kas varētu ietekmēt tavu garīgo labsajūtu, tiks slēpta. Tas ietver:
 \n

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -595,9 +595,14 @@
     <string name="filter_description_format">%1$s: %2$s</string>
     <string name="pref_title_http_proxy_port_message">Portnummer burde være mellom %1$d og %2$d</string>
     <string name="action_post_failed">Opplastningen mislyktes</string>
-    <string name="action_post_failed_detail_plural">Opplastningen av innleggene dine mislyktes og de har blitt lagret som utkast.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Opplastingen mislyktes og har blitt lagret som utkast.
 \n
-\nEnten kunne ikke tjeneren nås, eller så ble opplastningen avvist.</string>
+\nEnten kunne ikke tjeneren ikke kontaktes, eller så ble posten avvist.</item>
+        <item quantity="other">Opplastningen av innleggene dine mislyktes og de har blitt lagret som utkast.
+\n
+\nEnten kunne ikke tjeneren nås, eller så ble opplastningen avvist.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Vis utkast</string>
     <string name="action_post_failed_do_nothing">Lukk</string>
     <string name="post_media_alt">ALT</string>
@@ -611,9 +616,6 @@
     <string name="action_browser_login">Logg inn med nettleseren</string>
     <string name="description_browser_login">Kan støtte flere autentiseringsmetoder, men trenger en støttet nettleser.</string>
     <string name="description_login">Virker som oftest. Ingen informasjon deles med andre apper.</string>
-    <string name="action_post_failed_detail">Opplastingen mislyktes og har blitt lagret som utkast.
-\n
-\nEnten kunne ikke tjeneren ikke kontaktes, eller så ble posten avvist.</string>
     <string name="ui_success_accepted_follow_request">Følgeforespørsel akseptert</string>
     <string name="action_discard">Forkast endringer</string>
     <string name="action_continue_edit">Fortsett endring</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -576,12 +576,14 @@
     <string name="title_followed_hashtags">Gevolgde hashtags</string>
     <string name="dialog_follow_hashtag_title">Hashtag volgen</string>
     <string name="action_post_failed">Upload mislukt</string>
-    <string name="action_post_failed_detail">Je bericht kan niet worden geüpload en is opgeslagen in concepten.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Je bericht kan niet worden geüpload en is opgeslagen in concepten.
 \n
-\nEr kon geen contact worden opgenomen met de server, of het bericht werd geweigerd.</string>
-    <string name="action_post_failed_detail_plural">Je berichten kunnen niet worden geüpload en zijn opgeslagen in concepten.
+\nEr kon geen contact worden opgenomen met de server, of het bericht werd geweigerd.</item>
+        <item quantity="other">Je berichten kunnen niet worden geüpload en zijn opgeslagen in concepten.
 \n
-\nEr kon geen contact worden opgenomen met de server of de berichten werden geweigerd.</string>
+\nEr kon geen contact worden opgenomen met de server of de berichten werden geweigerd.</item>
+    </plurals>
     <string name="action_post_failed_do_nothing">Afwijzen</string>
     <string name="action_post_failed_show_drafts">Concepten tonen</string>
     <string name="error_unmuting_hashtag_format">Fout bij het niet langer negeren van #%1$s</string>

--- a/app/src/main/res/values-oc/strings.xml
+++ b/app/src/main/res/values-oc/strings.xml
@@ -596,12 +596,14 @@
     <string name="action_post_failed">Mandadís fracassat</string>
     <string name="action_post_failed_show_drafts">Afichar los borrolhons</string>
     <string name="action_post_failed_do_nothing">Ignorar</string>
-    <string name="action_post_failed_detail">Vòstra publicacion a pas pogut s’enviar e es estada salvada als borrolhons.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Vòstra publicacion a pas pogut s’enviar e es estada salvada als borrolhons.
 \n
-\nSiá se podiá pas contactar lo servidor, siá aquel a regetat la publicacion.</string>
-    <string name="action_post_failed_detail_plural">Vòstras publicacions an pas pogut s’enviar e son estadas salvadas als borrolhons.
+\nSiá se podiá pas contactar lo servidor, siá aquel a regetat la publicacion.</item>
+        <item quantity="other">Vòstras publicacions an pas pogut s’enviar e son estadas salvadas als borrolhons.
 \n
-\nSiá se podiá pas contactar lo servidor, siá aquel a regetat las publicacions.</string>
+\nSiá se podiá pas contactar lo servidor, siá aquel a regetat las publicacions.</item>
+    </plurals>
     <string name="action_browser_login">Connexion via Navigador</string>
     <string name="description_browser_login">Poiriá prendre en carga de metòdes d’autentificacions suplementaris, mas requerís un navigador compatible.</string>
     <string name="description_login">Fonciona los tres quarts del temps. Cap de donadas pèrdon pas per las autras aplicacions.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -609,12 +609,14 @@
     <string name="pref_summary_http_proxy_missing">&lt;nieustawiony&gt;</string>
     <string name="pref_summary_http_proxy_invalid">&lt;niepoprawny&gt;</string>
     <string name="pref_title_http_proxy_port_message">Port powinien być pomiędzy %1$d a %2$d</string>
-    <string name="action_post_failed_detail">Wystąpił problem podczas publikacji posta, ale został on zapisany w szkicach.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Wystąpił problem podczas publikacji posta, ale został on zapisany w szkicach.
 \n
-\nAlbo wystąpił problem z połączeniem z serwerem, albo serwer odrzucił post.</string>
-    <string name="action_post_failed_detail_plural">Wystąpił problem podczas publikacji Twojego posta i został on zapisany w szkicach.
+\nAlbo wystąpił problem z połączeniem z serwerem, albo serwer odrzucił post.</item>
+        <item quantity="other">Wystąpił problem podczas publikacji Twojego posta i został on zapisany w szkicach.
 \n
-\nAlbo wystąpił problem z połączeniem z serwerem, albo serwer odrzucił Twój post.</string>
+\nAlbo wystąpił problem z połączeniem z serwerem, albo serwer odrzucił Twój post.</item>
+    </plurals>
     <string name="error_muting_hashtag_format">Wystąpił błąd podczas wyciszania #%1$s</string>
     <string name="error_unmuting_hashtag_format">Wystąpił błąd podczas zdejmowania wyciszenia #%1$s</string>
     <string name="language_display_name_format">%1$s (%2$s)</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -552,12 +552,14 @@
     <string name="hint_media_description_missing">Imagem/Vídeo deve ter uma descrição.</string>
     <string name="pref_title_http_proxy_port_message">A porta deve estar entre %1$d e %2$d</string>
     <string name="action_post_failed">Erro no upload</string>
-    <string name="action_post_failed_detail">A tua publicação não conseguiu ser enviada e foi guardada nos rascunhos.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">A tua publicação não conseguiu ser enviada e foi guardada nos rascunhos.
 \n
-\nO servidor não pode ser contactado ou rejeitou a publicação.</string>
-    <string name="action_post_failed_detail_plural">As tuas publicações não conseguiram ser enviadas e foram guardadas nos rascunhos.
+\nO servidor não pode ser contactado ou rejeitou a publicação.</item>
+        <item quantity="other">As tuas publicações não conseguiram ser enviadas e foram guardadas nos rascunhos.
 \n
-\nO servidor não pode ser contactado ou rejeitou as publicações.</string>
+\nO servidor não pode ser contactado ou rejeitou as publicações.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Mostrar rascunhos</string>
     <string name="action_post_failed_do_nothing">Descartar</string>
     <string name="post_media_alt">ALT</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -601,12 +601,14 @@
     <string name="duration_60_days">60 дней</string>
     <string name="pref_title_http_proxy_port_message">Порт должен находиться в диапазоне от %1$d до %2$d</string>
     <string name="action_post_failed">Загрузка не удалась</string>
-    <string name="action_post_failed_detail">Ваше сообщение не удалось загрузить и оно было сохранено в черновиках.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Ваше сообщение не удалось загрузить и оно было сохранено в черновиках.
 \n
-\nЛибо с сервером не удалось связаться, либо он отклонил сообщение.</string>
-    <string name="action_post_failed_detail_plural">Ваши сообщения не удалось загрузить и они были сохранены в черновиках.
+\nЛибо с сервером не удалось связаться, либо он отклонил сообщение.</item>
+        <item quantity="other">Ваши сообщения не удалось загрузить и они были сохранены в черновиках.
 \n
-\nЛибо с сервером не удалось связаться, либо он отклонил сообщения.</string>
+\nЛибо с сервером не удалось связаться, либо он отклонил сообщения.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Показать черновики</string>
     <string name="action_post_failed_do_nothing">Отклонить</string>
     <string name="duration_30_days">30 дней</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -152,12 +152,14 @@
     <string name="action_compose">Napísať</string>
     <string name="action_browser_login">Prihlásiť sa cez prehliadač</string>
     <string name="action_post_failed">Nahrávanie zlyhalo</string>
-    <string name="action_post_failed_detail">Váš príspevok sa nepodarilo nahrať a bol uložený medzi koncepty.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Váš príspevok sa nepodarilo nahrať a bol uložený medzi koncepty.
 \n
-\nServer sa buď nepodarilo kontaktovať, alebo príspevok odmietol.</string>
-    <string name="action_post_failed_detail_plural">Váše príspevky sa nepodarilo nahrať a boli uložené medzi koncepty.
+\nServer sa buď nepodarilo kontaktovať, alebo príspevok odmietol.</item>
+        <item quantity="other">Váše príspevky sa nepodarilo nahrať a boli uložené medzi koncepty.
 \n
-\nServer sa buď nepodarilo kontaktovať, alebo príspevky odmietol.</string>
+\nServer sa buď nepodarilo kontaktovať, alebo príspevky odmietol.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Zobraziť koncepty</string>
     <string name="action_post_failed_do_nothing">Zrušiť</string>
     <string name="action_share_account_link">Zdieľať odkaz na účet</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -593,17 +593,19 @@
     <string name="action_continue_edit">Fortsätt redigera</string>
     <string name="compose_unsaved_changes">Du har ändringar som inte sparats.</string>
     <string name="action_post_failed">Uppladdning misslyckades</string>
-    <string name="action_post_failed_detail">Ett fel inträffade när inlägget skulle laddas upp och har sparats till utkast.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Ett fel inträffade när inlägget skulle laddas upp och har sparats till utkast.
 \n
-\nAntingen kunde servern inte kontaktas, eller så nekades uppladdningen.</string>
+\nAntingen kunde servern inte kontaktas, eller så nekades uppladdningen.</item>
+        <item quantity="other">Uppladdning av dina inlägg misslyckades och de har sparats i utkast.
+\n
+\nAntingen kunde inte servern nås eller så har uppladdningen nekats.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Visa utkast</string>
     <string name="action_browser_login">Inloggning via webbläsaren</string>
     <string name="pref_summary_http_proxy_disabled">Inaktiverad</string>
     <string name="pref_summary_http_proxy_missing">&lt;ej angiven&gt;</string>
     <string name="pref_summary_http_proxy_invalid">&lt;felaktig&gt;</string>
-    <string name="action_post_failed_detail_plural">Uppladdning av dina inlägg misslyckades och de har sparats i utkast.
-\n
-\nAntingen kunde inte servern nås eller så har uppladdningen nekats.</string>
     <string name="action_post_failed_do_nothing">Avbryt</string>
     <string name="description_login">Fungerar i de flesta fallen. Ingen information läcker till andra applikationer.</string>
     <string name="pref_reading_order_oldest_first">Äldsta först</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -597,12 +597,14 @@
     <string name="label_filter_keywords">Süzgeçlenecek anahtar kelimeler veya kelime öbekleri</string>
     <string name="filter_keyword_display_format">%1$s (tüm dünya)</string>
     <string name="action_post_failed">Yükleme başarısız</string>
-    <string name="action_post_failed_detail">Gönderin yüklenemedi ve taslaklara kaydedildi.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Gönderin yüklenemedi ve taslaklara kaydedildi.
 \n
-\nSunucuya bağlanılamamış veya sunucu gönderiyi reddetmiş olabilir.</string>
-    <string name="action_post_failed_detail_plural">Gönderilerin yüklenemedi ve taslaklara kaydedildi.
+\nSunucuya bağlanılamamış veya sunucu gönderiyi reddetmiş olabilir.</item>
+        <item quantity="other">Gönderilerin yüklenemedi ve taslaklara kaydedildi.
 \n
-\nSunucuya bağlanılamamış veya sunucu gönderiyi reddetmiş olabilir.</string>
+\nSunucuya bağlanılamamış veya sunucu gönderiyi reddetmiş olabilir.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Taslakları göster</string>
     <string name="action_post_failed_do_nothing">Yoksay</string>
     <string name="notification_unknown_name">Bilinmeyen</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -613,12 +613,14 @@
     <string name="action_post_failed">Не вдалося вивантажити</string>
     <string name="action_post_failed_show_drafts">Показати чернетки</string>
     <string name="action_post_failed_do_nothing">Відхилити</string>
-    <string name="action_post_failed_detail">Не вдалося вивантажити ваш допис і його було збережено в чернетках.
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Не вдалося вивантажити ваш допис і його було збережено в чернетках.
 \n
-\nАбо з не вдалося зв\'язатися з сервером, або він відхилив допис.</string>
-    <string name="action_post_failed_detail_plural">Не вдалося вивантажити ваш допис і його було збережено в чернетках.
+\nАбо з не вдалося зв\'язатися з сервером, або він відхилив допис.</item>
+        <item quantity="other">Не вдалося вивантажити ваш допис і його було збережено в чернетках.
 \n
-\nАбо з не вдалося зв\'язатися з сервером, або він відхилив допис.</string>
+\nАбо з не вдалося зв\'язатися з сервером, або він відхилив допис.</item>
+    </plurals>
     <string name="accessibility_talking_about_tag">%1$d людей обговорюють хештеґ %2$s</string>
     <string name="title_public_trending_hashtags">Популярні хештеги</string>
     <string name="total_usage">Усього використано</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -579,12 +579,11 @@
     <string name="action_browser_login">Đăng nhập bằng trình duyệt</string>
     <string name="description_login">Đăng nhập ổn định. Dữ liệu sẽ không bị lộ.</string>
     <string name="action_post_failed">Tải lên thất bại</string>
-    <string name="action_post_failed_detail">Tút của bạn không tải lên được và đã được lưu nháp.
+    <plurals name="action_post_failed_detail">
+        <item quantity="other">Tút của bạn không tải lên được và đã được lưu nháp.
 \n
-\nKhông thể liên lạc được với máy chủ hoặc nó đã từ chối tút.</string>
-    <string name="action_post_failed_detail_plural">Tút của bạn không tải lên được và đã được lưu nháp.
-\n
-\nKhông thể liên lạc được với máy chủ hoặc nó đã từ chối tút.</string>
+\nKhông thể liên lạc được với máy chủ hoặc nó đã từ chối tút.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Xem bản nháp</string>
     <string name="action_post_failed_do_nothing">Bỏ qua</string>
     <string name="title_public_trending_hashtags">Hashtag xu hướng</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -592,15 +592,14 @@
     <string name="action_browser_login">用浏览器登录</string>
     <string name="description_login">多数情况下有效。没有数据泄露给其他应用。</string>
     <string name="description_browser_login">可能支持额外的验证方法但需要受支持的浏览器。</string>
-    <string name="action_post_failed_detail_plural">你的嘟文上传失败，已被保存到草稿。
+    <plurals name="action_post_failed_detail">
+        <item quantity="other">你的嘟文上传失败，已被保存到草稿。
 \n
-\n要么是无法联系服务器，要么是服务器拒绝了它。</string>
+\n要么是无法联系服务器，要么是服务器拒绝了它。</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">显示草稿</string>
     <string name="action_post_failed_do_nothing">取消</string>
     <string name="action_post_failed">上传失败了</string>
-    <string name="action_post_failed_detail">你的嘟文上传失败，已被保存到草稿。
-\n
-\n要么是无法联系服务器，要么是服务器拒绝了它。</string>
     <string name="accessibility_talking_about_tag">%1$d 人正谈论话题标签 %2$s</string>
     <string name="title_public_trending_hashtags">热门话题标签</string>
     <string name="total_usage">总使用</string>

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -1,6 +1,0 @@
-<resources>
-    <plurals name="action_post_failed_detail">
-        <item quantity="one">@string/action_post_failed_detail</item>
-        <item quantity="other">@string/action_post_failed_detail_plural</item>
-    </plurals>
-</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,8 +130,10 @@
     <string name="action_logout">Log out</string>
     <string name="action_logout_confirm">Are you sure you want to log out of %1$s? This will delete all local data of the account, including drafts and preferences.</string>
     <string name="action_post_failed">Upload failed</string>
-    <string name="action_post_failed_detail">Your post failed to upload and has been saved to drafts.\n\nEither the server could not be contacted, or it rejected the post.</string>
-    <string name="action_post_failed_detail_plural">Your posts failed to upload and have been saved to drafts.\n\nEither the server could not be contacted, or it rejected the posts.</string>
+    <plurals name="action_post_failed_detail">
+        <item quantity="one">Your post failed to upload and has been saved to drafts.\n\nEither the server could not be contacted, or it rejected the post.</item>
+        <item quantity="other">Your posts failed to upload and have been saved to drafts.\n\nEither the server could not be contacted, or it rejected the posts.</item>
+    </plurals>
     <string name="action_post_failed_show_drafts">Show drafts</string>
     <string name="action_post_failed_do_nothing">Dismiss</string>
     <string name="action_follow">Follow</string>


### PR DESCRIPTION
Weblate handles Plurals better without the indirection. "one" and "other" might work for English, but not for all languages.