### PR TITLE
add isAdded check in ViewImageFragment to prevent crash

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewImageFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewImageFragment.kt
@@ -342,8 +342,10 @@ class ViewImageFragment : ViewMediaFragment() {
                 // post() because load() replaces image with null. Sometimes after we set
                 // the thumbnail.
                 binding.photoView.post {
-                    target.onResourceReady(resource, null)
-                    if (shouldStartTransition) photoActionsListener.onBringUp()
+                    if (isAdded) {
+                        target.onResourceReady(resource, null)
+                        if (shouldStartTransition) photoActionsListener.onBringUp()
+                    }
                 }
             } else {
                 // This waits for transition. If there's no transition then we should hit


### PR DESCRIPTION
```
Exception java.lang.IllegalStateException:
  at androidx.fragment.app.Fragment.requireActivity (Fragment.java:1005)
  at com.keylesspalace.tusky.fragment.ViewImageFragment.getPhotoActionsListener (ViewImageFragment.java:58)
  at com.keylesspalace.tusky.fragment.ViewImageFragment.access$getPhotoActionsListener (ViewImageFragment.java:48)
  at com.keylesspalace.tusky.fragment.ViewImageFragment$ImageRequestListener.onResourceReady$lambda$0 (ViewImageFragment.java:335)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:226)
  at android.os.Looper.loop (Looper.java:313)
  at android.app.ActivityThread.main (ActivityThread.java:8751)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:571)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1135)
```