### PR TITLE
Make caption dialog non-cancellable (issue #4939)

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/compose/dialog/CaptionDialog.kt
@@ -84,7 +84,7 @@ class CaptionDialog : DialogFragment() {
             binding.imageDescriptionText.setText(it)
         }
 
-        isCancelable = true
+        isCancelable = false
         dialog?.setCanceledOnTouchOutside(false) // Dialog is full screen anyway. But without this, taps in navbar while keyboard is up can dismiss the dialog.
 
         val previewUri = arguments?.getParcelableCompat<Uri>(PREVIEW_URI_ARG) ?: error("Preview Uri is null")


### PR DESCRIPTION
I just made the dialog non-cancellable. Actually I don't know why it was cancellable when there also is

```kotlin
dialog?.setCanceledOnTouchOutside(false)
```

Fixes #4939