### PR TITLE
fix Tusky sometimes displaying empty tabs

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -343,6 +343,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
         // https://github.com/tuskyapp/Tusky/issues/3251 for details.
         tabAdapter = MainPagerAdapter(emptyList(), this@MainActivity)
         binding.viewPager.adapter = tabAdapter
+        binding.viewPager.offscreenPageLimit = 2
 
         lifecycleScope.launch {
             viewModel.tabs.collect(::setupTabs)


### PR DESCRIPTION
Sometimes a tab is just empty after switching to it, but content appears as soon as you interact with it.
I found that setting a `offscreenPageLimit` on the `ViewPager2` makes that issue go away. 
This also has the side effect that the content of more tabs is preloaded, which makes tab switching *feel* different, one does not see so many loading spinners, content is just there instantly. I'm not sure if that is desireable but I would like to try it out for a while. If it happens to be a problem we can still move tab initialization to when it is actually visible.