### PR TITLE
Add support for the blur filter action

### DIFF
--- a/app/schemas/com.keylesspalace.tusky.db.AppDatabase/70.json
+++ b/app/schemas/com.keylesspalace.tusky.db.AppDatabase/70.json
@@ -1,0 +1,1405 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 70,
+    "identityHash": "f1ac7b67aa0a9a279f7f35f5817b6a17",
+    "entities": [
+      {
+        "tableName": "DraftEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `accountId` INTEGER NOT NULL, `inReplyToId` TEXT, `content` TEXT, `contentWarning` TEXT, `sensitive` INTEGER NOT NULL, `visibility` INTEGER NOT NULL, `attachments` TEXT NOT NULL, `poll` TEXT, `failedToSend` INTEGER NOT NULL, `failedToSendNew` INTEGER NOT NULL, `scheduledAt` TEXT, `language` TEXT, `statusId` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inReplyToId",
+            "columnName": "inReplyToId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentWarning",
+            "columnName": "contentWarning",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sensitive",
+            "columnName": "sensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "poll",
+            "columnName": "poll",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "failedToSend",
+            "columnName": "failedToSend",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "failedToSendNew",
+            "columnName": "failedToSendNew",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scheduledAt",
+            "columnName": "scheduledAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "statusId",
+            "columnName": "statusId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "AccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `domain` TEXT NOT NULL, `accessToken` TEXT NOT NULL, `clientId` TEXT, `clientSecret` TEXT, `isActive` INTEGER NOT NULL, `accountId` TEXT NOT NULL, `username` TEXT NOT NULL, `displayName` TEXT NOT NULL, `profilePictureUrl` TEXT NOT NULL, `profileHeaderUrl` TEXT NOT NULL DEFAULT '', `notificationsEnabled` INTEGER NOT NULL, `notificationsMentioned` INTEGER NOT NULL, `notificationsFollowed` INTEGER NOT NULL, `notificationsFollowRequested` INTEGER NOT NULL, `notificationsReblogged` INTEGER NOT NULL, `notificationsFavorited` INTEGER NOT NULL, `notificationsPolls` INTEGER NOT NULL, `notificationsSubscriptions` INTEGER NOT NULL, `notificationsUpdates` INTEGER NOT NULL, `notificationsAdmin` INTEGER NOT NULL DEFAULT true, `notificationsOther` INTEGER NOT NULL DEFAULT true, `notificationSound` INTEGER NOT NULL, `notificationVibration` INTEGER NOT NULL, `notificationLight` INTEGER NOT NULL, `defaultPostPrivacy` INTEGER NOT NULL, `defaultReplyPrivacy` INTEGER NOT NULL, `defaultMediaSensitivity` INTEGER NOT NULL, `defaultPostLanguage` TEXT NOT NULL, `alwaysShowSensitiveMedia` INTEGER NOT NULL, `alwaysOpenSpoiler` INTEGER NOT NULL DEFAULT 0, `mediaPreviewEnabled` INTEGER NOT NULL, `lastNotificationId` TEXT NOT NULL, `notificationMarkerId` TEXT NOT NULL DEFAULT '0', `emojis` TEXT NOT NULL, `tabPreferences` TEXT NOT NULL, `notificationsFilter` TEXT NOT NULL, `oauthScopes` TEXT NOT NULL, `unifiedPushUrl` TEXT NOT NULL, `pushPubKey` TEXT NOT NULL, `pushPrivKey` TEXT NOT NULL, `pushAuth` TEXT NOT NULL, `pushServerKey` TEXT NOT NULL, `lastVisibleHomeTimelineStatusId` TEXT, `locked` INTEGER NOT NULL DEFAULT 0, `hasDirectMessageBadge` INTEGER NOT NULL DEFAULT 0, `isShowHomeBoosts` INTEGER NOT NULL, `isShowHomeReplies` INTEGER NOT NULL, `isShowHomeSelfBoosts` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "accessToken",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientId",
+            "columnName": "clientId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "clientSecret",
+            "columnName": "clientSecret",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profilePictureUrl",
+            "columnName": "profilePictureUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "profileHeaderUrl",
+            "columnName": "profileHeaderUrl",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "notificationsEnabled",
+            "columnName": "notificationsEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsMentioned",
+            "columnName": "notificationsMentioned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFollowed",
+            "columnName": "notificationsFollowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFollowRequested",
+            "columnName": "notificationsFollowRequested",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsReblogged",
+            "columnName": "notificationsReblogged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFavorited",
+            "columnName": "notificationsFavorited",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsPolls",
+            "columnName": "notificationsPolls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsSubscriptions",
+            "columnName": "notificationsSubscriptions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsUpdates",
+            "columnName": "notificationsUpdates",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsAdmin",
+            "columnName": "notificationsAdmin",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "notificationsOther",
+            "columnName": "notificationsOther",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "notificationSound",
+            "columnName": "notificationSound",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationVibration",
+            "columnName": "notificationVibration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationLight",
+            "columnName": "notificationLight",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultPostPrivacy",
+            "columnName": "defaultPostPrivacy",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultReplyPrivacy",
+            "columnName": "defaultReplyPrivacy",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultMediaSensitivity",
+            "columnName": "defaultMediaSensitivity",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultPostLanguage",
+            "columnName": "defaultPostLanguage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alwaysShowSensitiveMedia",
+            "columnName": "alwaysShowSensitiveMedia",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alwaysOpenSpoiler",
+            "columnName": "alwaysOpenSpoiler",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mediaPreviewEnabled",
+            "columnName": "mediaPreviewEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastNotificationId",
+            "columnName": "lastNotificationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationMarkerId",
+            "columnName": "notificationMarkerId",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0'"
+          },
+          {
+            "fieldPath": "emojis",
+            "columnName": "emojis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tabPreferences",
+            "columnName": "tabPreferences",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationsFilter",
+            "columnName": "notificationsFilter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "oauthScopes",
+            "columnName": "oauthScopes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unifiedPushUrl",
+            "columnName": "unifiedPushUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushPubKey",
+            "columnName": "pushPubKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushPrivKey",
+            "columnName": "pushPrivKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushAuth",
+            "columnName": "pushAuth",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pushServerKey",
+            "columnName": "pushServerKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastVisibleHomeTimelineStatusId",
+            "columnName": "lastVisibleHomeTimelineStatusId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "locked",
+            "columnName": "locked",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "hasDirectMessageBadge",
+            "columnName": "hasDirectMessageBadge",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isShowHomeBoosts",
+            "columnName": "isShowHomeBoosts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShowHomeReplies",
+            "columnName": "isShowHomeReplies",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShowHomeSelfBoosts",
+            "columnName": "isShowHomeSelfBoosts",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AccountEntity_domain_accountId",
+            "unique": true,
+            "columnNames": [
+              "domain",
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_AccountEntity_domain_accountId` ON `${TABLE_NAME}` (`domain`, `accountId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "InstanceEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`instance` TEXT NOT NULL, `emojiList` TEXT, `maximumTootCharacters` INTEGER, `maxPollOptions` INTEGER, `maxPollOptionLength` INTEGER, `minPollDuration` INTEGER, `maxPollDuration` INTEGER, `charactersReservedPerUrl` INTEGER, `version` TEXT, `videoSizeLimit` INTEGER, `imageSizeLimit` INTEGER, `imageMatrixLimit` INTEGER, `maxMediaAttachments` INTEGER, `maxFields` INTEGER, `maxFieldNameLength` INTEGER, `maxFieldValueLength` INTEGER, `translationEnabled` INTEGER, `mastodonApiVersion` INTEGER, `filterV2Supported` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`instance`))",
+        "fields": [
+          {
+            "fieldPath": "instance",
+            "columnName": "instance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emojiList",
+            "columnName": "emojiList",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maximumTootCharacters",
+            "columnName": "maximumTootCharacters",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxPollOptions",
+            "columnName": "maxPollOptions",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxPollOptionLength",
+            "columnName": "maxPollOptionLength",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "minPollDuration",
+            "columnName": "minPollDuration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxPollDuration",
+            "columnName": "maxPollDuration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "charactersReservedPerUrl",
+            "columnName": "charactersReservedPerUrl",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "videoSizeLimit",
+            "columnName": "videoSizeLimit",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageSizeLimit",
+            "columnName": "imageSizeLimit",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageMatrixLimit",
+            "columnName": "imageMatrixLimit",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxMediaAttachments",
+            "columnName": "maxMediaAttachments",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxFields",
+            "columnName": "maxFields",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxFieldNameLength",
+            "columnName": "maxFieldNameLength",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxFieldValueLength",
+            "columnName": "maxFieldValueLength",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "translationEnabled",
+            "columnName": "translationEnabled",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mastodonApiVersion",
+            "columnName": "mastodonApiVersion",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "filterV2Supported",
+            "columnName": "filterV2Supported",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "instance"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "TimelineStatusEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `url` TEXT, `tuskyAccountId` INTEGER NOT NULL, `authorServerId` TEXT NOT NULL, `inReplyToId` TEXT, `inReplyToAccountId` TEXT, `content` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `editedAt` INTEGER, `emojis` TEXT NOT NULL, `reblogsCount` INTEGER NOT NULL, `favouritesCount` INTEGER NOT NULL, `repliesCount` INTEGER NOT NULL, `reblogged` INTEGER NOT NULL, `bookmarked` INTEGER NOT NULL, `favourited` INTEGER NOT NULL, `sensitive` INTEGER NOT NULL, `spoilerText` TEXT NOT NULL, `visibility` INTEGER NOT NULL, `attachments` TEXT NOT NULL, `mentions` TEXT NOT NULL, `tags` TEXT NOT NULL, `application` TEXT, `poll` TEXT, `muted` INTEGER NOT NULL, `expanded` INTEGER NOT NULL, `contentCollapsed` INTEGER NOT NULL, `contentShowing` INTEGER NOT NULL, `pinned` INTEGER NOT NULL, `card` TEXT, `language` TEXT, `filtered` TEXT NOT NULL, PRIMARY KEY(`serverId`, `tuskyAccountId`), FOREIGN KEY(`authorServerId`, `tuskyAccountId`) REFERENCES `TimelineAccountEntity`(`serverId`, `tuskyAccountId`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "tuskyAccountId",
+            "columnName": "tuskyAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authorServerId",
+            "columnName": "authorServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inReplyToId",
+            "columnName": "inReplyToId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "inReplyToAccountId",
+            "columnName": "inReplyToAccountId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "editedAt",
+            "columnName": "editedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "emojis",
+            "columnName": "emojis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reblogsCount",
+            "columnName": "reblogsCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favouritesCount",
+            "columnName": "favouritesCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repliesCount",
+            "columnName": "repliesCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reblogged",
+            "columnName": "reblogged",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarked",
+            "columnName": "bookmarked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favourited",
+            "columnName": "favourited",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sensitive",
+            "columnName": "sensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spoilerText",
+            "columnName": "spoilerText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attachments",
+            "columnName": "attachments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mentions",
+            "columnName": "mentions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "application",
+            "columnName": "application",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "poll",
+            "columnName": "poll",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "muted",
+            "columnName": "muted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expanded",
+            "columnName": "expanded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentCollapsed",
+            "columnName": "contentCollapsed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentShowing",
+            "columnName": "contentShowing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "card",
+            "columnName": "card",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "filtered",
+            "columnName": "filtered",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "tuskyAccountId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_TimelineStatusEntity_authorServerId_tuskyAccountId",
+            "unique": false,
+            "columnNames": [
+              "authorServerId",
+              "tuskyAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_TimelineStatusEntity_authorServerId_tuskyAccountId` ON `${TABLE_NAME}` (`authorServerId`, `tuskyAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "TimelineAccountEntity",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "authorServerId",
+              "tuskyAccountId"
+            ],
+            "referencedColumns": [
+              "serverId",
+              "tuskyAccountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "TimelineAccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`serverId` TEXT NOT NULL, `tuskyAccountId` INTEGER NOT NULL, `localUsername` TEXT NOT NULL, `username` TEXT NOT NULL, `displayName` TEXT NOT NULL, `url` TEXT NOT NULL, `avatar` TEXT NOT NULL, `note` TEXT NOT NULL DEFAULT '', `emojis` TEXT NOT NULL, `bot` INTEGER NOT NULL, PRIMARY KEY(`serverId`, `tuskyAccountId`))",
+        "fields": [
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tuskyAccountId",
+            "columnName": "tuskyAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUsername",
+            "columnName": "localUsername",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "emojis",
+            "columnName": "emojis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bot",
+            "columnName": "bot",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "tuskyAccountId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ConversationEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountId` INTEGER NOT NULL, `id` TEXT NOT NULL, `order` INTEGER NOT NULL, `accounts` TEXT NOT NULL, `unread` INTEGER NOT NULL, `s_id` TEXT NOT NULL, `s_url` TEXT, `s_inReplyToId` TEXT, `s_inReplyToAccountId` TEXT, `s_account` TEXT NOT NULL, `s_content` TEXT NOT NULL, `s_createdAt` INTEGER NOT NULL, `s_editedAt` INTEGER, `s_emojis` TEXT NOT NULL, `s_favouritesCount` INTEGER NOT NULL, `s_repliesCount` INTEGER NOT NULL, `s_favourited` INTEGER NOT NULL, `s_bookmarked` INTEGER NOT NULL, `s_sensitive` INTEGER NOT NULL, `s_spoilerText` TEXT NOT NULL, `s_attachments` TEXT NOT NULL, `s_mentions` TEXT NOT NULL, `s_tags` TEXT, `s_showingHiddenContent` INTEGER NOT NULL, `s_expanded` INTEGER NOT NULL, `s_collapsed` INTEGER NOT NULL, `s_muted` INTEGER NOT NULL, `s_poll` TEXT, `s_language` TEXT, PRIMARY KEY(`id`, `accountId`))",
+        "fields": [
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accounts",
+            "columnName": "accounts",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unread",
+            "columnName": "unread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.id",
+            "columnName": "s_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.url",
+            "columnName": "s_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastStatus.inReplyToId",
+            "columnName": "s_inReplyToId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastStatus.inReplyToAccountId",
+            "columnName": "s_inReplyToAccountId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastStatus.account",
+            "columnName": "s_account",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.content",
+            "columnName": "s_content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.createdAt",
+            "columnName": "s_createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.editedAt",
+            "columnName": "s_editedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastStatus.emojis",
+            "columnName": "s_emojis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.favouritesCount",
+            "columnName": "s_favouritesCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.repliesCount",
+            "columnName": "s_repliesCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.favourited",
+            "columnName": "s_favourited",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.bookmarked",
+            "columnName": "s_bookmarked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.sensitive",
+            "columnName": "s_sensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.spoilerText",
+            "columnName": "s_spoilerText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.attachments",
+            "columnName": "s_attachments",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.mentions",
+            "columnName": "s_mentions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.tags",
+            "columnName": "s_tags",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastStatus.showingHiddenContent",
+            "columnName": "s_showingHiddenContent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.expanded",
+            "columnName": "s_expanded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.collapsed",
+            "columnName": "s_collapsed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.muted",
+            "columnName": "s_muted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastStatus.poll",
+            "columnName": "s_poll",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastStatus.language",
+            "columnName": "s_language",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "accountId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "NotificationEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tuskyAccountId` INTEGER NOT NULL, `type` TEXT, `id` TEXT NOT NULL, `accountId` TEXT, `statusId` TEXT, `reportId` TEXT, `event` TEXT, `moderationWarning` TEXT, `loading` INTEGER NOT NULL, PRIMARY KEY(`id`, `tuskyAccountId`), FOREIGN KEY(`accountId`, `tuskyAccountId`) REFERENCES `TimelineAccountEntity`(`serverId`, `tuskyAccountId`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`statusId`, `tuskyAccountId`) REFERENCES `TimelineStatusEntity`(`serverId`, `tuskyAccountId`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`reportId`, `tuskyAccountId`) REFERENCES `NotificationReportEntity`(`serverId`, `tuskyAccountId`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "tuskyAccountId",
+            "columnName": "tuskyAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "statusId",
+            "columnName": "statusId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "reportId",
+            "columnName": "reportId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "event",
+            "columnName": "event",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "moderationWarning",
+            "columnName": "moderationWarning",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "loading",
+            "columnName": "loading",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "tuskyAccountId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_NotificationEntity_accountId_tuskyAccountId",
+            "unique": false,
+            "columnNames": [
+              "accountId",
+              "tuskyAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_NotificationEntity_accountId_tuskyAccountId` ON `${TABLE_NAME}` (`accountId`, `tuskyAccountId`)"
+          },
+          {
+            "name": "index_NotificationEntity_statusId_tuskyAccountId",
+            "unique": false,
+            "columnNames": [
+              "statusId",
+              "tuskyAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_NotificationEntity_statusId_tuskyAccountId` ON `${TABLE_NAME}` (`statusId`, `tuskyAccountId`)"
+          },
+          {
+            "name": "index_NotificationEntity_reportId_tuskyAccountId",
+            "unique": false,
+            "columnNames": [
+              "reportId",
+              "tuskyAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_NotificationEntity_reportId_tuskyAccountId` ON `${TABLE_NAME}` (`reportId`, `tuskyAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "TimelineAccountEntity",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId",
+              "tuskyAccountId"
+            ],
+            "referencedColumns": [
+              "serverId",
+              "tuskyAccountId"
+            ]
+          },
+          {
+            "table": "TimelineStatusEntity",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "statusId",
+              "tuskyAccountId"
+            ],
+            "referencedColumns": [
+              "serverId",
+              "tuskyAccountId"
+            ]
+          },
+          {
+            "table": "NotificationReportEntity",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "reportId",
+              "tuskyAccountId"
+            ],
+            "referencedColumns": [
+              "serverId",
+              "tuskyAccountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NotificationReportEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tuskyAccountId` INTEGER NOT NULL, `serverId` TEXT NOT NULL, `category` TEXT NOT NULL, `statusIds` TEXT, `createdAt` INTEGER NOT NULL, `targetAccountId` TEXT, PRIMARY KEY(`serverId`, `tuskyAccountId`), FOREIGN KEY(`targetAccountId`, `tuskyAccountId`) REFERENCES `TimelineAccountEntity`(`serverId`, `tuskyAccountId`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "tuskyAccountId",
+            "columnName": "tuskyAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "statusIds",
+            "columnName": "statusIds",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetAccountId",
+            "columnName": "targetAccountId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "serverId",
+            "tuskyAccountId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_NotificationReportEntity_targetAccountId_tuskyAccountId",
+            "unique": false,
+            "columnNames": [
+              "targetAccountId",
+              "tuskyAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_NotificationReportEntity_targetAccountId_tuskyAccountId` ON `${TABLE_NAME}` (`targetAccountId`, `tuskyAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "TimelineAccountEntity",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "targetAccountId",
+              "tuskyAccountId"
+            ],
+            "referencedColumns": [
+              "serverId",
+              "tuskyAccountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "HomeTimelineEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tuskyAccountId` INTEGER NOT NULL, `id` TEXT NOT NULL, `statusId` TEXT, `reblogAccountId` TEXT, `loading` INTEGER NOT NULL, PRIMARY KEY(`id`, `tuskyAccountId`), FOREIGN KEY(`statusId`, `tuskyAccountId`) REFERENCES `TimelineStatusEntity`(`serverId`, `tuskyAccountId`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`reblogAccountId`, `tuskyAccountId`) REFERENCES `TimelineAccountEntity`(`serverId`, `tuskyAccountId`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "tuskyAccountId",
+            "columnName": "tuskyAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "statusId",
+            "columnName": "statusId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "reblogAccountId",
+            "columnName": "reblogAccountId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "loading",
+            "columnName": "loading",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "tuskyAccountId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_HomeTimelineEntity_statusId_tuskyAccountId",
+            "unique": false,
+            "columnNames": [
+              "statusId",
+              "tuskyAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_HomeTimelineEntity_statusId_tuskyAccountId` ON `${TABLE_NAME}` (`statusId`, `tuskyAccountId`)"
+          },
+          {
+            "name": "index_HomeTimelineEntity_reblogAccountId_tuskyAccountId",
+            "unique": false,
+            "columnNames": [
+              "reblogAccountId",
+              "tuskyAccountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_HomeTimelineEntity_reblogAccountId_tuskyAccountId` ON `${TABLE_NAME}` (`reblogAccountId`, `tuskyAccountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "TimelineStatusEntity",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "statusId",
+              "tuskyAccountId"
+            ],
+            "referencedColumns": [
+              "serverId",
+              "tuskyAccountId"
+            ]
+          },
+          {
+            "table": "TimelineAccountEntity",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "reblogAccountId",
+              "tuskyAccountId"
+            ],
+            "referencedColumns": [
+              "serverId",
+              "tuskyAccountId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NotificationPolicyEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tuskyAccountId` INTEGER NOT NULL, `pendingRequestsCount` INTEGER NOT NULL, `pendingNotificationsCount` INTEGER NOT NULL, PRIMARY KEY(`tuskyAccountId`))",
+        "fields": [
+          {
+            "fieldPath": "tuskyAccountId",
+            "columnName": "tuskyAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pendingRequestsCount",
+            "columnName": "pendingRequestsCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pendingNotificationsCount",
+            "columnName": "pendingNotificationsCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tuskyAccountId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f1ac7b67aa0a9a279f7f35f5817b6a17')"
+    ]
+  }
+}

--- a/app/src/main/java/com/keylesspalace/tusky/StatusListActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/StatusListActivity.kt
@@ -204,7 +204,7 @@ class StatusListActivity : BottomSheetActivity() {
                 { filters ->
                     mutedFilter = filters.firstOrNull { filter ->
                         // TODO shouldn't this be an exact match (only one keyword; exactly the hashtag)?
-                        filter.context.contains(Filter.Kind.HOME.kind) && filter.title == hashedTag
+                        filter.context.contains(Filter.Kind.HOME) && filter.title == hashedTag
                     }
                     updateTagMuteState(mutedFilter != null)
                 },
@@ -250,8 +250,8 @@ class StatusListActivity : BottomSheetActivity() {
 
             mastodonApi.createFilter(
                 title = "#$tag",
-                context = listOf(Filter.Kind.HOME.kind),
-                filterAction = Filter.Action.WARN.action,
+                context = listOf(Filter.Kind.HOME),
+                filterAction = Filter.Action.WARN,
                 expiresIn = FilterExpiration.never
             ).fold(
                 { filter ->
@@ -286,7 +286,7 @@ class StatusListActivity : BottomSheetActivity() {
                         ).fold(
                             { filter ->
                                 mutedFilterV1 = filter
-                                eventHub.dispatch(FilterUpdatedEvent(filter.context))
+                                eventHub.dispatch(FilterUpdatedEvent(filter.context.map { Filter.Kind.valueOf(it) }))
                                 filterCreateSuccess = true
                             },
                             { throwable2 ->
@@ -344,7 +344,7 @@ class StatusListActivity : BottomSheetActivity() {
                     // This filter exists in multiple contexts, just remove the home context
                     mastodonApi.updateFilter(
                         id = filter.id,
-                        context = filter.context.filter { it != Filter.Kind.HOME.kind }
+                        context = filter.context.filterNot { it == Filter.Kind.HOME }
                     )
                 } else {
                     mastodonApi.deleteFilter(filter.id)
@@ -356,7 +356,7 @@ class StatusListActivity : BottomSheetActivity() {
                         mastodonApi.updateFilterV1(
                             id = filter.id,
                             phrase = filter.phrase,
-                            context = filter.context.filter { it != Filter.Kind.HOME.kind },
+                            context = filter.context.filterNot { it == Filter.Kind.HOME.kind },
                             irreversible = null,
                             wholeWord = null,
                             expiresIn = FilterExpiration.never
@@ -372,7 +372,7 @@ class StatusListActivity : BottomSheetActivity() {
             result?.fold(
                 {
                     updateTagMuteState(false)
-                    eventHub.dispatch(FilterUpdatedEvent(listOf(Filter.Kind.HOME.kind)))
+                    eventHub.dispatch(FilterUpdatedEvent(listOf(Filter.Kind.HOME)))
                     mutedFilterV1 = null
                     mutedFilter = null
 

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -278,7 +278,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
         this.setTextVisible(sensitive, expanded, status, statusDisplayOptions, listener);
 
-        setupCard(status, expanded, statusDisplayOptions.cardViewMode(), statusDisplayOptions, listener);
+        setupCard(status, expanded, !status.isShowingContent(), statusDisplayOptions.cardViewMode(), statusDisplayOptions, listener);
     }
 
     private void setTextVisible(boolean sensitive,
@@ -834,7 +834,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                 hideSensitiveMediaWarning();
             }
 
-            setupCard(status, status.isExpanded(), statusDisplayOptions.cardViewMode(), statusDisplayOptions, listener);
+            setupCard(status, status.isExpanded(), !status.isShowingContent(), statusDisplayOptions.cardViewMode(), statusDisplayOptions, listener);
 
             setupButtons(listener, actionable.getAccount().getId(), status.getContent().toString(),
                 statusDisplayOptions);
@@ -859,7 +859,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
                     setMetaData(status, statusDisplayOptions, listener);
                     if (status.getStatus().getCard() != null && status.getStatus().getCard().getPublishedAt() != null) {
                         // there is a preview card showing the published time, we need to refresh it as well
-                        setupCard(status, status.isExpanded(), statusDisplayOptions.cardViewMode(), statusDisplayOptions, listener);
+                        setupCard(status, status.isExpanded(), !status.isShowingContent(), statusDisplayOptions.cardViewMode(), statusDisplayOptions, listener);
                     }
                     break;
                 }
@@ -1161,6 +1161,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
     protected void setupCard(
         final @NonNull StatusViewData.Concrete status,
         boolean expanded,
+        boolean blurMedia,
         final @NonNull CardViewMode cardViewMode,
         final @NonNull StatusDisplayOptions statusDisplayOptions,
         final @NonNull StatusActionListener listener
@@ -1240,7 +1241,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             // Statuses from other activitypub sources can be marked sensitive even if there's no media,
             // so let's blur the preview in that case
             // If media previews are disabled, show placeholder for cards as well
-            if (statusDisplayOptions.mediaPreviewEnabled() && !actionable.getSensitive() && !TextUtils.isEmpty(card.getImage())) {
+            if (statusDisplayOptions.mediaPreviewEnabled() && !blurMedia && !actionable.getSensitive() && !TextUtils.isEmpty(card.getImage())) {
 
                 int radius = context.getResources().getDimensionPixelSize(R.dimen.inner_card_radius);
                 ShapeAppearanceModel.Builder cardImageShape = ShapeAppearanceModel.builder();

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -45,6 +45,7 @@ import com.keylesspalace.tusky.ViewMediaActivity;
 import com.keylesspalace.tusky.entity.Attachment;
 import com.keylesspalace.tusky.entity.Attachment.Focus;
 import com.keylesspalace.tusky.entity.Attachment.MetaData;
+import com.keylesspalace.tusky.entity.Filter;
 import com.keylesspalace.tusky.entity.PreviewCard;
 import com.keylesspalace.tusky.entity.Emoji;
 import com.keylesspalace.tusky.entity.HashTag;
@@ -523,7 +524,8 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         boolean sensitive,
         final @NonNull StatusActionListener listener,
         boolean showingContent,
-        boolean useBlurhash
+        boolean useBlurhash,
+        Filter filter
     ) {
 
         mediaPreview.setVisibility(View.VISIBLE);
@@ -559,7 +561,9 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             final CharSequence formattedDescription = AttachmentHelper.getFormattedDescription(attachment, imageView.getContext());
             setAttachmentClickListener(imageView, listener, i, formattedDescription, true);
 
-            if (sensitive) {
+            if (filter != null) {
+                sensitiveMediaWarning.setText(sensitiveMediaWarning.getContext().getString(R.string.status_filter_placeholder_label_format, filter.getTitle()));
+            } else if (sensitive) {
                 sensitiveMediaWarning.setText(R.string.post_sensitive_media_title);
             } else {
                 sensitiveMediaWarning.setText(R.string.post_media_hidden_title);
@@ -812,7 +816,7 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
             } else if (statusDisplayOptions.mediaPreviewEnabled() && hasPreviewableAttachment(attachments)) {
                 mediaContainer.setVisibility(View.VISIBLE);
 
-                setMediaPreviews(attachments, sensitive, listener, status.isShowingContent(), statusDisplayOptions.useBlurhash());
+                setMediaPreviews(attachments, sensitive, listener, status.isShowingContent(), statusDisplayOptions.useBlurhash(), status.getFilter());
 
                 if (attachments.isEmpty()) {
                     hideSensitiveMediaWarning();

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
@@ -149,7 +149,7 @@ public class StatusDetailedViewHolder extends StatusBaseViewHolder {
             status;
 
         super.setupWithStatus(uncollapsedStatus, listener, statusDisplayOptions, payloads, showStatusInfo);
-        setupCard(uncollapsedStatus, status.isExpanded(), CardViewMode.FULL_WIDTH, statusDisplayOptions, listener); // Always show card for detailed status
+        setupCard(uncollapsedStatus, status.isExpanded(), !status.isShowingContent(), CardViewMode.FULL_WIDTH, statusDisplayOptions, listener); // Always show card for detailed status
         if (payloads.isEmpty()) {
             Status actionable = uncollapsedStatus.getActionable();
 

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusViewHolder.java
@@ -69,7 +69,7 @@ public class StatusViewHolder extends StatusBaseViewHolder {
 
             setupCollapsedState(sensitive, expanded, status, listener);
 
-            if (!showStatusInfo || status.getFilterAction() == Filter.Action.WARN) {
+            if (!showStatusInfo || (status.getFilter() != null && status.getFilter().getAction() == Filter.Action.WARN)) {
                 hideStatusInfo();
             } else {
                 Status rebloggingStatus = status.getRebloggingStatus();

--- a/app/src/main/java/com/keylesspalace/tusky/appstore/Events.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/appstore/Events.kt
@@ -1,6 +1,7 @@
 package com.keylesspalace.tusky.appstore
 
 import com.keylesspalace.tusky.entity.Account
+import com.keylesspalace.tusky.entity.Filter
 import com.keylesspalace.tusky.entity.Notification
 import com.keylesspalace.tusky.entity.Poll
 import com.keylesspalace.tusky.entity.Status
@@ -18,7 +19,7 @@ data class PollVoteEvent(val statusId: String, val poll: Poll) : Event
 data class PollShowResultsEvent(val statusId: String) : Event
 data class DomainMuteEvent(val instance: String) : Event
 data class AnnouncementReadEvent(val announcementId: String) : Event
-data class FilterUpdatedEvent(val filterContext: List<String>) : Event
+data class FilterUpdatedEvent(val filterContext: List<Filter.Kind>) : Event
 data class NewNotificationsEvent(
     val accountId: String,
     val notifications: List<Notification>

--- a/app/src/main/java/com/keylesspalace/tusky/components/accountlist/AccountListFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/accountlist/AccountListFragment.kt
@@ -205,8 +205,8 @@ class AccountListFragment :
         viewModel.unblock(id)
     }
 
-    override fun onRespondToFollowRequest(accept: Boolean, id: String, position: Int) {
-        viewModel.respondToFollowRequest(accept, id)
+    override fun onRespondToFollowRequest(accept: Boolean, accountIdRequestingFollow: String, position: Int) {
+        viewModel.respondToFollowRequest(accept, accountIdRequestingFollow)
     }
 
     companion object {

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationViewHolder.java
@@ -96,7 +96,7 @@ public class ConversationViewHolder extends StatusBaseViewHolder {
                 mediaContainer.setVisibility(View.VISIBLE);
 
                 setMediaPreviews(attachments, sensitive, listener, statusViewData.isShowingContent(),
-                        statusDisplayOptions.useBlurhash());
+                        statusDisplayOptions.useBlurhash(), statusViewData.getFilter());
 
                 if (attachments.isEmpty()) {
                     hideSensitiveMediaWarning();

--- a/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/conversation/ConversationsFragment.kt
@@ -242,9 +242,9 @@ class ConversationsFragment :
         }
     }
 
-    override fun onBookmark(favourite: Boolean, position: Int) {
+    override fun onBookmark(bookmark: Boolean, position: Int) {
         adapter?.peek(position)?.let { conversation ->
-            viewModel.bookmark(favourite, conversation)
+            viewModel.bookmark(bookmark, conversation)
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
@@ -124,14 +124,13 @@ class EditFilterActivity : BaseActivity() {
             viewModel.setTitle(editable.toString())
             validateSaveButton()
         }
-        binding.filterActionWarn.setOnCheckedChangeListener { _, checked ->
-            viewModel.setAction(
-                if (checked) {
-                    Filter.Action.WARN
-                } else {
-                    Filter.Action.HIDE
-                }
-            )
+        binding.filterActionGroup.setOnCheckedChangeListener { _, checkedId ->
+            val action = when (checkedId) {
+                R.id.filter_action_blur -> Filter.Action.BLUR
+                R.id.filter_action_hide -> Filter.Action.HIDE
+                else -> Filter.Action.WARN
+            }
+            viewModel.setAction(action)
         }
         binding.filterDurationDropDown.onItemClickListener = AdapterView.OnItemClickListener { _, _, position, _ ->
             viewModel.setDuration(
@@ -178,6 +177,7 @@ class EditFilterActivity : BaseActivity() {
         lifecycleScope.launch {
             viewModel.action.collect { action ->
                 when (action) {
+                    Filter.Action.BLUR -> binding.filterActionBlur.isChecked = true
                     Filter.Action.HIDE -> binding.filterActionHide.isChecked = true
                     else -> binding.filterActionWarn.isChecked = true
                 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
@@ -67,7 +67,7 @@ class EditFilterActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
 
         originalFilter = intent.getParcelableExtraCompat(FILTER_TO_EDIT)
-        filter = originalFilter ?: Filter("", "", listOf(), null, Filter.Action.WARN.action, listOf())
+        filter = originalFilter ?: Filter("", "", listOf(), null, Filter.Action.WARN, listOf())
         binding.apply {
             contextSwitches = mapOf(
                 filterContextHome to Filter.Kind.HOME,
@@ -299,14 +299,14 @@ class EditFilterActivity : BaseActivity() {
             if (viewModel.saveChanges(this@EditFilterActivity)) {
                 finish()
                 // Possibly affected contexts: any context affected by the original filter OR any context affected by the updated filter
-                val affectedContexts = viewModel.contexts.value.map {
-                    it.kind
-                }.union(originalFilter?.context ?: listOf()).distinct()
+                val affectedContexts = viewModel.contexts.value
+                    .union(originalFilter?.context.orEmpty())
+                    .distinct()
                 eventHub.dispatch(FilterUpdatedEvent(affectedContexts))
             } else {
                 Snackbar.make(
                     binding.root,
-                    getString(R.string.error_deleting_filter, viewModel.title.value),
+                    getString(R.string.error_saving_filter, viewModel.title.value),
                     Snackbar.LENGTH_SHORT
                 ).show()
             }

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
@@ -35,6 +35,7 @@ import com.keylesspalace.tusky.BaseActivity
 import com.keylesspalace.tusky.R
 import com.keylesspalace.tusky.appstore.EventHub
 import com.keylesspalace.tusky.appstore.FilterUpdatedEvent
+import com.keylesspalace.tusky.components.instanceinfo.InstanceInfoRepository
 import com.keylesspalace.tusky.databinding.ActivityEditFilterBinding
 import com.keylesspalace.tusky.databinding.DialogFilterBinding
 import com.keylesspalace.tusky.entity.Filter
@@ -55,6 +56,9 @@ class EditFilterActivity : BaseActivity() {
 
     @Inject
     lateinit var eventHub: EventHub
+
+    @Inject
+    lateinit var instanceInfoRepository: InstanceInfoRepository
 
     private val binding by viewBinding(ActivityEditFilterBinding::inflate)
     private val viewModel: EditFilterViewModel by viewModels()
@@ -124,6 +128,10 @@ class EditFilterActivity : BaseActivity() {
             viewModel.setTitle(editable.toString())
             validateSaveButton()
         }
+
+        // blur filter is supported in mastodon api version 5+
+        val blurFilterSupported = instanceInfoRepository.cachedInstanceInfoOrFallback.mastodonApiVersion?.let { it >= 5 } == true
+        binding.filterActionBlur.visible(blurFilterSupported)
         binding.filterActionGroup.setOnCheckedChangeListener { _, checkedId ->
             val action = when (checkedId) {
                 R.id.filter_action_blur -> Filter.Action.BLUR

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterActivity.kt
@@ -67,7 +67,7 @@ class EditFilterActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
 
         originalFilter = intent.getParcelableExtraCompat(FILTER_TO_EDIT)
-        filter = originalFilter ?: Filter("", "", listOf(), null, Filter.Action.WARN, listOf())
+        filter = originalFilter ?: Filter(context = emptyList(), action = Filter.Action.WARN)
         binding.apply {
             contextSwitches = mapOf(
                 filterContextHome to Filter.Kind.HOME,

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/EditFilterViewModel.kt
@@ -60,7 +60,7 @@ class EditFilterViewModel @Inject constructor(val api: MastodonApi) : ViewModel(
         } else {
             -1
         }
-        _contexts.value = filter.kinds
+        _contexts.value = filter.context
     }
 
     fun addKeyword(keyword: FilterKeyword) {
@@ -109,10 +109,10 @@ class EditFilterViewModel @Inject constructor(val api: MastodonApi) : ViewModel(
     }
 
     suspend fun saveChanges(context: Context): Boolean {
-        val contexts = _contexts.value.map { it.kind }
+        val contexts = _contexts.value
         val title = _title.value
         val durationIndex = _duration.value
-        val action = _action.value.action
+        val action = _action.value
 
         return withContext(viewModelScope.coroutineContext) {
             originalFilter?.let { filter ->
@@ -123,8 +123,8 @@ class EditFilterViewModel @Inject constructor(val api: MastodonApi) : ViewModel(
 
     private suspend fun createFilter(
         title: String,
-        contexts: List<String>,
-        action: String,
+        contexts: List<Filter.Kind>,
+        action: Filter.Action,
         durationIndex: Int,
         context: Context
     ): Boolean {
@@ -149,7 +149,7 @@ class EditFilterViewModel @Inject constructor(val api: MastodonApi) : ViewModel(
                 return (
                     throwable.isHttpNotFound() &&
                         // Endpoint not found, fall back to v1 api
-                        createFilterV1(contexts, expiration)
+                        createFilterV1(contexts.map(Filter.Kind::kind), expiration)
                     )
             }
         )
@@ -158,8 +158,8 @@ class EditFilterViewModel @Inject constructor(val api: MastodonApi) : ViewModel(
     private suspend fun updateFilter(
         originalFilter: Filter,
         title: String,
-        contexts: List<String>,
-        action: String,
+        contexts: List<Filter.Kind>,
+        action: Filter.Action,
         durationIndex: Int,
         context: Context
     ): Boolean {
@@ -189,7 +189,7 @@ class EditFilterViewModel @Inject constructor(val api: MastodonApi) : ViewModel(
             { throwable ->
                 if (throwable.isHttpNotFound()) {
                     // Endpoint not found, fall back to v1 api
-                    if (updateFilterV1(contexts, expiration)) {
+                    if (updateFilterV1(contexts.map(Filter.Kind::kind), expiration)) {
                         return true
                     }
                 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/filters/FiltersAdapter.kt
@@ -43,7 +43,7 @@ class FiltersAdapter(val listener: FiltersListener, val filters: List<Filter>) :
         binding.textSecondary.text = context.getString(
             R.string.filter_description_format,
             actions.getOrNull(filter.action.ordinal - 1),
-            filter.context.map { contexts.getOrNull(Filter.Kind.from(it).ordinal) }.joinToString("/")
+            filter.context.map { contexts.getOrNull(it.ordinal) }.joinToString("/")
         )
 
         binding.delete.setOnClickListener {

--- a/app/src/main/java/com/keylesspalace/tusky/components/instanceinfo/InstanceInfo.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/instanceinfo/InstanceInfo.kt
@@ -31,4 +31,5 @@ data class InstanceInfo(
     val maxFieldValueLength: Int?,
     val version: String?,
     val translationEnabled: Boolean?,
+    val mastodonApiVersion: Int?,
 )

--- a/app/src/main/java/com/keylesspalace/tusky/components/instanceinfo/InstanceInfoRepository.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/instanceinfo/InstanceInfoRepository.kt
@@ -145,7 +145,8 @@ class InstanceInfoRepository @Inject constructor(
         maxFieldNameLength = this?.maxFieldNameLength,
         maxFieldValueLength = this?.maxFieldValueLength,
         version = this?.version,
-        translationEnabled = this?.translationEnabled
+        translationEnabled = this?.translationEnabled,
+        mastodonApiVersion = this?.mastodonApiVersion,
     )
 
     private fun Instance.toEntity() = InstanceInfoEntity(
@@ -173,7 +174,8 @@ class InstanceInfoRepository @Inject constructor(
         maxFields = this.configuration?.accounts?.maxProfileFields ?: this.pleroma?.metadata?.fieldLimits?.maxFields,
         maxFieldNameLength = this.pleroma?.metadata?.fieldLimits?.nameLength,
         maxFieldValueLength = this.pleroma?.metadata?.fieldLimits?.valueLength,
-        translationEnabled = this.configuration?.translation?.enabled
+        translationEnabled = this.configuration?.translation?.enabled,
+        mastodonApiVersion = this.apiVersions?.mastodon,
     )
 
     private fun InstanceV1.toEntity(instanceName: String) =
@@ -202,6 +204,7 @@ class InstanceInfoRepository @Inject constructor(
             maxFieldNameLength = this.pleroma?.metadata?.fieldLimits?.nameLength,
             maxFieldValueLength = this.pleroma?.metadata?.fieldLimits?.valueLength,
             translationEnabled = null,
+            mastodonApiVersion = null,
         )
 
     companion object {

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationTypeMappers.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationTypeMappers.kt
@@ -22,6 +22,7 @@ import com.keylesspalace.tusky.db.entity.NotificationDataEntity
 import com.keylesspalace.tusky.db.entity.NotificationEntity
 import com.keylesspalace.tusky.db.entity.NotificationReportEntity
 import com.keylesspalace.tusky.db.entity.TimelineAccountEntity
+import com.keylesspalace.tusky.entity.Filter
 import com.keylesspalace.tusky.entity.Notification
 import com.keylesspalace.tusky.entity.Report
 import com.keylesspalace.tusky.util.toViewData
@@ -61,6 +62,7 @@ fun Notification.toViewData(
     isShowingContent: Boolean,
     isExpanded: Boolean,
     isCollapsed: Boolean,
+    filter: Filter?,
 ): NotificationViewData.Concrete = NotificationViewData.Concrete(
     id = id,
     type = type,
@@ -68,7 +70,8 @@ fun Notification.toViewData(
     statusViewData = status?.toViewData(
         isShowingContent = isShowingContent,
         isExpanded = isExpanded,
-        isCollapsed = isCollapsed
+        isCollapsed = isCollapsed,
+        filter = filter,
     ),
     report = report,
     moderationWarning = moderationWarning,

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsPagingAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsPagingAdapter.kt
@@ -83,13 +83,13 @@ class NotificationsPagingAdapter(
             is NotificationViewData.Concrete -> {
                 when (notification.type) {
                     Notification.Type.Mention,
-                    Notification.Type.Poll -> if (notification.statusViewData?.filterAction == Filter.Action.WARN) {
+                    Notification.Type.Poll -> if (notification.statusViewData?.filter?.action == Filter.Action.WARN) {
                         VIEW_TYPE_STATUS_FILTERED
                     } else {
                         VIEW_TYPE_STATUS
                     }
                     Notification.Type.Status,
-                    Notification.Type.Update -> if (notification.statusViewData?.filterAction == Filter.Action.WARN) {
+                    Notification.Type.Update -> if (notification.statusViewData?.filter?.action == Filter.Action.WARN) {
                         VIEW_TYPE_STATUS_FILTERED
                     } else {
                         VIEW_TYPE_STATUS_NOTIFICATION

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
@@ -117,7 +117,7 @@ class NotificationsViewModel @Inject constructor(
                     val translation = translations[notification.status?.serverId]
                     notification.toViewData(translation = translation)
                 }.filter { notificationViewData ->
-                    shouldFilterStatus(notificationViewData) != Filter.Action.HIDE
+                    shouldFilterStatus(notificationViewData)?.action != Filter.Action.HIDE
                 }
             }
     }
@@ -165,21 +165,21 @@ class NotificationsViewModel @Inject constructor(
         }
     }
 
-    private fun shouldFilterStatus(notificationViewData: NotificationViewData): Filter.Action {
+    private fun shouldFilterStatus(notificationViewData: NotificationViewData): Filter? {
         return when ((notificationViewData as? NotificationViewData.Concrete)?.type) {
             Notification.Type.Mention, Notification.Type.Poll, Notification.Type.Status, Notification.Type.Update -> {
                 val account = activeAccountFlow.value
                 notificationViewData.statusViewData?.let { statusViewData ->
                     if (statusViewData.status.account.id == account?.accountId) {
-                        return Filter.Action.NONE
+                        return null
                     }
-                    statusViewData.filterAction = filterModel.shouldFilterStatus(statusViewData.actionable)
-                    return statusViewData.filterAction
+                    statusViewData.filter = filterModel.shouldFilterStatus(statusViewData.actionable)
+                    return statusViewData.filter
                 }
-                Filter.Action.NONE
+                null
             }
 
-            else -> Filter.Action.NONE
+            else -> null
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/NotificationsViewModel.kt
@@ -131,7 +131,7 @@ class NotificationsViewModel @Inject constructor(
                 if (event is PreferenceChangedEvent) {
                     onPreferenceChanged(event.preferenceKey)
                 }
-                if (event is FilterUpdatedEvent && event.filterContext.contains(Filter.Kind.NOTIFICATIONS.kind)) {
+                if (event is FilterUpdatedEvent && event.filterContext.contains(Filter.Kind.NOTIFICATIONS)) {
                     filterModel.init(Filter.Kind.NOTIFICATIONS)
                     refreshTrigger.value += 1
                 }
@@ -346,10 +346,7 @@ class NotificationsViewModel @Inject constructor(
                     return@launch
                 }
 
-                val account = activeAccountFlow.value
-                if (account == null) {
-                    return@launch
-                }
+                val account = activeAccountFlow.value ?: return@launch
 
                 val statusDao = db.timelineStatusDao()
                 val accountDao = db.timelineAccountDao()

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/requests/details/NotificationRequestDetailsFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/requests/details/NotificationRequestDetailsFragment.kt
@@ -285,9 +285,9 @@ class NotificationRequestDetailsFragment : SFragment(R.layout.fragment_notificat
         // not needed, blocking via the more menu on statuses is handled in SFragment
     }
 
-    override fun onRespondToFollowRequest(accept: Boolean, id: String, position: Int) {
+    override fun onRespondToFollowRequest(accept: Boolean, accountIdRequestingFollow: String, position: Int) {
         val notification = adapter?.peek(position) ?: return
-        viewModel.respondToFollowRequest(accept, accountId = id, notification = notification)
+        viewModel.respondToFollowRequest(accept, accountId = accountIdRequestingFollow, notification = notification)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/requests/details/NotificationRequestDetailsRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/requests/details/NotificationRequestDetailsRemoteMediator.kt
@@ -20,6 +20,7 @@ import androidx.paging.LoadType
 import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
 import com.keylesspalace.tusky.components.notifications.toViewData
+import com.keylesspalace.tusky.entity.Filter
 import com.keylesspalace.tusky.entity.Notification
 import com.keylesspalace.tusky.util.HttpHeaderLink
 import com.keylesspalace.tusky.viewdata.NotificationViewData
@@ -69,10 +70,12 @@ class NotificationRequestDetailsRemoteMediator(
         val alwaysShowSensitiveMedia = viewModel.accountManager.activeAccount?.alwaysShowSensitiveMedia == true
         val alwaysOpenSpoiler = viewModel.accountManager.activeAccount?.alwaysOpenSpoiler == false
         val notificationData = notifications.map { notification ->
+            val filter = notification.status?.getApplicableFilter(Filter.Kind.NOTIFICATIONS)
             notification.toViewData(
-                isShowingContent = alwaysShowSensitiveMedia,
+                isShowingContent = alwaysShowSensitiveMedia || filter?.action != Filter.Action.BLUR,
                 isExpanded = alwaysOpenSpoiler,
-                true
+                isCollapsed = true,
+                filter = filter,
             )
         }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/notifications/requests/details/NotificationRequestDetailsRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/notifications/requests/details/NotificationRequestDetailsRemoteMediator.kt
@@ -70,12 +70,11 @@ class NotificationRequestDetailsRemoteMediator(
         val alwaysShowSensitiveMedia = viewModel.accountManager.activeAccount?.alwaysShowSensitiveMedia == true
         val alwaysOpenSpoiler = viewModel.accountManager.activeAccount?.alwaysOpenSpoiler == false
         val notificationData = notifications.map { notification ->
-            val filter = notification.status?.getApplicableFilter(Filter.Kind.NOTIFICATIONS)
             notification.toViewData(
-                isShowingContent = alwaysShowSensitiveMedia || filter?.action != Filter.Action.BLUR,
+                isShowingContent = notification.status?.shouldShowContent(alwaysShowSensitiveMedia, Filter.Kind.NOTIFICATIONS) ?: true,
                 isExpanded = alwaysOpenSpoiler,
                 isCollapsed = true,
-                filter = filter,
+                filter = notification.status?.getApplicableFilter(Filter.Kind.NOTIFICATIONS),
             )
         }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/report/ReportViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/report/ReportViewModel.kt
@@ -87,7 +87,7 @@ class ReportViewModel @Inject constructor(
         .map { pagingData ->
             /* TODO: refactor reports to use the isShowingContent / isExpanded / isCollapsed attributes from StatusViewData.Concrete
              instead of StatusViewState */
-            pagingData.map { status -> status.toViewData(false, false, false) }
+            pagingData.map { status -> status.toViewData(false, false, false, filter = null) }
         }
         .cachedIn(viewModelScope)
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
@@ -30,6 +30,7 @@ import com.keylesspalace.tusky.components.search.adapter.SearchPagingSourceFacto
 import com.keylesspalace.tusky.db.AccountManager
 import com.keylesspalace.tusky.db.entity.AccountEntity
 import com.keylesspalace.tusky.entity.DeletedStatus
+import com.keylesspalace.tusky.entity.Filter
 import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.network.MastodonApi
 import com.keylesspalace.tusky.usecase.TimelineCases
@@ -69,10 +70,12 @@ class SearchViewModel @Inject constructor(
     private val statusesPagingSourceFactory =
         SearchPagingSourceFactory(mastodonApi, SearchType.Status, loadedStatuses) {
             it.statuses.map { status ->
+                val filter = status.getApplicableFilter(Filter.Kind.PUBLIC)
                 status.toViewData(
-                    isShowingContent = alwaysShowSensitiveMedia || !status.actionableStatus.sensitive,
+                    isShowingContent = alwaysShowSensitiveMedia || (!status.actionableStatus.sensitive && filter?.action != Filter.Action.BLUR),
                     isExpanded = alwaysOpenSpoiler,
-                    isCollapsed = true
+                    isCollapsed = true,
+                    filter = filter,
                 )
             }.apply {
                 loadedStatuses.addAll(this)

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
@@ -70,12 +70,11 @@ class SearchViewModel @Inject constructor(
     private val statusesPagingSourceFactory =
         SearchPagingSourceFactory(mastodonApi, SearchType.Status, loadedStatuses) {
             it.statuses.map { status ->
-                val filter = status.getApplicableFilter(Filter.Kind.PUBLIC)
                 status.toViewData(
-                    isShowingContent = alwaysShowSensitiveMedia || (!status.actionableStatus.sensitive && filter?.action != Filter.Action.BLUR),
+                    isShowingContent = status.shouldShowContent(alwaysShowSensitiveMedia, Filter.Kind.PUBLIC),
                     isExpanded = alwaysOpenSpoiler,
                     isCollapsed = true,
-                    filter = filter,
+                    filter = status.getApplicableFilter(Filter.Kind.PUBLIC),
                 )
             }.apply {
                 loadedStatuses.addAll(this)

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelinePagingAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelinePagingAdapter.kt
@@ -84,7 +84,7 @@ class TimelinePagingAdapter(
             val holder = viewHolder as PlaceholderViewHolder
             holder.setup(viewData.isLoading)
         } else if (viewData is StatusViewData.Concrete) {
-            if (viewData.filterAction == Filter.Action.WARN) {
+            if (viewData.filter?.action == Filter.Action.WARN) {
                 val holder = viewHolder as FilteredStatusViewHolder
                 holder.bind(viewData)
             } else {
@@ -104,7 +104,7 @@ class TimelinePagingAdapter(
         val viewData = getItem(position)
         return if (viewData is StatusViewData.Placeholder) {
             VIEW_TYPE_PLACEHOLDER
-        } else if (viewData?.filterAction == Filter.Action.WARN) {
+        } else if (viewData?.filter?.action == Filter.Action.WARN) {
             VIEW_TYPE_STATUS_FILTERED
         } else {
             VIEW_TYPE_STATUS

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineTypeMappers.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineTypeMappers.kt
@@ -19,6 +19,7 @@ import com.keylesspalace.tusky.db.entity.HomeTimelineData
 import com.keylesspalace.tusky.db.entity.HomeTimelineEntity
 import com.keylesspalace.tusky.db.entity.TimelineAccountEntity
 import com.keylesspalace.tusky.db.entity.TimelineStatusEntity
+import com.keylesspalace.tusky.entity.Filter
 import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.entity.TimelineAccount
 import com.keylesspalace.tusky.viewdata.StatusViewData
@@ -143,7 +144,11 @@ fun TimelineStatusEntity.toStatus(
     filtered = filtered,
 )
 
-fun HomeTimelineData.toViewData(isDetailed: Boolean = false, translation: TranslationViewData? = null): StatusViewData {
+fun HomeTimelineData.toViewData(
+    isDetailed: Boolean = false,
+    translation: TranslationViewData? = null,
+    filter: Filter? = null,
+): StatusViewData {
     if (this.account == null || this.status == null) {
         return StatusViewData.Placeholder(this.id, loading)
     }
@@ -195,5 +200,5 @@ fun HomeTimelineData.toViewData(isDetailed: Boolean = false, translation: Transl
         isDetailed = isDetailed,
         repliedToAccount = repliedToAccount?.toAccount(),
         translation = translation,
-    )
+    ).apply { this.filter = filter }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
@@ -161,7 +161,7 @@ class CachedTimelineRemoteMediator(
                 if (oldStatus != null) break
             }
 
-            val filter = viewModel.kind?.let { status.getApplicableFilter(it.toFilterKind()) }
+            val filter = status.getApplicableFilter(viewModel.kind.toFilterKind())
             val expanded = oldStatus?.expanded ?: activeAccount.alwaysOpenSpoiler
             val contentShowing = oldStatus?.contentShowing ?: (activeAccount.alwaysShowSensitiveMedia || (!status.actionableStatus.sensitive && filter?.action != Filter.Action.BLUR))
             val contentCollapsed = oldStatus?.contentCollapsed != false

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
@@ -161,7 +161,7 @@ class CachedTimelineRemoteMediator(
                 if (oldStatus != null) break
             }
 
-            val filter = status.getApplicableFilter(viewModel.kind.toFilterKind())
+            val filter = viewModel.kind?.let { status.getApplicableFilter(it.toFilterKind()) }
             val expanded = oldStatus?.expanded ?: activeAccount.alwaysOpenSpoiler
             val contentShowing = oldStatus?.contentShowing ?: (activeAccount.alwaysShowSensitiveMedia || (!status.actionableStatus.sensitive && filter?.action != Filter.Action.BLUR))
             val contentCollapsed = oldStatus?.contentCollapsed != false

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
@@ -29,7 +29,6 @@ import com.keylesspalace.tusky.db.entity.AccountEntity
 import com.keylesspalace.tusky.db.entity.HomeTimelineData
 import com.keylesspalace.tusky.db.entity.HomeTimelineEntity
 import com.keylesspalace.tusky.db.entity.TimelineStatusEntity
-import com.keylesspalace.tusky.entity.Filter
 import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.network.MastodonApi
 import retrofit2.HttpException
@@ -161,9 +160,8 @@ class CachedTimelineRemoteMediator(
                 if (oldStatus != null) break
             }
 
-            val filter = status.getApplicableFilter(viewModel.kind.toFilterKind())
             val expanded = oldStatus?.expanded ?: activeAccount.alwaysOpenSpoiler
-            val contentShowing = oldStatus?.contentShowing ?: (activeAccount.alwaysShowSensitiveMedia || (!status.actionableStatus.sensitive && filter?.action != Filter.Action.BLUR))
+            val contentShowing = oldStatus?.contentShowing ?: status.shouldShowContent(activeAccount.alwaysShowSensitiveMedia, viewModel.kind.toFilterKind())
             val contentCollapsed = oldStatus?.contentCollapsed != false
 
             statusDao.insert(

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineRemoteMediator.kt
@@ -29,6 +29,7 @@ import com.keylesspalace.tusky.db.entity.AccountEntity
 import com.keylesspalace.tusky.db.entity.HomeTimelineData
 import com.keylesspalace.tusky.db.entity.HomeTimelineEntity
 import com.keylesspalace.tusky.db.entity.TimelineStatusEntity
+import com.keylesspalace.tusky.entity.Filter
 import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.network.MastodonApi
 import retrofit2.HttpException
@@ -160,8 +161,9 @@ class CachedTimelineRemoteMediator(
                 if (oldStatus != null) break
             }
 
+            val filter = status.getApplicableFilter(viewModel.kind.toFilterKind())
             val expanded = oldStatus?.expanded ?: activeAccount.alwaysOpenSpoiler
-            val contentShowing = oldStatus?.contentShowing ?: (activeAccount.alwaysShowSensitiveMedia || !status.actionableStatus.sensitive)
+            val contentShowing = oldStatus?.contentShowing ?: (activeAccount.alwaysShowSensitiveMedia || (!status.actionableStatus.sensitive && filter?.action != Filter.Action.BLUR))
             val contentCollapsed = oldStatus?.contentCollapsed != false
 
             statusDao.insert(

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -34,6 +34,7 @@ import com.keylesspalace.tusky.components.preference.PreferencesFragment.Reading
 import com.keylesspalace.tusky.components.preference.PreferencesFragment.ReadingOrder.OLDEST_FIRST
 import com.keylesspalace.tusky.components.timeline.Placeholder
 import com.keylesspalace.tusky.components.timeline.toEntity
+import com.keylesspalace.tusky.components.timeline.toStatus
 import com.keylesspalace.tusky.components.timeline.toViewData
 import com.keylesspalace.tusky.components.timeline.util.ifExpected
 import com.keylesspalace.tusky.db.AccountManager
@@ -100,12 +101,15 @@ class CachedTimelineViewModel @Inject constructor(
         .combine(translations) { pagingData, translations ->
             pagingData.map { timelineData ->
                 val translation = translations[timelineData.status?.serverId]
+                val status = timelineData.account?.let { timelineData.status?.toStatus(it) }
+                val filter = status?.let { shouldFilterStatus(it) }
                 timelineData.toViewData(
                     isDetailed = false,
-                    translation = translation
+                    translation = translation,
+                    filter = filter,
                 )
             }.filter { statusViewData ->
-                shouldFilterStatus(statusViewData) != Filter.Action.HIDE
+                statusViewData.filter?.action != Filter.Action.HIDE
             }
         }
         .flowOn(Dispatchers.Default)
@@ -203,11 +207,12 @@ class CachedTimelineViewModel @Inject constructor(
                             ?.let { rebloggedAccount ->
                                 accountDao.insert(rebloggedAccount)
                             }
+                        val filter = status.getApplicableFilter(kind.toFilterKind())
                         statusDao.insert(
                             status.actionableStatus.toEntity(
                                 tuskyAccountId = accountId,
                                 expanded = account.alwaysOpenSpoiler,
-                                contentShowing = account.alwaysShowSensitiveMedia || !status.actionableStatus.sensitive,
+                                contentShowing = account.alwaysShowSensitiveMedia || (!status.actionableStatus.sensitive && filter?.action != Filter.Action.BLUR),
                                 contentCollapsed = true
                             )
                         )

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -207,13 +207,12 @@ class CachedTimelineViewModel @Inject constructor(
                             ?.let { rebloggedAccount ->
                                 accountDao.insert(rebloggedAccount)
                             }
-                        val filter = status.getApplicableFilter(kind.toFilterKind())
                         statusDao.insert(
                             status.actionableStatus.toEntity(
                                 tuskyAccountId = accountId,
                                 expanded = account.alwaysOpenSpoiler,
-                                contentShowing = account.alwaysShowSensitiveMedia || (!status.actionableStatus.sensitive && filter?.action != Filter.Action.BLUR),
-                                contentCollapsed = true
+                                contentShowing = status.shouldShowContent(account.alwaysShowSensitiveMedia, kind.toFilterKind()),
+                                contentCollapsed = true,
                             )
                         )
                         timelineDao.insertHomeTimelineItem(

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -75,7 +75,7 @@ class NetworkTimelineRemoteMediator(
                     s.asStatusOrNull()?.id == status.id
                 }?.asStatusOrNull()
 
-                val filter = oldStatus?.filter ?: viewModel.kind?.let { status.getApplicableFilter(it.toFilterKind()) }
+                val filter = oldStatus?.filter ?: status.getApplicableFilter(viewModel.kind.toFilterKind())
                 val contentShowing = oldStatus?.isShowingContent ?: (activeAccount.alwaysShowSensitiveMedia || (!status.actionableStatus.sensitive && filter?.action != Filter.Action.BLUR))
                 val expanded = oldStatus?.isExpanded ?: activeAccount.alwaysOpenSpoiler
                 val contentCollapsed = oldStatus?.isCollapsed != false

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -21,6 +21,7 @@ import androidx.paging.LoadType
 import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
 import com.keylesspalace.tusky.components.timeline.util.ifExpected
+import com.keylesspalace.tusky.entity.Filter
 import com.keylesspalace.tusky.util.HttpHeaderLink
 import com.keylesspalace.tusky.util.toViewData
 import com.keylesspalace.tusky.viewdata.StatusViewData
@@ -74,14 +75,16 @@ class NetworkTimelineRemoteMediator(
                     s.asStatusOrNull()?.id == status.id
                 }?.asStatusOrNull()
 
-                val contentShowing = oldStatus?.isShowingContent ?: (activeAccount.alwaysShowSensitiveMedia || !status.actionableStatus.sensitive)
+                val filter = oldStatus?.filter ?: status.getApplicableFilter(viewModel.kind.toFilterKind())
+                val contentShowing = oldStatus?.isShowingContent ?: (activeAccount.alwaysShowSensitiveMedia || (!status.actionableStatus.sensitive && filter?.action != Filter.Action.BLUR))
                 val expanded = oldStatus?.isExpanded ?: activeAccount.alwaysOpenSpoiler
                 val contentCollapsed = oldStatus?.isCollapsed != false
 
                 status.toViewData(
                     isShowingContent = contentShowing,
                     isExpanded = expanded,
-                    isCollapsed = contentCollapsed
+                    isCollapsed = contentCollapsed,
+                    filter = filter,
                 )
             }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -75,7 +75,7 @@ class NetworkTimelineRemoteMediator(
                     s.asStatusOrNull()?.id == status.id
                 }?.asStatusOrNull()
 
-                val filter = oldStatus?.filter ?: status.getApplicableFilter(viewModel.kind.toFilterKind())
+                val filter = oldStatus?.filter ?: viewModel.kind?.let { status.getApplicableFilter(it.toFilterKind()) }
                 val contentShowing = oldStatus?.isShowingContent ?: (activeAccount.alwaysShowSensitiveMedia || (!status.actionableStatus.sensitive && filter?.action != Filter.Action.BLUR))
                 val expanded = oldStatus?.isExpanded ?: activeAccount.alwaysOpenSpoiler
                 val contentCollapsed = oldStatus?.isCollapsed != false

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineRemoteMediator.kt
@@ -21,7 +21,6 @@ import androidx.paging.LoadType
 import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
 import com.keylesspalace.tusky.components.timeline.util.ifExpected
-import com.keylesspalace.tusky.entity.Filter
 import com.keylesspalace.tusky.util.HttpHeaderLink
 import com.keylesspalace.tusky.util.toViewData
 import com.keylesspalace.tusky.viewdata.StatusViewData
@@ -76,7 +75,7 @@ class NetworkTimelineRemoteMediator(
                 }?.asStatusOrNull()
 
                 val filter = oldStatus?.filter ?: status.getApplicableFilter(viewModel.kind.toFilterKind())
-                val contentShowing = oldStatus?.isShowingContent ?: (activeAccount.alwaysShowSensitiveMedia || (!status.actionableStatus.sensitive && filter?.action != Filter.Action.BLUR))
+                val contentShowing = oldStatus?.isShowingContent ?: status.shouldShowContent(activeAccount.alwaysShowSensitiveMedia, viewModel.kind.toFilterKind())
                 val expanded = oldStatus?.isExpanded ?: activeAccount.alwaysOpenSpoiler
                 val contentCollapsed = oldStatus?.isCollapsed != false
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -222,12 +222,11 @@ class NetworkTimelineViewModel @Inject constructor(
 
                 val activeAccount = accountManager.activeAccount!!
                 val data: MutableList<StatusViewData> = statuses.map { status ->
-                    val filter = status.getApplicableFilter(kind.toFilterKind())
                     status.toViewData(
-                        isShowingContent = activeAccount.alwaysShowSensitiveMedia || (!status.actionableStatus.sensitive && filter?.action != Filter.Action.BLUR),
+                        isShowingContent = status.shouldShowContent(activeAccount.alwaysShowSensitiveMedia, kind.toFilterKind()),
                         isExpanded = activeAccount.alwaysOpenSpoiler,
                         isCollapsed = true,
-                        filter = filter,
+                        filter = status.getApplicableFilter(kind.toFilterKind()),
                     )
                 }.toMutableList()
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
@@ -184,7 +184,7 @@ abstract class TimelineViewModel(
             (status.reblog != null && filterRemoveReblogs) ||
             (status.account.id == status.reblog?.account?.id && filterRemoveSelfReblogs)
         ) {
-            Filter("", "", listOf(kind.toFilterKind()), action = Filter.Action.HIDE)
+            Filter(context = listOf(kind.toFilterKind()), action = Filter.Action.HIDE)
         } else if (status.actionableStatus.account.id == activeAccountFlow.value?.accountId) {
             // Mastodon filters don't apply for own posts
             null

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
@@ -184,7 +184,7 @@ abstract class TimelineViewModel(
             (status.reblog != null && filterRemoveReblogs) ||
             (status.account.id == status.reblog?.account?.id && filterRemoveSelfReblogs)
         ) {
-            Filter("", "", listOf(kind.toFilterKind().kind), filterAction = Filter.Action.HIDE.action)
+            Filter("", "", listOf(kind.toFilterKind()), action = Filter.Action.HIDE)
         } else if (status.actionableStatus.account.id == activeAccountFlow.value?.accountId) {
             // Mastodon filters don't apply for own posts
             null
@@ -242,9 +242,8 @@ abstract class TimelineViewModel(
         private const val TAG = "TimelineVM"
         internal const val LOAD_AT_ONCE = 30
 
-        fun filterContextMatchesKind(kind: Kind, filterContext: List<String>): Boolean {
-            return filterContext.contains(kind.toFilterKind().kind)
-        }
+        fun filterContextMatchesKind(kind: Kind, filterContext: List<Filter.Kind>): Boolean =
+            filterContext.contains(kind.toFilterKind())
     }
 
     enum class Kind {

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
@@ -178,20 +178,18 @@ abstract class TimelineViewModel(
     /** Triggered when currently displayed data must be reloaded. */
     protected abstract suspend fun invalidate()
 
-    protected fun shouldFilterStatus(statusViewData: StatusViewData): Filter.Action {
-        val status = statusViewData.asStatusOrNull()?.status ?: return Filter.Action.NONE
+    protected fun shouldFilterStatus(status: Status): Filter? {
         return if (
             (status.isReply && filterRemoveReplies) ||
             (status.reblog != null && filterRemoveReblogs) ||
             (status.account.id == status.reblog?.account?.id && filterRemoveSelfReblogs)
         ) {
-            Filter.Action.HIDE
+            Filter("", "", listOf(kind.toFilterKind().kind), filterAction = Filter.Action.HIDE.action)
         } else if (status.actionableStatus.account.id == activeAccountFlow.value?.accountId) {
             // Mastodon filters don't apply for own posts
-            Filter.Action.NONE
+            null
         } else {
-            statusViewData.filterAction = filterModel.shouldFilterStatus(status.actionableStatus)
-            statusViewData.filterAction
+            filterModel.shouldFilterStatus(status.actionableStatus)
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/trending/viewmodel/TrendingTagsViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/trending/viewmodel/TrendingTagsViewModel.kt
@@ -95,7 +95,7 @@ class TrendingTagsViewModel @Inject constructor(
                     TrendingTagsUiState(emptyList(), LoadingState.LOADED)
                 } else {
                     val homeFilters = deferredFilters.await().getOrNull()?.filter { filter ->
-                        filter.context.contains(Filter.Kind.HOME.kind)
+                        filter.context.contains(Filter.Kind.HOME)
                     }
                     val tags = tagResponse
                         .filter { tag ->

--- a/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ThreadAdapter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ThreadAdapter.kt
@@ -71,7 +71,7 @@ class ThreadAdapter(
         val viewData = getItem(position)
         return if (viewData.isDetailed) {
             VIEW_TYPE_STATUS_DETAILED
-        } else if (viewData.filterAction == Filter.Action.WARN) {
+        } else if (viewData.filter?.action == Filter.Action.WARN) {
             VIEW_TYPE_STATUS_FILTERED
         } else {
             VIEW_TYPE_STATUS

--- a/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModel.kt
@@ -432,14 +432,12 @@ class ViewThreadViewModel @Inject constructor(
         val oldStatus = (_uiState.value as? ThreadUiState.Success)?.statusViewData?.find {
             it.id == this.id
         }
-        val filter = oldStatus?.filter ?: actionableStatus.getApplicableFilter(Filter.Kind.THREAD)
         return toViewData(
-            isShowingContent = oldStatus?.isShowingContent
-                ?: (alwaysShowSensitiveMedia || (!actionableStatus.sensitive && filter?.action != Filter.Action.BLUR)),
+            isShowingContent = oldStatus?.isShowingContent ?: actionableStatus.shouldShowContent(alwaysShowSensitiveMedia, Filter.Kind.THREAD),
             isExpanded = oldStatus?.isExpanded ?: alwaysOpenSpoiler,
             isCollapsed = oldStatus?.isCollapsed ?: !isDetailed,
             isDetailed = oldStatus?.isDetailed ?: isDetailed,
-            filter = filter,
+            filter = oldStatus?.filter ?: actionableStatus.getApplicableFilter(Filter.Kind.THREAD),
         )
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/viewthread/ViewThreadViewModel.kt
@@ -312,6 +312,7 @@ class ViewThreadViewModel @Inject constructor(
                 isCollapsed = viewData.isCollapsed,
                 isDetailed = viewData.isDetailed,
                 translation = viewData.translation,
+                filter = viewData.filter,
             )
         }
     }
@@ -421,8 +422,8 @@ class ViewThreadViewModel @Inject constructor(
             if (status.isDetailed || status.status.account.id == activeAccount.accountId) {
                 true
             } else {
-                status.filterAction = filterModel.shouldFilterStatus(status.status)
-                status.filterAction != Filter.Action.HIDE
+                status.filter = filterModel.shouldFilterStatus(status.status)
+                status.filter?.action != Filter.Action.HIDE
             }
         }
     }
@@ -431,12 +432,14 @@ class ViewThreadViewModel @Inject constructor(
         val oldStatus = (_uiState.value as? ThreadUiState.Success)?.statusViewData?.find {
             it.id == this.id
         }
+        val filter = oldStatus?.filter ?: actionableStatus.getApplicableFilter(Filter.Kind.THREAD)
         return toViewData(
             isShowingContent = oldStatus?.isShowingContent
-                ?: (alwaysShowSensitiveMedia || !actionableStatus.sensitive),
+                ?: (alwaysShowSensitiveMedia || (!actionableStatus.sensitive && filter?.action != Filter.Action.BLUR)),
             isExpanded = oldStatus?.isExpanded ?: alwaysOpenSpoiler,
             isCollapsed = oldStatus?.isCollapsed ?: !isDetailed,
-            isDetailed = oldStatus?.isDetailed ?: isDetailed
+            isDetailed = oldStatus?.isDetailed ?: isDetailed,
+            filter = filter,
         )
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/db/AppDatabase.java
+++ b/app/src/main/java/com/keylesspalace/tusky/db/AppDatabase.java
@@ -65,7 +65,7 @@ import java.io.File;
     },
     // Note: Starting with version 54, database versions in Tusky are always even.
     // This is to reserve odd version numbers for use by forks.
-    version = 68,
+    version = 70,
     autoMigrations = {
         @AutoMigration(from = 48, to = 49),
         @AutoMigration(from = 49, to = 50, spec = AppDatabase.MIGRATION_49_50.class),
@@ -76,6 +76,7 @@ import java.io.File;
         @AutoMigration(from = 62, to = 64), // filterV2Available in InstanceEntity
         @AutoMigration(from = 64, to = 66), // added profileHeaderUrl to AccountEntity
         @AutoMigration(from = 66, to = 68, spec = AppDatabase.MIGRATION_66_68.class), // added event and moderationAction to NotificationEntity, new NotificationPolicyEntity
+        @AutoMigration(from = 68, to = 70), // added mastodonApiVersion to InstanceEntity
     }
 )
 public abstract class AppDatabase extends RoomDatabase {

--- a/app/src/main/java/com/keylesspalace/tusky/db/entity/InstanceEntity.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/db/entity/InstanceEntity.kt
@@ -42,6 +42,8 @@ data class InstanceEntity(
     val maxFieldNameLength: Int?,
     val maxFieldValueLength: Int?,
     val translationEnabled: Boolean?,
+    val mastodonApiVersion: Int?,
+
     // ToDo: Remove this again when filter v1 support is dropped
     @ColumnInfo(defaultValue = "false") val filterV2Supported: Boolean = false
 )
@@ -69,4 +71,5 @@ data class InstanceInfoEntity(
     val maxFieldNameLength: Int?,
     val maxFieldValueLength: Int?,
     val translationEnabled: Boolean?,
+    val mastodonApiVersion: Int?,
 )

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Filter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Filter.kt
@@ -11,38 +11,54 @@ import kotlinx.parcelize.Parcelize
 data class Filter(
     val id: String,
     val title: String,
-    val context: List<String>,
+    val context: List<Kind>,
     @Json(name = "expires_at") val expiresAt: Date? = null,
-    @Json(name = "filter_action") val filterAction: String,
+    @Json(name = "filter_action") val action: Action,
     // This field is mandatory according to the API documentation but is in fact optional in some instances
     val keywords: List<FilterKeyword> = emptyList(),
     // val statuses: List<FilterStatus>,
 ) : Parcelable {
     enum class Action(val action: String) {
+        @Json(name = "none")
         NONE("none"),
+
+        @Json(name = "blur")
         BLUR("blur"),
+
+        @Json(name = "warn")
         WARN("warn"),
+
+        @Json(name = "hide")
         HIDE("hide");
+
+        // Retrofit will call toString when sending this class as part of a form-urlencoded body.
+        override fun toString() = action
 
         companion object {
             fun from(action: String): Action = entries.firstOrNull { it.action == action } ?: WARN
         }
     }
     enum class Kind(val kind: String) {
+        @Json(name = "home")
         HOME("home"),
+
+        @Json(name = "notifications")
         NOTIFICATIONS("notifications"),
+
+        @Json(name = "public")
         PUBLIC("public"),
+
+        @Json(name = "thread")
         THREAD("thread"),
+
+        @Json(name = "account")
         ACCOUNT("account");
+
+        // Retrofit will call toString when sending this class as part of a form-urlencoded body.
+        override fun toString() = kind
 
         companion object {
             fun from(kind: String): Kind = entries.firstOrNull { it.kind == kind } ?: PUBLIC
         }
     }
-
-    val action: Action
-        get() = Action.from(filterAction)
-
-    val kinds: List<Kind>
-        get() = context.map { Kind.from(it) }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Filter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Filter.kt
@@ -20,6 +20,7 @@ data class Filter(
 ) : Parcelable {
     enum class Action(val action: String) {
         NONE("none"),
+        BLUR("blur"),
         WARN("warn"),
         HIDE("hide");
 

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Filter.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Filter.kt
@@ -9,8 +9,8 @@ import kotlinx.parcelize.Parcelize
 @JsonClass(generateAdapter = true)
 @Parcelize
 data class Filter(
-    val id: String,
-    val title: String,
+    val id: String = "",
+    val title: String = "",
     val context: List<Kind>,
     @Json(name = "expires_at") val expiresAt: Date? = null,
     @Json(name = "filter_action") val action: Action,

--- a/app/src/main/java/com/keylesspalace/tusky/entity/FilterV1.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/FilterV1.kt
@@ -40,20 +40,18 @@ data class FilterV1(
         return other.id == id
     }
 
-    fun toFilter(): Filter {
-        return Filter(
-            id = id,
-            title = phrase,
-            context = context,
-            expiresAt = expiresAt,
-            filterAction = Filter.Action.WARN.action,
-            keywords = listOf(
-                FilterKeyword(
-                    id = id,
-                    keyword = phrase,
-                    wholeWord = wholeWord
-                )
+    fun toFilter() = Filter(
+        id = id,
+        title = phrase,
+        context = context.map(Filter.Kind::from),
+        expiresAt = expiresAt,
+        action = Filter.Action.WARN,
+        keywords = listOf(
+            FilterKeyword(
+                id = id,
+                keyword = phrase,
+                wholeWord = wholeWord
             )
         )
-    }
+    )
 }

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Instance.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Instance.kt
@@ -17,7 +17,8 @@ data class Instance(
 //    val registrations: Registrations,
 //    val contact: Contact,
     val rules: List<Rule> = emptyList(),
-    val pleroma: PleromaConfiguration? = null
+    val pleroma: PleromaConfiguration? = null,
+    @Json(name = "api_versions") val apiVersions: ApiVersions? = null,
 ) {
     @JsonClass(generateAdapter = true)
     data class Usage(val users: Users) {
@@ -45,7 +46,7 @@ data class Instance(
         val statuses: Statuses? = null,
         @Json(name = "media_attachments") val mediaAttachments: MediaAttachments? = null,
         val polls: Polls? = null,
-        val translation: Translation? = null
+        val translation: Translation? = null,
     ) {
         @JsonClass(generateAdapter = true)
         data class Urls(@Json(name = "streaming_api") val streamingApi: String? = null)
@@ -99,4 +100,7 @@ data class Instance(
 
     @JsonClass(generateAdapter = true)
     data class Rule(val id: String, val text: String)
+
+    @JsonClass(generateAdapter = true)
+    data class ApiVersions(val mastodon: Int? = null)
 }

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Status.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Status.kt
@@ -159,7 +159,7 @@ data class Status(
     }
 
     fun getApplicableFilter(kind: Filter.Kind): Filter? =
-        actionableStatus.filtered?.filter { it.filter.kinds.contains(kind) }?.maxByOrNull { it.filter.action }?.filter
+        actionableStatus.filtered?.filter { it.filter.context.contains(kind) }?.maxByOrNull { it.filter.action.ordinal }?.filter
 
     @JsonClass(generateAdapter = true)
     data class Mention(

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Status.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Status.kt
@@ -161,6 +161,9 @@ data class Status(
     fun getApplicableFilter(kind: Filter.Kind): Filter? =
         actionableStatus.filtered?.filter { it.filter.context.contains(kind) }?.maxByOrNull { it.filter.action.ordinal }?.filter
 
+    fun shouldShowContent(alwayShowSensitiveContent: Boolean, context: Filter.Kind): Boolean =
+        alwayShowSensitiveContent || (!actionableStatus.sensitive && getApplicableFilter(context)?.action != Filter.Action.BLUR)
+
     @JsonClass(generateAdapter = true)
     data class Mention(
         val id: String,

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Status.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Status.kt
@@ -158,6 +158,9 @@ data class Status(
         return builder.toString()
     }
 
+    fun getApplicableFilter(kind: Filter.Kind): Filter? =
+        actionableStatus.filtered?.filter { it.filter.kinds.contains(kind) }?.maxByOrNull { it.filter.action }?.filter
+
     @JsonClass(generateAdapter = true)
     data class Mention(
         val id: String,

--- a/app/src/main/java/com/keylesspalace/tusky/network/FilterModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/FilterModel.kt
@@ -72,7 +72,7 @@ class FilterModel @Inject constructor(
             val matcher = pattern?.matcher("") ?: return null
 
             if (status.poll?.options?.any { matcher.reset(it.title).find() } == true) {
-                return Filter("", "", listOf(kind.kind), filterAction = Filter.Action.HIDE.action)
+                return Filter("", "", listOf(kind), action = Filter.Action.HIDE)
             }
 
             val spoilerText = status.actionableStatus.spoilerText
@@ -83,7 +83,7 @@ class FilterModel @Inject constructor(
                 (spoilerText.isNotEmpty() && matcher.reset(spoilerText).find()) ||
                 (attachmentsDescriptions.isNotEmpty() && matcher.reset(attachmentsDescriptions.joinToString("\n")).find())
             ) {
-                return Filter("", "", listOf(kind.kind), filterAction = Filter.Action.HIDE.action)
+                return Filter("", "", listOf(kind), action = Filter.Action.HIDE)
             } else {
                 null
             }

--- a/app/src/main/java/com/keylesspalace/tusky/network/FilterModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/FilterModel.kt
@@ -72,7 +72,7 @@ class FilterModel @Inject constructor(
             val matcher = pattern?.matcher("") ?: return null
 
             if (status.poll?.options?.any { matcher.reset(it.title).find() } == true) {
-                return Filter("", "", listOf(kind), action = Filter.Action.HIDE)
+                return Filter(context = listOf(kind), action = Filter.Action.HIDE)
             }
 
             val spoilerText = status.actionableStatus.spoilerText
@@ -83,7 +83,7 @@ class FilterModel @Inject constructor(
                 (spoilerText.isNotEmpty() && matcher.reset(spoilerText).find()) ||
                 (attachmentsDescriptions.isNotEmpty() && matcher.reset(attachmentsDescriptions.joinToString("\n")).find())
             ) {
-                return Filter("", "", listOf(kind), action = Filter.Action.HIDE)
+                return Filter(context = listOf(kind), action = Filter.Action.HIDE)
             } else {
                 null
             }

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -561,8 +561,8 @@ interface MastodonApi {
     @POST("api/v2/filters")
     suspend fun createFilter(
         @Field("title") title: String,
-        @Field("context[]") context: List<String>,
-        @Field("filter_action") filterAction: String,
+        @Field("context[]") context: List<Filter.Kind>,
+        @Field("filter_action") filterAction: Filter.Action,
         @Field("expires_in") expiresIn: FilterExpiration?
     ): NetworkResult<Filter>
 
@@ -571,8 +571,8 @@ interface MastodonApi {
     suspend fun updateFilter(
         @Path("id") id: String,
         @Field("title") title: String? = null,
-        @Field("context[]") context: List<String>? = null,
-        @Field("filter_action") filterAction: String? = null,
+        @Field("context[]") context: List<Filter.Kind>? = null,
+        @Field("filter_action") filterAction: Filter.Action? = null,
         @Field("expires_in") expires: FilterExpiration? = null
     ): NetworkResult<Filter>
 

--- a/app/src/main/java/com/keylesspalace/tusky/util/ViewDataUtils.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ViewDataUtils.kt
@@ -36,6 +36,7 @@ package com.keylesspalace.tusky.util
 
 import androidx.paging.CombinedLoadStates
 import androidx.paging.LoadState
+import com.keylesspalace.tusky.entity.Filter
 import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.entity.TrendingTag
 import com.keylesspalace.tusky.viewdata.StatusViewData
@@ -47,17 +48,16 @@ fun Status.toViewData(
     isExpanded: Boolean,
     isCollapsed: Boolean,
     isDetailed: Boolean = false,
+    filter: Filter?,
     translation: TranslationViewData? = null,
-): StatusViewData.Concrete {
-    return StatusViewData.Concrete(
-        status = this,
-        isShowingContent = isShowingContent,
-        isCollapsed = isCollapsed,
-        isExpanded = isExpanded,
-        isDetailed = isDetailed,
-        translation = translation,
-    )
-}
+) = StatusViewData.Concrete(
+    status = this,
+    isShowingContent = isShowingContent,
+    isCollapsed = isCollapsed,
+    isExpanded = isExpanded,
+    isDetailed = isDetailed,
+    translation = translation,
+).apply { this.filter = filter }
 
 fun List<TrendingTag>.toViewData(): List<TrendingViewData.Tag> {
     val maxTrendingValue = flatMap { tag -> tag.history }

--- a/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.kt
@@ -42,7 +42,7 @@ sealed interface TranslationViewData {
  */
 sealed class StatusViewData {
     abstract val id: String
-    var filterAction: Filter.Action = Filter.Action.NONE
+    var filter: Filter? = null
 
     data class Concrete(
         val status: Status,

--- a/app/src/main/res/layout/activity_edit_filter.xml
+++ b/app/src/main/res/layout/activity_edit_filter.xml
@@ -82,6 +82,13 @@
                 android:layout_height="wrap_content">
 
                 <RadioButton
+                    android:id="@+id/filter_action_blur"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="48dp"
+                    android:text="@string/filter_description_blur" />
+
+                <RadioButton
                     android:id="@+id/filter_action_warn"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/values/string-arrays.xml
+++ b/app/src/main/res/values/string-arrays.xml
@@ -47,6 +47,7 @@
     </string-array>
 
     <string-array name="filter_actions">
+        <item>@string/filter_action_blur</item>
         <item>@string/filter_action_warn</item>
         <item>@string/filter_action_hide</item>
     </string-array>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -817,9 +817,11 @@
 
     <string name="hint_filter_title">My filter</string>
     <string name="label_filter_title">Title</string>
+    <string name="filter_action_blur">Blur</string>
     <string name="filter_action_warn">Warn</string>
     <string name="filter_action_hide">Hide</string>
-    <string name="filter_description_warn">Hide with a warning</string>
+    <string name="filter_description_blur">Hide media with a warning</string>
+    <string name="filter_description_warn">Hide entire post with a warning</string>
     <string name="filter_description_hide">Hide completely</string>
     <string name="label_filter_action">Filter action</string>
     <string name="label_filter_context">Filter contexts</string>

--- a/app/src/test/java/com/keylesspalace/tusky/FilterV1Test.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/FilterV1Test.kt
@@ -33,6 +33,7 @@ import java.util.Date
 import kotlinx.coroutines.runBlocking
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -127,8 +128,7 @@ class FilterV1Test {
 
     @Test
     fun shouldNotFilter() {
-        assertEquals(
-            Filter.Action.NONE,
+        assertNull(
             filterModel.shouldFilterStatus(
                 mockStatus(content = "should not be filtered")
             )
@@ -141,7 +141,7 @@ class FilterV1Test {
             Filter.Action.HIDE,
             filterModel.shouldFilterStatus(
                 mockStatus(content = "one two badWord three")
-            )
+            )?.action
         )
     }
 
@@ -151,7 +151,7 @@ class FilterV1Test {
             Filter.Action.HIDE,
             filterModel.shouldFilterStatus(
                 mockStatus(content = "one two badWordPart three")
-            )
+            )?.action
         )
     }
 
@@ -161,14 +161,13 @@ class FilterV1Test {
             Filter.Action.HIDE,
             filterModel.shouldFilterStatus(
                 mockStatus(content = "one two badWholeWord three")
-            )
+            )?.action
         )
     }
 
     @Test
     fun shouldNotFilter_whenContentDoesNotMatchWholeWord() {
-        assertEquals(
-            Filter.Action.NONE,
+        assertNull(
             filterModel.shouldFilterStatus(
                 mockStatus(content = "one two badWholeWordTest three")
             )
@@ -184,7 +183,7 @@ class FilterV1Test {
                     content = "should not be filtered",
                     spoilerText = "badWord should be filtered"
                 )
-            )
+            )?.action
         )
     }
 
@@ -198,7 +197,7 @@ class FilterV1Test {
                     spoilerText = "should not be filtered",
                     pollOptions = listOf("should not be filtered", "badWord")
                 )
-            )
+            )?.action
         )
     }
 
@@ -212,7 +211,7 @@ class FilterV1Test {
                     spoilerText = "should not be filtered",
                     attachmentsDescriptions = listOf("should not be filtered", "badWord")
                 )
-            )
+            )?.action
         )
     }
 
@@ -222,7 +221,7 @@ class FilterV1Test {
             Filter.Action.HIDE,
             filterModel.shouldFilterStatus(
                 mockStatus(content = "one two someone@twitter.com three")
-            )
+            )?.action
         )
     }
 
@@ -232,7 +231,7 @@ class FilterV1Test {
             Filter.Action.HIDE,
             filterModel.shouldFilterStatus(
                 mockStatus(content = "#hashtag one two three")
-            )
+            )?.action
         )
     }
 
@@ -242,14 +241,13 @@ class FilterV1Test {
             Filter.Action.HIDE,
             filterModel.shouldFilterStatus(
                 mockStatus(content = "<p><a href=\"https://foo.bar/tags/hashtag\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>hashtag</span></a>one two three</p>")
-            )
+            )?.action
         )
     }
 
     @Test
     fun shouldNotFilterHtmlAttributes() {
-        assertEquals(
-            Filter.Action.NONE,
+        assertNull(
             filterModel.shouldFilterStatus(
                 mockStatus(content = "<p><a href=\"https://foo.bar/\">https://foo.bar/</a> one two three</p>")
             )
@@ -258,8 +256,7 @@ class FilterV1Test {
 
     @Test
     fun shouldNotFilter_whenFilterIsExpired() {
-        assertEquals(
-            Filter.Action.NONE,
+        assertNull(
             filterModel.shouldFilterStatus(
                 mockStatus(content = "content matching expired filter should not be filtered")
             )
@@ -272,7 +269,7 @@ class FilterV1Test {
             Filter.Action.HIDE,
             filterModel.shouldFilterStatus(
                 mockStatus(content = "content matching unexpired filter should be filtered")
-            )
+            )?.action
         )
     }
 

--- a/app/src/test/java/com/keylesspalace/tusky/components/compose/ComposeActivityTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/compose/ComposeActivityTest.kt
@@ -137,7 +137,7 @@ class ComposeActivityTest {
 
         val instanceDaoMock: InstanceDao = mock {
             onBlocking { getInstanceInfo(any()) } doReturn
-                InstanceInfoEntity(instanceDomain, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null)
+                InstanceInfoEntity(instanceDomain, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,)
             onBlocking { getEmojiInfo(any()) } doReturn
                 EmojisEntity(instanceDomain, emptyList())
         }

--- a/app/src/test/java/com/keylesspalace/tusky/components/timeline/CachedTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/timeline/CachedTimelineRemoteMediatorTest.kt
@@ -12,6 +12,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.keylesspalace.tusky.components.timeline.viewmodel.CachedTimelineRemoteMediator
 import com.keylesspalace.tusky.components.timeline.viewmodel.CachedTimelineViewModel
+import com.keylesspalace.tusky.components.timeline.viewmodel.TimelineViewModel
 import com.keylesspalace.tusky.db.AccountManager
 import com.keylesspalace.tusky.db.AppDatabase
 import com.keylesspalace.tusky.db.Converters
@@ -531,6 +532,7 @@ class CachedTimelineRemoteMediatorTest {
         return mock {
             on { accountManager } doReturn accManager
             on { activeAccountFlow } doReturn MutableStateFlow(account)
+            on { kind } doReturn TimelineViewModel.Kind.PUBLIC_FEDERATED
         }
     }
 }

--- a/app/src/test/java/com/keylesspalace/tusky/components/timeline/NetworkTimelineRemoteMediatorTest.kt
+++ b/app/src/test/java/com/keylesspalace/tusky/components/timeline/NetworkTimelineRemoteMediatorTest.kt
@@ -94,6 +94,8 @@ class NetworkTimelineRemoteMediatorTest {
             on { activeAccountFlow } doReturn MutableStateFlow(account)
             on { statusData } doReturn statuses
             on { nextKey } doReturn null
+            on { kind } doReturn TimelineViewModel.Kind.PUBLIC_FEDERATED
+
             onBlocking { fetchStatusesForKind(null, null, 20) } doReturn Response.success(
                 listOf(
                     fakeStatus("7"),
@@ -147,6 +149,8 @@ class NetworkTimelineRemoteMediatorTest {
             on { activeAccountFlow } doReturn MutableStateFlow(account)
             on { statusData } doReturn statuses
             on { nextKey } doReturn "0"
+            on { kind } doReturn TimelineViewModel.Kind.PUBLIC_FEDERATED
+
             onBlocking { fetchStatusesForKind(null, null, 20) } doReturn Response.success(
                 listOf(
                     fakeStatus("5"),
@@ -201,6 +205,8 @@ class NetworkTimelineRemoteMediatorTest {
             on { activeAccountFlow } doReturn MutableStateFlow(account)
             on { statusData } doReturn statuses
             on { nextKey } doReturn "0"
+            on { kind } doReturn TimelineViewModel.Kind.PUBLIC_FEDERATED
+
             onBlocking { fetchStatusesForKind(null, null, 20) } doReturn Response.success(
                 listOf(
                     fakeStatus("10"),
@@ -256,6 +262,8 @@ class NetworkTimelineRemoteMediatorTest {
             on { activeAccountFlow } doReturn MutableStateFlow(account)
             on { statusData } doReturn statuses
             on { nextKey } doReturn "3"
+            on { kind } doReturn TimelineViewModel.Kind.PUBLIC_FEDERATED
+
             onBlocking { fetchStatusesForKind("3", null, 20) } doReturn Response.success(
                 listOf(
                     fakeStatus("3"),
@@ -311,6 +319,8 @@ class NetworkTimelineRemoteMediatorTest {
             on { activeAccountFlow } doReturn MutableStateFlow(account)
             on { statusData } doReturn statuses
             on { nextKey } doReturn "3"
+            on { kind } doReturn TimelineViewModel.Kind.PUBLIC_FEDERATED
+
             onBlocking { fetchStatusesForKind("3", null, 20) } doReturn Response.success(
                 listOf(
                     fakeStatus("3"),


### PR DESCRIPTION
Add support for the [blur](https://docs.joinmastodon.org/entities/Filter/#filter_action) filter action added in mastodon 4.4.0.
Images and videos on matched posts are hidden by default, and the label reads "Filtered: ${title of applied filter}".
If a matched post has a preview card, the preview image is also blurred.

~~This is draft for now until I upgrade my instance and test, I've tested so far with spoofed data.~~

<img width="418" alt="Screenshot of two posts in the timeline with blurred media. The label reads: Filtered: BLUR" src="https://github.com/user-attachments/assets/3058e7f7-0dd7-49ad-b7b7-90827e8ea8f1" />
