### PR TITLE
fix conversations jumping down on first load

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
@@ -168,6 +168,16 @@ class ConversationsFragment :
             }
         })
 
+        // Workaround RecyclerView jumping to bottom on first load because of the load state footer
+        // https://issuetracker.google.com/issues/184874613#comment7
+        var firstLoad = true
+        adapter.addOnPagesUpdatedListener {
+            if (adapter.itemCount > 0 && firstLoad) {
+                (binding.recyclerView.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(0, 0)
+                firstLoad = false
+            }
+        }
+
         viewLifecycleOwner.lifecycleScope.launch {
             viewModel.conversationFlow.collectLatest { pagingData ->
                 adapter.submitData(pagingData)


### PR DESCRIPTION
When opening the conversations tab with empty cache (i.e. after a frash login), it would sometimes start with 6 year old messages for me, which I find very annoying. The issue is that the loading footer is shown first and the RecyclerView tries to keep it visible when new items are added. This works around the issue. Note that it does not happen when there are already some conversations in the cache.