### PR TITLE
fix crash when there are 2 or more unifiedpush distributors

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.kt
@@ -189,7 +189,7 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
     private val requestNotificationPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
             if (isGranted) {
-                viewModel.setupNotifications()
+                viewModel.setupNotifications(this)
             }
         }
 
@@ -218,6 +218,8 @@ class MainActivity : BottomSheetActivity(), ActionButtonActivity, MenuProvider {
             ActivityCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
         ) {
             requestNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        } else {
+            viewModel.setupNotifications(this)
         }
 
         if (explodeAnimationWasRequested()) {

--- a/app/src/main/java/com/keylesspalace/tusky/MainViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/MainViewModel.kt
@@ -27,7 +27,6 @@ import com.keylesspalace.tusky.appstore.NewNotificationsEvent
 import com.keylesspalace.tusky.appstore.NotificationsLoadingEvent
 import com.keylesspalace.tusky.components.systemnotifications.NotificationService
 import com.keylesspalace.tusky.db.AccountManager
-import com.keylesspalace.tusky.db.entity.AccountEntity
 import com.keylesspalace.tusky.entity.Emoji
 import com.keylesspalace.tusky.entity.Notification
 import com.keylesspalace.tusky.entity.Status
@@ -97,8 +96,6 @@ class MainViewModel @Inject constructor(
                     accountManager.updateAccount(activeAccount, userInfo)
 
                     shareShortcutHelper.updateShortcuts()
-
-                    setupNotifications(activeAccount)
                 },
                 { throwable ->
                     Log.e(TAG, "Failed to fetch user info.", throwable)
@@ -161,19 +158,16 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun setupNotifications(account: AccountEntity? = null) {
+    fun setupNotifications(activity: MainActivity) {
         // TODO this is only called on full app (re) start; so changes in-between (push distributor uninstalled/subscription changed, or
         //   notifications fully disabled) will get unnoticed; and also an app restart cannot be easily triggered by the user.
 
-        if (account != null) {
-            // TODO it's quite odd to separate channel creation (for an account) from the "is enabled by channels" question below
-
-            notificationService.createNotificationChannelsForAccount(account)
-        }
+        // TODO it's quite odd to separate channel creation (for an account) from the "is enabled by channels" question below
+        notificationService.createNotificationChannelsForAccount(activeAccount)
 
         if (notificationService.areNotificationsEnabledBySystem()) {
             viewModelScope.launch {
-                notificationService.setupNotifications(account)
+                notificationService.setupNotifications(activity)
             }
         } else {
             viewModelScope.launch {


### PR DESCRIPTION
`UnifiedPush.registerAppWithDialog` will show a dialog when there are 2 or more distributors, for that it needs an activity context but we passed an application one. I think this is improved in a newer Unified push library version, will upgrade soon. In the meantime this change fixes the crash.

```
android.view.WindowManager$BadTokenException: Unable to add window -- token null is not valid; is your activity running?
    at android.view.ViewRootImpl.setView(ViewRootImpl.java:1314)
    at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:421)
    at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:149)
    at android.app.Dialog.show(Dialog.java:352)
    at org.unifiedpush.android.connector.UnifiedPush.registerAppWithDialog(UnifiedPush.kt:139)
    at org.unifiedpush.android.connector.UnifiedPush.registerAppWithDialog$default(UnifiedPush.kt:67)
    at com.keylesspalace.tusky.components.systemnotifications.NotificationService.setupPushNotificationsForAccount(NotificationService.kt:775)
    at com.keylesspalace.tusky.components.systemnotifications.NotificationService.access$setupPushNotificationsForAccount(NotificationService.kt:76)
    at com.keylesspalace.tusky.components.systemnotifications.NotificationService$setupPushNotificationsForAccount$1.invokeSuspend(Unknown Source:15)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
    at android.os.Handler.handleCallback(Handler.java:942)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:201)
    at android.os.Looper.loop(Looper.java:288)
    at android.app.ActivityThread.main(ActivityThread.java:7932)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:942)
```