### PR TITLE
display the following badge on other profile pages in wellbeing mode,…

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/account/AccountActivity.kt
@@ -687,10 +687,7 @@ class AccountActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvide
         blockingDomain = relation.blockingDomain
         showingReblogs = relation.showingReblogs
 
-        // If wellbeing mode is enabled, "follows you" text should not be visible
-        val wellbeingEnabled = preferences.getBoolean(PrefKeys.WELLBEING_HIDE_STATS_PROFILE, false)
-
-        binding.accountFollowsYouTextView.visible(relation.followedBy && !wellbeingEnabled)
+        binding.accountFollowsYouTextView.visible(relation.followedBy)
 
         // because subscribing is Pleroma extension, enable it __only__ when we have non-null subscribing field
         // it's also now supported in Mastodon 3.3.0rc but called notifying and use different API call


### PR DESCRIPTION
… as requested in #4219

No unit tests failed because of this change, as far as I could see. However, one could add some if necessary.