### PR TITLE
improve rendering quality when zooming into large images

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewImageFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewImageFragment.kt
@@ -282,9 +282,11 @@ class ViewImageFragment : ViewMediaFragment() {
             // Request image from the network on fail load image from cache
             .error(
                 glide.load(url)
+                    .override(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL)
                     .centerInside()
                     .addListener(ImageRequestListener(false, isThumbnailRequest = false))
             )
+            .override(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL)
             .centerInside()
             .addListener(ImageRequestListener(true, isThumbnailRequest = false))
             .into(photoView)


### PR DESCRIPTION
Glide downscales images to fit ImageViews, which makes perfect sense, except here where the ImageView is zoomable.
Always loading the memory in full resolution of course uses more memory but I think this is worth the additional quality. If it leds to performance problems or crashes I will check if we can mitigate those in another way.

Before / after:

![Screenshot_20250421_111204](https://github.com/user-attachments/assets/f00e9e54-d78b-40af-b2fc-0cfb83e588a6)
![Screenshot_20250421_110843](https://github.com/user-attachments/assets/b8319582-d149-4e47-ac08-7eb8a46be208)
