### PR TITLE
fix MainActivity not restarting when theme changes

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/preference/PreferencesActivity.kt
@@ -92,9 +92,7 @@ class PreferencesActivity :
         }
 
         onBackPressedDispatcher.addCallback(this, restartActivitiesOnBackPressedCallback)
-        restartActivitiesOnBackPressedCallback.isEnabled = intent.extras?.getBoolean(
-            EXTRA_RESTART_ON_BACK
-        ) ?: savedInstanceState?.getBoolean(EXTRA_RESTART_ON_BACK, false) ?: false
+        restartActivitiesOnBackPressedCallback.isEnabled = savedInstanceState?.getBoolean(EXTRA_RESTART_ON_BACK, false) == true
     }
 
     override fun onPreferenceStartFragment(


### PR DESCRIPTION
`EXTRA_RESTART_ON_BACK` is never set on the Intent extras, but `intent.extras?.getBoolean(EXTRA_RESTART_ON_BACK)` will return `false` as long as there are any extras, hiding the actual value from the `savedInstanceState`.