### PR TITLE
fix filtering boosts from the home timeline

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineTypeMappers.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/TimelineTypeMappers.kt
@@ -19,7 +19,6 @@ import com.keylesspalace.tusky.db.entity.HomeTimelineData
 import com.keylesspalace.tusky.db.entity.HomeTimelineEntity
 import com.keylesspalace.tusky.db.entity.TimelineAccountEntity
 import com.keylesspalace.tusky.db.entity.TimelineStatusEntity
-import com.keylesspalace.tusky.entity.Filter
 import com.keylesspalace.tusky.entity.Status
 import com.keylesspalace.tusky.entity.TimelineAccount
 import com.keylesspalace.tusky.viewdata.StatusViewData
@@ -147,7 +146,6 @@ fun TimelineStatusEntity.toStatus(
 fun HomeTimelineData.toViewData(
     isDetailed: Boolean = false,
     translation: TranslationViewData? = null,
-    filter: Filter? = null,
 ): StatusViewData {
     if (this.account == null || this.status == null) {
         return StatusViewData.LoadMore(this.id, loading)
@@ -200,5 +198,5 @@ fun HomeTimelineData.toViewData(
         isDetailed = isDetailed,
         repliedToAccount = repliedToAccount?.toAccount(),
         translation = translation,
-    ).apply { this.filter = filter }
+    )
 }

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/CachedTimelineViewModel.kt
@@ -34,7 +34,6 @@ import com.keylesspalace.tusky.components.preference.PreferencesFragment.Reading
 import com.keylesspalace.tusky.components.preference.PreferencesFragment.ReadingOrder.OLDEST_FIRST
 import com.keylesspalace.tusky.components.timeline.LoadMorePlaceholder
 import com.keylesspalace.tusky.components.timeline.toEntity
-import com.keylesspalace.tusky.components.timeline.toStatus
 import com.keylesspalace.tusky.components.timeline.toViewData
 import com.keylesspalace.tusky.components.timeline.util.ifExpected
 import com.keylesspalace.tusky.db.AccountManager
@@ -101,13 +100,12 @@ class CachedTimelineViewModel @Inject constructor(
         .combine(translations) { pagingData, translations ->
             pagingData.map { timelineData ->
                 val translation = translations[timelineData.status?.serverId]
-                val status = timelineData.account?.let { timelineData.status?.toStatus(it) }
-                val filter = status?.let { shouldFilterStatus(it) }
-                timelineData.toViewData(
+                val viewData = timelineData.toViewData(
                     isDetailed = false,
-                    translation = translation,
-                    filter = filter,
+                    translation = translation
                 )
+                viewData.filter = shouldFilterStatus(viewData)
+                viewData
             }.filter { statusViewData ->
                 statusViewData.filter?.action != Filter.Action.HIDE
             }

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/NetworkTimelineViewModel.kt
@@ -102,9 +102,7 @@ class NetworkTimelineViewModel @Inject constructor(
     ).flow
         .map { pagingData ->
             pagingData.filter(Dispatchers.Default.asExecutor()) { statusViewData ->
-                statusViewData.asStatusOrNull()?.actionable?.let {
-                    shouldFilterStatus(it)?.action != Filter.Action.HIDE
-                } ?: true
+                shouldFilterStatus(statusViewData)?.action != Filter.Action.HIDE
             }
         }
         .flowOn(Dispatchers.Default)

--- a/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/com/keylesspalace/tusky/components/timeline/viewmodel/TimelineViewModel.kt
@@ -178,7 +178,8 @@ abstract class TimelineViewModel(
     /** Triggered when currently displayed data must be reloaded. */
     protected abstract suspend fun invalidate()
 
-    protected fun shouldFilterStatus(status: Status): Filter? {
+    protected fun shouldFilterStatus(statusViewData: StatusViewData): Filter? {
+        val status = statusViewData.asStatusOrNull()?.status ?: return null
         return if (
             (status.isReply && filterRemoveReplies) ||
             (status.reblog != null && filterRemoveReblogs) ||


### PR DESCRIPTION
Since https://github.com/tuskyapp/Tusky/pull/5038 the option to filter boosts was ignored and boosts never filtered.

The issue here was that the `HomeTimelineData.status` holds no reblog information, so `timelineData.status?.toStatus(it)` will always return a unreblogged status. `timelineData.toViewData` constructs the correct structure as it considers `HomeTimelineData.reblogAccount` as well.