### PR TITLE
fix dropdowns in dialogs going behind the keyboard

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ListsActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/ListsActivity.kt
@@ -123,8 +123,13 @@ class ListsActivity : BaseActivity() {
                 selectedReplyPolicyIndex = position
             }
         }
+        val inset = resources.getDimensionPixelSize(R.dimen.dialog_inset)
         val dialog = MaterialAlertDialogBuilder(this)
             .setView(binding.root)
+            .setBackgroundInsetTop(inset)
+            .setBackgroundInsetEnd(inset)
+            .setBackgroundInsetBottom(inset)
+            .setBackgroundInsetStart(inset)
             .setPositiveButton(
                 if (list == null) {
                     R.string.action_create_list
@@ -142,7 +147,10 @@ class ListsActivity : BaseActivity() {
             .setNegativeButton(android.R.string.cancel, null)
             .show()
 
-        dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
+        // yes, SOFT_INPUT_ADJUST_RESIZE is deprecated, but without it the dropdown can get behind the keyboard
+        dialog.window?.setSoftInputMode(
+            WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE or WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
+        )
 
         binding.nameText.let { editText ->
             editText.doOnTextChanged { s, _, _, _ ->

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/AddPollDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/AddPollDialog.kt
@@ -38,10 +38,16 @@ fun showAddPollDialog(
 ) {
     val binding = DialogAddPollBinding.inflate(LayoutInflater.from(context))
 
+    val inset = context.resources.getDimensionPixelSize(R.dimen.dialog_inset)
+
     val dialog = MaterialAlertDialogBuilder(context)
         .setIcon(R.drawable.ic_poll_24dp)
         .setTitle(R.string.create_poll_title)
         .setView(binding.root)
+        .setBackgroundInsetTop(inset)
+        .setBackgroundInsetEnd(inset)
+        .setBackgroundInsetBottom(inset)
+        .setBackgroundInsetStart(inset)
         .setNegativeButton(android.R.string.cancel, null)
         .setPositiveButton(android.R.string.ok, null)
         .create()
@@ -88,7 +94,7 @@ fun showAddPollDialog(
         selectedDurationIndex = position
     }
 
-    binding.multipleChoicesCheckBox.isChecked = poll?.multiple ?: false
+    binding.multipleChoicesCheckBox.isChecked = poll?.multiple == true
 
     dialog.setOnShowListener {
         val button = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
@@ -107,7 +113,11 @@ fun showAddPollDialog(
 
     dialog.show()
 
-    dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
+    // yes, SOFT_INPUT_ADJUST_RESIZE is deprecated, but without it the dropdown can get behind the keyboard
+    dialog.window?.setSoftInputMode(
+        WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE or WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
+    )
+
     binding.pollChoices.post {
         val firstItemView = binding.pollChoices.layoutManager?.findViewByPosition(0)
         val editText = firstItemView?.findViewById<TextInputEditText>(R.id.optionEditText)

--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
@@ -49,7 +49,7 @@ class CaptionDialog : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val localId = arguments?.getInt(LOCAL_ID_ARG) ?: error("Missing localId")
-        val inset = requireContext().resources.getDimensionPixelSize(R.dimen.caption_dialog_inset)
+        val inset = requireContext().resources.getDimensionPixelSize(R.dimen.dialog_inset)
         return MaterialAlertDialogBuilder(requireContext())
             .setView(createView(savedInstanceState))
             .setBackgroundInsetTop(inset)

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -80,7 +80,7 @@
     <dimen name="recyclerview_bottom_padding_actionbutton">88dp</dimen>
     <dimen name="recyclerview_bottom_padding_no_actionbutton">32dp</dimen>
 
-    <dimen name="caption_dialog_inset">24dp</dimen>
+    <dimen name="dialog_inset">24dp</dimen>
 
     <dimen name="media_description_sheet_bottom_padding">8dp</dimen>
 


### PR DESCRIPTION
I tried to find a solution without using a deprecated api to no avail. But better a working app than perfect code I guess.

In the end this probably is a bug in the Material component library https://github.com/material-components/material-components-android/issues/3307.

I also made the insets smaller which improves the dialogs a lot on small screens.