### PR TITLE
Ensure correct font weight for boost/fav count in all locales

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -3,13 +3,17 @@ package com.keylesspalace.tusky.adapter;
 import static com.keylesspalace.tusky.viewdata.PollViewDataKt.buildDescription;
 
 import android.content.Context;
+import android.graphics.Typeface;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.text.Spannable;
+import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.format.DateUtils;
+import android.text.style.StyleSpan;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -22,10 +26,10 @@ import android.widget.TextView;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.PluralsRes;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.appcompat.widget.TooltipCompat;
 import androidx.constraintlayout.widget.ConstraintLayout;
-import androidx.core.text.HtmlCompat;
 import androidx.recyclerview.widget.DefaultItemAnimator;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -980,14 +984,21 @@ public abstract class StatusBaseViewHolder extends RecyclerView.ViewHolder {
 
     @NonNull
     protected CharSequence getFavsText(@NonNull Context context, int count) {
-        String countString = numberFormat.format(count);
-        return HtmlCompat.fromHtml(context.getResources().getQuantityString(R.plurals.favs, count, countString), HtmlCompat.FROM_HTML_MODE_LEGACY);
+        return getMetaDataText(context, R.plurals.favs, count);
     }
 
     @NonNull
     protected CharSequence getReblogsText(@NonNull Context context, int count) {
+        return getMetaDataText(context, R.plurals.reblogs, count);
+    }
+
+    private CharSequence getMetaDataText(@NonNull Context context, @PluralsRes int text, int count) {
         String countString = numberFormat.format(count);
-        return HtmlCompat.fromHtml(context.getResources().getQuantityString(R.plurals.reblogs, count, countString), HtmlCompat.FROM_HTML_MODE_LEGACY);
+        String textString = context.getResources().getQuantityString(text, count, countString);
+        SpannableStringBuilder sb = new SpannableStringBuilder(textString);
+        int countIndex = textString.indexOf(countString);
+        sb.setSpan(new StyleSpan(Typeface.BOLD), countIndex, countIndex + countString.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        return sb;
     }
 
     private void setupPoll(PollViewData poll, List<Emoji> emojis,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -556,15 +556,13 @@
     <string name="failed_to_unpin">Failed to Unpin</string>
 
     <plurals name="favs">
-        <item quantity="zero"><b>%1$s</b> Favorites</item>
-        <item quantity="one">&lt;b>%1$s&lt;/b> Favorite</item>
-        <item quantity="other">&lt;b>%1$s&lt;/b> Favorites</item>
+        <item quantity="one">%1$s Favorite</item>
+        <item quantity="other">%1$s Favorites</item>
     </plurals>
 
     <plurals name="reblogs">
-        <item quantity="zero"><b>%1$s</b> Boosts</item>
-        <item quantity="one">&lt;b>%1$s&lt;/b> Boost</item>
-        <item quantity="other">&lt;b>%1$s&lt;/b> Boosts</item>
+        <item quantity="one">%1$s Boost</item>
+        <item quantity="other">%1$s Boosts</item>
     </plurals>
 
     <string name="label_translating">Translating…</string>


### PR DESCRIPTION
This never worked as intended when the font weight was defined inside the resources. Seems like Weblate is not dealing with that correctly.
If there is `<b>%1$s</b>` used inside the resource, it gets stripped by `getQuantityString`. To work around that, it needs to be HTML escaped `&lt;b>%1$s&lt;/b>` and then passed to `fromHtml`.

Since for some reason not even the source strings got the `&lt;b>%1$s&lt;/b>` correct everywhere, I'm changing it to a completely code based version that will always be right no matter what is defined in the resource.