### PR TITLE
4986 - Add delete_media parameter support when deleting statuses

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/SearchViewModel.kt
@@ -121,9 +121,9 @@ class SearchViewModel @Inject constructor(
         hashtagsPagingSourceFactory.newSearch(query)
     }
 
-    fun removeItem(statusViewData: StatusViewData.Concrete) {
+    fun removeItem(statusViewData: StatusViewData.Concrete, deleteMedia: Boolean) {
         viewModelScope.launch {
-            if (timelineCases.delete(statusViewData.id).isSuccess) {
+            if (timelineCases.delete(statusViewData.id, deleteMedia).isSuccess) {
                 if (loadedStatuses.remove(statusViewData)) {
                     statusesPagingSourceFactory.invalidate()
                 }
@@ -207,9 +207,9 @@ class SearchViewModel @Inject constructor(
         }
     }
 
-    fun deleteStatusAsync(id: String): Deferred<NetworkResult<DeletedStatus>> {
+    fun deleteStatusAsync(id: String, deleteMedia: Boolean): Deferred<NetworkResult<DeletedStatus>> {
         return viewModelScope.async {
-            timelineCases.delete(id)
+            timelineCases.delete(id, deleteMedia)
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchStatusesFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/search/fragments/SearchStatusesFragment.kt
@@ -265,9 +265,9 @@ class SearchStatusesFragment : SearchFragment<StatusViewData.Concrete>(), Status
 
     override fun clearWarningAction(position: Int) {}
 
-    private fun removeItem(position: Int) {
+    private fun removeItem(position: Int, deleteMedia: Boolean) {
         adapter?.peek(position)?.let {
-            viewModel.removeItem(it)
+            viewModel.removeItem(it, deleteMedia)
         }
     }
 
@@ -578,8 +578,8 @@ class SearchStatusesFragment : SearchFragment<StatusViewData.Concrete>(), Status
             MaterialAlertDialogBuilder(it)
                 .setMessage(R.string.dialog_delete_post_warning)
                 .setPositiveButton(android.R.string.ok) { _, _ ->
-                    viewModel.deleteStatusAsync(id)
-                    removeItem(position)
+                    viewModel.deleteStatusAsync(id, true)
+                    removeItem(position, true)
                 }
                 .setNegativeButton(android.R.string.cancel, null)
                 .show()
@@ -592,9 +592,9 @@ class SearchStatusesFragment : SearchFragment<StatusViewData.Concrete>(), Status
                 .setMessage(R.string.dialog_redraft_post_warning)
                 .setPositiveButton(android.R.string.ok) { _, _ ->
                     viewLifecycleOwner.lifecycleScope.launch {
-                        viewModel.deleteStatusAsync(id).await().fold(
+                        viewModel.deleteStatusAsync(id, false).await().fold(
                             { deletedStatus ->
-                                removeItem(position)
+                                removeItem(position, false)
 
                                 val redraftStatus = if (deletedStatus.isEmpty) {
                                     status.toDeletedStatus()

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.kt
@@ -432,7 +432,7 @@ abstract class SFragment(@LayoutRes contentLayoutId: Int) : Fragment(contentLayo
             .setMessage(R.string.dialog_delete_post_warning)
             .setPositiveButton(android.R.string.ok) { _: DialogInterface?, _: Int ->
                 viewLifecycleOwner.lifecycleScope.launch {
-                    val result = timelineCases.delete(id).exceptionOrNull()
+                    val result = timelineCases.delete(id, true).exceptionOrNull()
                     if (result != null) {
                         Log.w("SFragment", "error deleting status", result)
                         Toast.makeText(requireContext(), R.string.error_generic, Toast.LENGTH_SHORT).show()
@@ -456,7 +456,7 @@ abstract class SFragment(@LayoutRes contentLayoutId: Int) : Fragment(contentLayo
             .setMessage(R.string.dialog_redraft_post_warning)
             .setPositiveButton(android.R.string.ok) { _: DialogInterface?, _: Int ->
                 viewLifecycleOwner.lifecycleScope.launch {
-                    timelineCases.delete(id).fold(
+                    timelineCases.delete(id, false).fold(
                         { deletedStatus ->
                             removeItem(position)
                             val sourceStatus = if (deletedStatus.isEmpty) {

--- a/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/network/MastodonApi.kt
@@ -250,7 +250,10 @@ interface MastodonApi {
     ): Response<List<TimelineAccount>>
 
     @DELETE("api/v1/statuses/{id}")
-    suspend fun deleteStatus(@Path("id") statusId: String): NetworkResult<DeletedStatus>
+    suspend fun deleteStatus(
+        @Path("id") statusId: String,
+        @Query("delete_media") deleteMedia: Boolean? = null
+    ): NetworkResult<DeletedStatus>
 
     @FormUrlEncoded
     @POST("api/v1/statuses/{id}/reblog")

--- a/app/src/main/java/com/keylesspalace/tusky/usecase/TimelineCases.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/usecase/TimelineCases.kt
@@ -109,8 +109,8 @@ class TimelineCases @Inject constructor(
         }
     }
 
-    suspend fun delete(statusId: String): NetworkResult<DeletedStatus> {
-        return mastodonApi.deleteStatus(statusId)
+    suspend fun delete(statusId: String, deleteMedia: Boolean): NetworkResult<DeletedStatus> {
+        return mastodonApi.deleteStatus(statusId, deleteMedia)
             .onSuccess { eventHub.dispatch(StatusDeletedEvent(statusId)) }
             .onFailure { Log.w(TAG, "Failed to delete status", it) }
     }


### PR DESCRIPTION
### Summary
This pull request updates the delete status API call to support the optional `delete_media` parameter introduced in Mastodon 4.2.

### Changes
Updated `deleteStatus` function to accept a `delete_media` query parameter

Fixes #4986