### PR TITLE
Properly handle more than 4 fields in EditProfileViewModel

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/instanceinfo/InstanceInfoRepository.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/instanceinfo/InstanceInfoRepository.kt
@@ -170,7 +170,7 @@ class InstanceInfoRepository @Inject constructor(
             ?: DEFAULT_IMAGE_MATRIX_LIMIT,
         maxMediaAttachments = this.configuration?.statuses?.maxMediaAttachments
             ?: DEFAULT_MAX_MEDIA_ATTACHMENTS,
-        maxFields = this.pleroma?.metadata?.fieldLimits?.maxFields,
+        maxFields = this.configuration?.accounts?.maxProfileFields ?: this.pleroma?.metadata?.fieldLimits?.maxFields,
         maxFieldNameLength = this.pleroma?.metadata?.fieldLimits?.nameLength,
         maxFieldValueLength = this.pleroma?.metadata?.fieldLimits?.valueLength,
         translationEnabled = this.configuration?.translation?.enabled

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Instance.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Instance.kt
@@ -51,7 +51,11 @@ data class Instance(
         data class Urls(@Json(name = "streaming_api") val streamingApi: String? = null)
 
         @JsonClass(generateAdapter = true)
-        data class Accounts(@Json(name = "max_featured_tags") val maxFeaturedTags: Int)
+        data class Accounts(
+            @Json(name = "max_featured_tags") val maxFeaturedTags: Int,
+            // GoToSocial feature
+            @Json(name = "max_profile_fields") val maxProfileFields: Int?
+        )
 
         @JsonClass(generateAdapter = true)
         data class Statuses(

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -67,6 +67,7 @@ import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Part
+import retrofit2.http.PartMap
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -314,14 +315,7 @@ interface MastodonApi {
         @Part(value = "locked") locked: RequestBody?,
         @Part avatar: MultipartBody.Part?,
         @Part header: MultipartBody.Part?,
-        @Part(value = "fields_attributes[0][name]") fieldName0: RequestBody?,
-        @Part(value = "fields_attributes[0][value]") fieldValue0: RequestBody?,
-        @Part(value = "fields_attributes[1][name]") fieldName1: RequestBody?,
-        @Part(value = "fields_attributes[1][value]") fieldValue1: RequestBody?,
-        @Part(value = "fields_attributes[2][name]") fieldName2: RequestBody?,
-        @Part(value = "fields_attributes[2][value]") fieldValue2: RequestBody?,
-        @Part(value = "fields_attributes[3][name]") fieldName3: RequestBody?,
-        @Part(value = "fields_attributes[3][value]") fieldValue3: RequestBody?
+        @PartMap fields: Map<String, RequestBody>
     ): NetworkResult<Account>
 
     @GET("api/v1/accounts/search")

--- a/app/src/test/java/com/keylesspalace/tusky/components/compose/ComposeActivityTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/compose/ComposeActivityTest.kt
@@ -599,7 +599,7 @@ class ComposeActivityTest {
     private fun getConfiguration(maximumStatusCharacters: Int?, charactersReservedPerUrl: Int?): Instance.Configuration {
         return Instance.Configuration(
             Instance.Configuration.Urls(),
-            Instance.Configuration.Accounts(1),
+            Instance.Configuration.Accounts(maxFeaturedTags = 1, maxProfileFields = 4),
             Instance.Configuration.Statuses(
                 maximumStatusCharacters ?: InstanceInfoRepository.DEFAULT_CHARACTER_LIMIT,
                 InstanceInfoRepository.DEFAULT_MAX_MEDIA_ATTACHMENTS,


### PR DESCRIPTION
Also read `configuration.accounts.max_profile_fields` from `api/v2/instance` to get the correct limit for GoToSocial.

Glitch-soc also allows more fields but does not provide configuration yet, see https://github.com/glitch-soc/mastodon/issues/2973

closes https://github.com/tuskyapp/Tusky/issues/3305