### PR TITLE
fix text selection shrinking the view in ViewThreadFragment

### DIFF
--- a/app/src/main/res/layout-sw640dp/fragment_view_thread.xml
+++ b/app/src/main/res/layout-sw640dp/fragment_view_thread.xml
@@ -26,7 +26,7 @@
                 android:background="?android:attr/colorBackground"
                 android:clipToPadding="false"
                 android:paddingBottom="@dimen/recyclerview_bottom_padding_no_actionbutton"
-                android:scrollbarStyle="outsideInset"
+                android:scrollbarStyle="outsideOverlay"
                 android:scrollbars="vertical" />
 
             <com.google.android.material.progressindicator.LinearProgressIndicator

--- a/app/src/main/res/layout/fragment_view_thread.xml
+++ b/app/src/main/res/layout/fragment_view_thread.xml
@@ -35,7 +35,7 @@
                     android:background="?android:attr/colorBackground"
                     android:clipToPadding="false"
                     android:paddingBottom="@dimen/recyclerview_bottom_padding_no_actionbutton"
-                    android:scrollbarStyle="outsideInset"
+                    android:scrollbarStyle="outsideOverlay"
                     android:scrollbars="vertical" />
 
                 <com.keylesspalace.tusky.view.BackgroundMessageView


### PR DESCRIPTION
https://layer8.space/@andre/114268763071943595

wtf is this bug 😳

Happens only on Android 15

I have no idea what exactly is going on here, I found this fix by trial and error. `outsideOverlay` seems to look exactly the same as `outsideInset` so i hope this is safe.