### PR TITLE
fix notification channel names

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/systemnotifications/NotificationChannelData.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/systemnotifications/NotificationChannelData.kt
@@ -48,13 +48,13 @@ enum class NotificationChannelData(
         R.string.notification_poll_description
     ),
 
-    STATUS(
+    SUBSCRIPTIONS(
         listOf(Notification.Type.Status),
         R.string.notification_subscription_name,
         R.string.notification_subscription_description
     ),
 
-    UPDATE(
+    UPDATES(
         listOf(Notification.Type.Update),
         R.string.notification_update_name,
         R.string.notification_update_description
@@ -77,7 +77,7 @@ enum class NotificationChannelData(
     }
 
     fun getChannelId(accountIdentifier: String): String {
-        return "CHANNEL_${name}_$accountIdentifier"
+        return "CHANNEL_${name}$accountIdentifier"
     }
 }
 


### PR DESCRIPTION
This changes the notification channel names back to what they were pre https://github.com/tuskyapp/Tusky/pull/4929 so users don't lose their settings and the channels won't be duplicated. Tusky nightly users that installed a in-between version will still have duplicate channels, they will need to reinstall.